### PR TITLE
Chore: Enhance ai-code-send-command to support multi-level context inputs

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,8 @@
 * Release history
 
 ** Main branch change
+
+** 1.21
 - Chore: Enhance ai-code-send-command to support multi-level context inputs
 - Fix: Start AI CLI with Kiro-cli backend leads to error, reported by texastony
 

--- a/ai-code.el
+++ b/ai-code.el
@@ -1,7 +1,7 @@
 ;;; ai-code.el --- Unified interface for AI coding CLI such as Codex, Copilot CLI, Opencode, Grok CLI, etc -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 1.20
+;; Version: 1.21
 ;; Package-Requires: ((emacs "28.1") (transient "0.8.0") (magit "2.1.0"))
 ;; URL: https://github.com/tninja/ai-code-interface.el
 


### PR DESCRIPTION
During using, feel that ai-code-send-command (C-c a SPC) sometime also need file/repo context. This change is about to add that.

C-u: Add file/repo context
C-u C-u: Add file/repo/clipboard context