### PR TITLE
Fix: Handle github copilot cli prompt sent truncate issue 

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -628,7 +628,7 @@ When PREFIX and WORKING-DIR are provided, select from multiple sessions."
         (with-current-buffer buffer
           (ai-code-backends-infra--remember-session-buffer prefix working-dir buffer)
           (ai-code-backends-infra--terminal-send-string line)
-          (sit-for 0.1)
+          (sit-for 0.5) ;; 0.1 might be too low for some cli backends such as github copilot cli
           (ai-code-backends-infra--terminal-send-return))
       (user-error "%s" missing-message))))
 


### PR DESCRIPTION
I notice that all other backends works well, but github-copilot-cli have this
  issue: any prompt got programmly sent to github copilot cli session (for
  example ai-code-send-command) got truncated after first 5-10 characters, and
  these first characters got sent, just like we press enter; rest text got
  truncated as second prompt, and it keep in input box of session, and not got
  sent.