### PR TITLE
chore (inspector): migrate to eshell for improved command handling

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -14,3 +14,4 @@
   - be able to insert ai generated command to shell buffer
 - Feat: Add MCP debug command and customizable run options for Python files
 - Chore: Enhance AI shell command input to support file name expansion in dired mode
+- Chore (inspector): migrate to eshell for improved command handling

--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -1,7 +1,7 @@
 ;;; ai-code-interface.el --- AI code interface for editing AI prompt files -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 0.33
+;; Version: 0.34
 ;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0"))
 
 ;; SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Previously it use compile buffer and cannot reply to question from mcp-inspector. Eg. when mcp-inspector ask us to install some additional python package (y/n), we cannot type y to it.

Switching to eshell buffer should be able to input properly