### PR TITLE
Feat: Add github copilot cli backend

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -4,3 +4,4 @@
 ** Main branch change
 
 - Feat: add resume functionality for CLI sessions across backends, by ileixe 
+- Feat: add support for OpenAI Codex CLI backend, by tninja

--- a/README.org
+++ b/README.org
@@ -6,6 +6,7 @@ An Emacs interface for AI-assisted software development. *The purpose is to prov
   - [[https://github.com/anthropics/claude-code][Claude Code]]
   - [[https://github.com/google-gemini/gemini-cli][Gemini CLI]]
   - [[https://github.com/openai/codex][OpenAI Codex]]
+  - [[https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli][GitHub Copilot CLI]]
 
 - I switch across different CLI based AI tool in emacs: Claude Code / Gemini CLI / Aider / OpenAI Codex. If you also use different AI tools inside emacs, but want to keep same user interface and experience, this package is for you.
 
@@ -45,6 +46,7 @@ An Emacs interface for AI-assisted software development. *The purpose is to prov
    - Claude Code IDE (`[[https://github.com/manzaltu/claude-code-ide.el][claude-code-ide.el]]`)
    - Gemini CLI (`[[https://github.com/linchen2chris/gemini-cli.el][gemini-cli.el]]`)
    - [[https://github.com/openai/codex][OpenAI codex CLI]] (`[[./ai-code-codex-cli.el][ai-code-codex-cli.el]]`)
+   - [[https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli][GitHub Copilot CLI]] (`[[./ai-code-github-copilot-cli.el][ai-code-github-copilot-cli.el]]`)
 
    You can add other backends by customizing the `ai-code-backends` variable.
 

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -52,6 +52,15 @@
       :resume  nil
       :config  "~/.gemini/settings.json"
       :cli     "gemini")
+    (github-copilot-cli
+     :label "ai-code-github-copilot-cli.el"
+     :require ai-code-github-copilot-cli
+     :start   github-copilot-cli
+     :switch  github-copilot-cli-switch-to-buffer
+     :send    github-copilot-cli-send-command
+     :resume  nil
+     :config  "~/.config/mcp-config.json" ;; https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli
+     :cli     "copilot")
     (codex
      :label "ai-code-codex-cli.el"
      :require ai-code-codex-cli

--- a/ai-code-codex-cli.el
+++ b/ai-code-codex-cli.el
@@ -42,7 +42,6 @@
   (interactive "sCodex> ")
   (claude-code-send-command line))
 
-
 ;;;###autoload
 (defun codex-cli-resume (&optional arg)
   "Resume a previous Codex CLI session."
@@ -53,6 +52,7 @@
     (claude-code--term-send-string claude-code-terminal-backend "")
     (with-current-buffer claude-code-terminal-backend
       (goto-char (point-min)))))
+
 (provide 'ai-code-codex-cli)
 
 ;;; ai-code-codex-cli.el ends here

--- a/ai-code-github-copilot-cli.el
+++ b/ai-code-github-copilot-cli.el
@@ -1,0 +1,50 @@
+;;; ai-code-github-copilot-cli.el --- Thin wrapper for Github Copilot CLI  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; Thin wrapper that reuses `claude-code' to run Github Copilot CLI.
+;; Provides interactive commands and aliases for the AI Code suite.
+;;
+;;; Code:
+
+(require 'claude-code)
+
+(defvar claude-code-program)
+(defvar claude-code-program-switches)
+(declare-function claude-code "claude-code" (&optional arg extra-switches force-prompt force-switch-to-buffer))
+(declare-function claude-code-resume "claude-code" (&optional arg))
+(declare-function claude-code-switch-to-buffer "claude-code" (&optional arg))
+(declare-function claude-code-send-command "claude-code" (line))
+
+
+(defgroup ai-code-github-copilot-cli nil
+  "Github Copilot CLI integration via `claude-code'."
+  :group 'tools
+  :prefix "github-copilot-cli-")
+
+(defcustom github-copilot-cli-program "copilot"
+  "Path to the Github Copilot CLI executable."
+  :type 'string
+  :group 'ai-code-github-copilot-cli)
+
+;;;###autoload
+(defun github-copilot-cli (&optional arg)
+  "Start Github Copilot CLI (reuses `claude-code' startup logic)."
+  (interactive "P")
+  (let ((claude-code-program github-copilot-cli-program) ; override dynamically
+        (claude-code-program-switches nil))         ; optional e.g.: '("exec" "--non-interactive")
+    (claude-code arg)))
+
+;;;###autoload
+(defun github-copilot-cli-switch-to-buffer ()
+  (interactive)
+  (claude-code-switch-to-buffer))
+
+;;;###autoload
+(defun github-copilot-cli-send-command (line)
+  (interactive "sCopilot> ")
+  (claude-code-send-command line))
+
+(provide 'ai-code-github-copilot-cli)
+
+;;; ai-code-github-copilot-cli.el ends here

--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -1,7 +1,7 @@
 ;;; ai-code-interface.el --- AI code interface for editing AI prompt files -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 0.16
+;; Version: 0.20
 ;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0"))
 
 ;; SPDX-License-Identifier: Apache-2.0

--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -24,6 +24,8 @@
 (require 'ai-code-git)
 (require 'ai-code-change)
 (require 'ai-code-discussion)
+(require 'ai-code-codex-cli)
+(require 'ai-code-github-copilot-cli)
 
 ;; Forward declarations for dynamically defined backend functions
 (declare-function ai-code-cli-start "ai-code-backends")


### PR DESCRIPTION
Github copilot cli doc: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli