### PR TITLE
Fix: ai-code-prompt-send-block

### DIFF
--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -29,6 +29,7 @@
 (declare-function ai-code--git-ignored-repo-file-p "ai-code-git" (file root))
 (declare-function ai-code--hash-completion-target-file "ai-code-input" (&optional end-pos))
 (declare-function ai-code--choose-symbol-from-file "ai-code-input" (file))
+(declare-function ai-code-read-string "ai-code-input" (prompt &optional initial-input candidate-list))
 (declare-function ai-code-current-backend-label "ai-code-backends" ())
 
 (defcustom ai-code-prompt-preprocess-filepaths t
@@ -436,15 +437,46 @@ Special commands:
 The block is the text separated by blank lines.
 It trims leading/trailing whitespace."
   (interactive)
-  (let* ((block-text (thing-at-point 'paragraph))
+  ;; DONE: use save-excursion, mark-paragraph to get the block-text
+  (let* ((block-text (save-excursion
+                       (save-mark-and-excursion
+                         (ai-code--mark-prompt-block)
+                         (buffer-substring-no-properties (region-beginning)
+                                                         (region-end)))))
          (trimmed-text (when block-text (string-trim block-text))))
     (if (and trimmed-text (string-match-p "\\S-" trimmed-text))
-        (progn
-          (ai-code-cli-send-command trimmed-text)
-          (ai-code-cli-switch-to-buffer))
+        (if (and buffer-file-name
+                 (string= (file-name-nondirectory buffer-file-name)
+                          ai-code-prompt-file-name))
+            (ai-code--send-prompt trimmed-text)
+          (when-let ((edited-prompt
+                      (ai-code-read-string "Confirm and edit prompt before sending: "
+                                           trimmed-text)))
+            (ai-code--insert-prompt edited-prompt)))
       (message "No text in the current block to send."))))
 
-;; ai coding task feature
+(defun ai-code--mark-prompt-block ()
+  "Mark a code block. A code block is defined as multiple lines without empty lines inside,
+but with empty lines before and after the block."
+  (interactive)
+  (let ((start (point))
+        (end (point)))
+    (save-excursion
+      (while (and (not (bobp)) (not (looking-at-p "^$")))
+        (forward-line -1))
+      (unless (bobp)
+        (forward-line 1))
+      (setq start (point)))
+    (save-excursion
+      (while (and (not (eobp)) (not (looking-at-p "^$")))
+        (forward-line 1))
+      (setq end (point)))
+    (goto-char start)
+    (set-mark (point))
+    (goto-char end)
+    (message "Code block marked from line %d to line %d"
+             (line-number-at-pos start)
+             (line-number-at-pos end))))
 
 ;;;###autoload
 (defconst ai-code-files-dir-name ".ai.code.files"

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -86,6 +86,58 @@ and ensures everything is cleaned up afterward."
       (should (string= (ai-code--preprocess-prompt-text prompt)
                        prompt)))))
 
+(ert-deftest ai-code-test-prompt-send-block-in-prompt-file-sends-directly ()
+  "Send block directly when current buffer is the prompt file."
+  (let ((sent-prompt nil)
+        (read-called nil)
+        (insert-called nil))
+    (with-temp-buffer
+      (insert "line one\nline two\n\nline three")
+      (goto-char (point-min))
+      (setq-local buffer-file-name
+                  (expand-file-name ai-code-prompt-file-name temporary-file-directory))
+      (cl-letf (((symbol-function 'ai-code--send-prompt)
+                 (lambda (prompt)
+                   (setq sent-prompt prompt)))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (&rest _args)
+                   (setq read-called t)
+                   "edited prompt"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (&rest _args)
+                   (setq insert-called t))))
+        (ai-code-prompt-send-block)))
+    (should (string= sent-prompt "line one\nline two"))
+    (should-not read-called)
+    (should-not insert-called)))
+
+(ert-deftest ai-code-test-prompt-send-block-in-other-buffer-confirms-before-send ()
+  "Ask confirmation and edit prompt before sending when not in prompt file."
+  (let ((read-args nil)
+        (inserted-prompt nil)
+        (sent-directly nil))
+    (with-temp-buffer
+      (insert "line one\nline two\n\nline three")
+      (goto-char (point-min))
+      (setq-local buffer-file-name (expand-file-name "notes.org" temporary-file-directory))
+      (cl-letf (((symbol-function 'ai-code-read-string)
+                 (lambda (prompt &optional initial-input candidate-list)
+                   (setq read-args (list prompt initial-input candidate-list))
+                   "edited prompt"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt)
+                   (setq inserted-prompt prompt)))
+                ((symbol-function 'ai-code--send-prompt)
+                 (lambda (&rest _args)
+                   (setq sent-directly t))))
+        (ai-code-prompt-send-block)))
+    (should (equal read-args
+                   '("Confirm and edit prompt before sending: "
+                     "line one\nline two"
+                     nil)))
+    (should (string= inserted-prompt "edited prompt"))
+    (should-not sent-directly)))
+
 ;;; Tests for task file functions
 
 (ert-deftest ai-code-test-get-files-directory-in-git-repo ()


### PR DESCRIPTION
Add new elisp function to identify block (continuous lines). If the current buffer is not ai-code-prompt-file, should let user confirm the prompt before sending.