### PR TITLE
Introduce ai-code-sed-command.

### DIFF
--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -21,6 +21,10 @@
 (declare-function ai-code--process-word-for-filepath "ai-code-prompt-mode" (word git-root-truename))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode" (prompt))
 
+(defcustom ai-code-sed-command "sed"
+  "GNU sed command used to apply prompts to files."
+  :type 'string)
+
 ;; Variables that will be defined in ai-code-interface.el
 (defvar ai-code-use-prompt-suffix)
 (defvar ai-code-prompt-suffix)
@@ -190,7 +194,8 @@ and runs it in a compilation buffer."
                      ((buffer-file-name)
                       (buffer-file-name))
                      (t (user-error "Cannot determine the file name"))))
-         (command (format "sed \"1i %s: \" %s | %s"
+         (command (format "%s \"1i %s: \" %s | %s"
+                          ai-code-sed-command
                           (shell-quote-argument prompt-with-suffix)
                           (shell-quote-argument file-name)
                           ai-code-cli)))


### PR DESCRIPTION
On macOS, `sed` is BSD sed, which uses different syntax from GNU sed. In ai-code-apply-prompt-on-current-file, the command line arguments applied to sed are compatible with GNU sed but not BSD sed. I have GNU sed installed as `gsed`, so with this fix I can do `(setq ai-code-sed-command "gsed")` and it will work.