### PR TITLE
[codex] Avoid eat reflow suppression on session buffers

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -98,7 +98,10 @@ Can be either `vterm' or `eat'."
   :group 'ai-code-backends-infra)
 
 (defcustom ai-code-backends-infra-eat-preserve-position t
-  "Maintain terminal scroll position when switching windows in eat."
+  "Obsolete compatibility toggle for eat-specific reflow suppression.
+Eat sessions now always use the terminal's native resize and redisplay
+behavior because suppressing reflow can leave the screen stale when a
+window becomes visible again."
   :type 'boolean
   :group 'ai-code-backends-infra)
 
@@ -388,9 +391,7 @@ Activity tracking for notifications is handled separately by
   "Add or remove terminal reflow advice according to current settings."
   (let* ((resize-handler (ai-code-backends-infra--terminal-resize-handler))
          (enabled (and ai-code-backends-infra-prevent-reflow-glitch
-                       (or (eq ai-code-backends-infra-terminal-backend 'vterm)
-                           (and (eq ai-code-backends-infra-terminal-backend 'eat)
-                                ai-code-backends-infra-eat-preserve-position)))))
+                       (eq ai-code-backends-infra-terminal-backend 'vterm))))
     (dolist (handler (cl-copy-list ai-code-backends-infra--reflow-advised-handlers))
       (unless (and enabled (eq handler resize-handler))
         (when (advice-member-p #'ai-code-backends-infra--terminal-reflow-filter

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -108,8 +108,8 @@
         (advice-remove handler #'ai-code-backends-infra--terminal-reflow-filter))
       (fmakunbound handler))))
 
-(ert-deftest test-ai-code-backends-infra-sync-reflow-filter-advice-eat-toggle ()
-  "Respect `ai-code-backends-infra-eat-preserve-position' for eat backend."
+(ert-deftest test-ai-code-backends-infra-sync-reflow-filter-advice-eat-disabled ()
+  "Never install reflow advice for eat backend."
   (let ((handler 'ai-code-backends-infra--test-resize-eat))
     (fset handler (lambda (&rest args) args))
     (unwind-protect
@@ -125,8 +125,8 @@
                 (ai-code-backends-infra-prevent-reflow-glitch t)
                 (ai-code-backends-infra-eat-preserve-position t))
             (ai-code-backends-infra--sync-reflow-filter-advice)
-            (should (advice-member-p #'ai-code-backends-infra--terminal-reflow-filter
-                                     handler))))
+            (should-not (advice-member-p #'ai-code-backends-infra--terminal-reflow-filter
+                                         handler))))
       (when (advice-member-p #'ai-code-backends-infra--terminal-reflow-filter handler)
         (advice-remove handler #'ai-code-backends-infra--terminal-reflow-filter))
       (fmakunbound handler))))


### PR DESCRIPTION
## Summary

This change fixes a redraw regression for Eat-backed AI session buffers when switching back to a window that was temporarily hidden. Users could return to a session buffer and see stale terminal content because the package was suppressing Eat resize reflow in the same way it handles the Vterm glitch, even though Eat relies on its native resize and redisplay behavior to repaint correctly.

The root cause was that `ai-code-backends-infra--sync-reflow-filter-advice` still treated Eat as eligible for the reflow suppression advice whenever `ai-code-backends-infra-eat-preserve-position` was enabled. That advice is useful for Vterm, but for Eat it prevents the normal resize-driven redraw path and leaves the buffer visually out of date after buffer or window switches.

The fix narrows reflow suppression so it is only installed for the Vterm backend. The legacy Eat customization remains in place as an obsolete compatibility toggle, but its docstring now explains that Eat sessions always use their native resize behavior. The backend-infra test suite was updated so the Eat-specific advice test now asserts that the reflow filter is never installed for Eat, regardless of the toggle value.

## Validation

I validated the change with the targeted batch ERT suite:

- `emacs -Q -batch -L . -l ert -l test/test_ai-code-backends-infra.el -f ert-run-tests-batch-and-exit`
