### PR TITLE
fix: add claude-code.el to Package-Requires

### DIFF
--- a/ai-code-interface.el
+++ b/ai-code-interface.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 0.70
-;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0"))
+;; Package-Requires: ((emacs "26.1") (transient "0.8.0") (magit "2.1.0") (claude-code "0.4.5"))
 
 ;; SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Fixed an issue where builds would fail on certain build systems (such as flake.nix) if claude-code.el was not added to Package-Requires.

```
       > ai-code-grok-cli.el:10:11: Error: Cannot open load file: No such file or directory, claude-code
       >
       > In toplevel form:
       > ai-code-interface.el:27:11: Error: Cannot open load file: No such file or directory, claude-code
       >
       > In toplevel form:
       > ai-code-opencode.el:16:11: Error: Cannot open load file: No such file or directory, claude-code
```