### PR TITLE
Chore: Add clipboard context option to ai-code-send-command function

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -3,6 +3,7 @@
 
 ** Main branch change
 
+- Chore: Add clipboard context option to ai-code-send-command function
 - Chore: add compilation buffer content as error context
 - Chore: Refactor AI shell command prompt to include marked files in dired mode
 - Fix: work around claude-code-send-command signature change that broke programmatic command sending

--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -1,7 +1,7 @@
 ;;; ai-code-interface.el --- AI code interface for editing AI prompt files -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 0.47
+;; Version: 0.48
 ;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0"))
 
 ;; SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
In case we want LLM to analyze content from other application outside of emacs.