### PR TITLE
Chore: Enhance AI shell command input to support file name expansion in dired mode

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -13,3 +13,4 @@
   - handle region and improve input
   - be able to insert ai generated command to shell buffer
 - Feat: Add MCP debug command and customizable run options for Python files
+- Chore: Enhance AI shell command input to support file name expansion in dired mode

--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -173,6 +173,24 @@ Read initial command from user with INITIAL-INPUT as default.
 If command starts with ':', treat as prompt for AI to generate command.
 Return the final command string."
   (let* ((initial-command (ai-code-read-string "Shell command: " initial-input))
+         ;; if current buffer is dired buffer, replace the * character
+         ;; inside initial-command with file base name under cursor,
+         ;; or marked files, separate with space
+         (initial-command
+          (if (and (eq major-mode 'dired-mode)
+                   (string-match-p "\\*" initial-command))
+              (let* ((files (ignore-errors (dired-get-marked-files)))
+                     (file-names (when files
+                                   (mapcar #'file-name-nondirectory files))))
+                (if file-names
+                    (replace-regexp-in-string
+                     (regexp-quote "*")
+                     (mapconcat #'identity file-names " ")
+                     initial-command
+                     nil
+                     t)
+                  initial-command))
+            initial-command))
          (command 
           (if (string-prefix-p ":" initial-command)
               ;; If command starts with :, treat as prompt for AI

--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -1,7 +1,7 @@
 ;;; ai-code-interface.el --- AI code interface for editing AI prompt files -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 0.32
+;; Version: 0.33
 ;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0"))
 
 ;; SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
expand * to filename under cursor or marked files

eg, :convert * into markdown file with same base name, using pandoc