### PR TITLE
style: correct capitalization of 'GitHub' in Copilot CLI backend

### DIFF
--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -70,7 +70,7 @@ When called from Lisp code, sends CMD directly without prompting."
      :upgrade "npm install -g @google/gemini-cli"
      :cli     "gemini")
     (github-copilot-cli
-     :label "Github Copilot CLI"
+     :label "GitHub Copilot CLI"
      :require ai-code-github-copilot-cli
      :start   github-copilot-cli
      :switch  github-copilot-cli-switch-to-buffer

--- a/ai-code-github-copilot-cli.el
+++ b/ai-code-github-copilot-cli.el
@@ -1,8 +1,8 @@
-;;; ai-code-github-copilot-cli.el --- Thin wrapper for Github Copilot CLI  -*- lexical-binding: t; -*-
+;;; ai-code-github-copilot-cli.el --- Thin wrapper for GitHub Copilot CLI  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;
-;; Thin wrapper that reuses `claude-code' to run Github Copilot CLI.
+;; Thin wrapper that reuses `claude-code' to run GitHub Copilot CLI.
 ;; Provides interactive commands and aliases for the AI Code suite.
 ;;
 ;;; Code:
@@ -22,12 +22,12 @@
 
 
 (defgroup ai-code-github-copilot-cli nil
-  "Github Copilot CLI integration via `claude-code'."
+  "GitHub Copilot CLI integration via `claude-code'."
   :group 'tools
   :prefix "github-copilot-cli-")
 
 (defcustom github-copilot-cli-program "copilot"
-  "Path to the Github Copilot CLI executable."
+  "Path to the GitHub Copilot CLI executable."
   :type 'string
   :group 'ai-code-github-copilot-cli)
 
@@ -38,7 +38,7 @@
 
 ;;;###autoload
 (defun github-copilot-cli (&optional arg)
-  "Start Github Copilot CLI (reuses `claude-code' startup logic)."
+  "Start GitHub Copilot CLI (reuses `claude-code' startup logic)."
   (interactive "P")
   (let ((claude-code-program github-copilot-cli-program) ; override dynamically
         (claude-code-program-switches github-copilot-cli-program-switches))
@@ -51,7 +51,7 @@
 
 ;;;###autoload
 (defun github-copilot-cli-send-command (line)
-  "Send LINE to Github Copilot CLI programmatically or interactively.
+  "Send LINE to GitHub Copilot CLI programmatically or interactively.
 When called interactively, prompts for the command.
 When called from Lisp code, sends LINE directly without prompting."
   (interactive "sCopilot> ")


### PR DESCRIPTION
Sorry for the nitpick, but I noticed a small capitalization inconsistency: Github appears in a few places (including the repository About description). This PR standardizes it to the official GitHub spelling. Feel free to close if you’d prefer to keep it as-is.