### PR TITLE
Fix ECA follow-up regressions after #229

### DIFF
--- a/ai-code-eca.el
+++ b/ai-code-eca.el
@@ -9,13 +9,13 @@
 
 ;;; Commentary:
 ;; ECA backend bridge for ai-code with:
-;;   - Session management (list, switch, create, dashboard)
-;;   - Workspace management (list, add, remove, sync projects)
+;;   - Session management (list, switch, dashboard)
+;;   - Workspace management (list, add, remove)
 ;;   - Context commands (file, cursor, repo-map, clipboard)
 ;;   - Shared context (cross-session sharing)
-;;   - Multi-Project Mode (auto-switch, auto-sync, mode-line)
+;;   - Multi-project mode with periodic sync timer
 ;;   - ai-code-menu integration (transient)
-;;   - Health verification and context synchronization
+;;   - Backend upgrade and basic session health reporting
 ;;
 ;; MULTI-PROJECT WORKFLOWS:
 ;;
@@ -39,18 +39,15 @@
 ;;   ECA Workspace              ECA Context         ECA Shared Context
 ;;     wm - Multi-Project Mode    cf - File           F - Share file
 ;;     wa - Add folder            cc - Cursor         R - Share repo map
-;;     wA - Add to ALL            cr - Repo map       p - Apply shared
 ;;     wl - List folders          cy - Clipboard      c - Clear shared
-;;     wr - Remove folder         cs - Start sync
-;;     ws - Sync projects         cS - Stop sync
+;;     wr - Remove folder
 ;;     wd - Dashboard
-;;     wt - Toggle auto-switch
 ;;
 ;;   ECA Sessions
 ;;     s? - Which session?
 ;;     sl - List sessions
 ;;     ss - Switch session
-;;     sv - Verify health
+;;     sv - Report session health
 ;;     su - Upgrade ECA
 ;;
 ;; Usage:
@@ -172,12 +169,21 @@ With prefix ARG, force new session."
   (when (fboundp 'eca-list-sessions)
     (eca-list-sessions)))
 
+(defun ai-code-eca--format-session-summary (session)
+  "Return a display string for ECA SESSION plist."
+  (format "Session %s: %s (%s) - %s chats"
+          (or (plist-get session :id) "?")
+          (string-join (or (plist-get session :workspace-folders) '()) ", ")
+          (or (plist-get session :status) "unknown")
+          (or (plist-get session :chat-count) 0)))
+
 (defun ai-code-eca-list-sessions ()
   "List ECA sessions."
   (interactive)
   (let ((sessions (ai-code-eca-get-sessions)))
     (if sessions
-        (message "ECA sessions: %s" (mapconcat #'identity sessions ", "))
+        (message "ECA sessions: %s"
+                 (mapconcat #'ai-code-eca--format-session-summary sessions " | "))
       (message "No ECA sessions found"))))
 
 (defun ai-code-eca-switch-session (&optional session-id)

--- a/docs/plans/2026-03-14-eca-pr-229-fixes.md
+++ b/docs/plans/2026-03-14-eca-pr-229-fixes.md
@@ -1,0 +1,129 @@
+# ECA PR 229 Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the confirmed PR #229 regressions in ECA session listing, ECA tests, misleading ECA documentation, and clipboard temp-file handling.
+
+**Architecture:** Keep the current PR structure intact and make only targeted corrections. Use TDD for each bugfix, verify the failing case first, then implement the smallest change that passes and re-run focused tests before the full relevant suite.
+
+**Tech Stack:** Emacs Lisp, ERT, batch Emacs, existing `ai-code-eca.el` / `eca-ext.el` modules
+
+---
+
+### Task 1: Fix ECA Session List Formatting
+
+**Files:**
+- Modify: `ai-code-eca.el`
+- Test: `test/test_ai-code-eca.el`
+
+**Step 1: Write the failing test**
+
+Add an ERT that stubs `eca-list-sessions` to return plist objects and asserts `ai-code-eca-list-sessions` emits a formatted message instead of erroring.
+
+**Step 2: Run test to verify it fails**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_ai-code-eca.el -f ert-run-tests-batch-and-exit`
+Expected: FAIL or error in the new session-listing test before the implementation change.
+
+**Step 3: Write minimal implementation**
+
+Format `eca-list-sessions` plist entries into user-facing strings in `ai-code-eca-list-sessions`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_ai-code-eca.el -f ert-run-tests-batch-and-exit`
+Expected: PASS for the new session-listing test.
+
+### Task 2: Repair ECA Test File Loading
+
+**Files:**
+- Modify: `test/test_ai-code-eca.el`
+
+**Step 1: Write the failing test harness expectation**
+
+Adjust the test file to load the modules it actually exercises, including stubbing optional `magit` when unavailable.
+
+**Step 2: Run test to verify current failure**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_ai-code-eca.el -f ert-run-tests-batch-and-exit`
+Expected: FAIL before the test harness fix due to missing variables/functions.
+
+**Step 3: Write minimal implementation**
+
+Require `ai-code-eca` and any immediate dependencies needed by the test file, without broadening unrelated setup.
+
+**Step 4: Run test to verify it passes**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_ai-code-eca.el -f ert-run-tests-batch-and-exit`
+Expected: PASS for all tests in `test/test_ai-code-eca.el`.
+
+### Task 3: Correct Misleading ECA Documentation
+
+**Files:**
+- Modify: `ai-code-eca.el`
+- Modify: `README.org`
+- Modify: `HISTORY.org` if necessary
+
+**Step 1: Write the failing documentation checklist**
+
+Verify every documented ECA command exists with `fboundp`, and identify all comment/doc references to non-existent commands.
+
+**Step 2: Run the documentation check**
+
+Run: `emacs -Q -batch -L . --eval "(progn ...)"` or equivalent focused command to show missing symbols.
+Expected: Missing command list includes undocumented functions currently referenced by comments/docs.
+
+**Step 3: Write minimal implementation**
+
+Remove or narrow unsupported claims so comments and docs only describe commands that actually exist.
+
+**Step 4: Run verification**
+
+Re-run the focused `fboundp` check and inspect the affected doc sections.
+Expected: No remaining references to non-existent ECA commands in the touched sections.
+
+### Task 4: Reduce Clipboard Temp File Risk
+
+**Files:**
+- Modify: `eca-ext.el`
+- Test: `test/test_eca-ext.el`
+
+**Step 1: Write the failing test**
+
+Add an ERT that verifies clipboard temp files are created via a safer temp path flow and still register for cleanup.
+
+**Step 2: Run test to verify it fails**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_eca-ext.el -f ert-run-tests-batch-and-exit`
+Expected: FAIL before the implementation change.
+
+**Step 3: Write minimal implementation**
+
+Switch clipboard temp-file creation to `make-temp-file` under `temporary-file-directory` and preserve cleanup registration.
+
+**Step 4: Run test to verify it passes**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_eca-ext.el -f ert-run-tests-batch-and-exit`
+Expected: PASS for the new clipboard temp-file test and existing `eca-ext` tests.
+
+### Task 5: Full Verification
+
+**Files:**
+- Verify: `ai-code-eca.el`
+- Verify: `eca-ext.el`
+- Verify: `test/test_ai-code-backends.el`
+- Verify: `test/test_ai-code-eca.el`
+- Verify: `test/test_ai-code-file.el`
+- Verify: `test/test_eca-ext.el`
+
+**Step 1: Run relevant ERT suites**
+
+Run: `emacs -Q -batch -L . -L test -l ert -l test/test_ai-code-backends.el -l test/test_ai-code-eca.el -l test/test_ai-code-file.el -l test/test_eca-ext.el -f ert-run-tests-batch-and-exit`
+
+**Step 2: Run byte compilation with required local stubs**
+
+Run: `emacs -Q -batch --eval "(progn (defun magit-toplevel (&optional _dir) nil) (defun magit-get-current-branch () nil) (defun magit-git-lines (&rest _args) nil) (provide 'magit))" -L . -f batch-byte-compile ai-code-eca.el eca-ext.el`
+
+**Step 3: Read output and fix remaining failures**
+
+Do not claim success until both commands exit cleanly.

--- a/eca-ext.el
+++ b/eca-ext.el
@@ -305,18 +305,10 @@ Return nil if FILE-PATH does not belong to any workspace folder."
 (defun eca-chat-add-clipboard-context (session content)
   "Add CONTENT as a temporary file context to SESSION."
   (eca-assert-session-running session)
-  (let* ((temp-dir (file-name-as-directory
-                    (or (bound-and-true-p eca-config-directory)
-                        (expand-file-name "~/.eca"))))
-         (tmp-subdir (expand-file-name "tmp" temp-dir))
-         (temp-file (expand-file-name
-                     (format "clipboard-%d-%d-%d.txt"
-                             (emacs-pid)
-                             (floor (float-time))
-                             (random 1000000))
-                     tmp-subdir)))
-    (unless (file-directory-p tmp-subdir)
-      (make-directory tmp-subdir t))
+  (let ((temp-file (make-temp-file
+                    (expand-file-name "eca-clipboard-" temporary-file-directory)
+                    nil
+                    ".txt")))
     (with-temp-file temp-file
       (insert content))
     (eca--register-temp-file temp-file session)

--- a/test/test_ai-code-eca.el
+++ b/test/test_ai-code-eca.el
@@ -2,6 +2,17 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'subr-x)
+
+(setq load-prefer-newer t)
+
+(unless (featurep 'magit)
+  (defun magit-toplevel (&optional _dir) nil)
+  (defun magit-get-current-branch () nil)
+  (defun magit-git-lines (&rest _args) nil)
+  (provide 'magit))
+
+(require 'ai-code-eca)
 
 (ert-deftest ai-code-test-eca-backend-registered ()
   "ECA should be registered in ai-code-backends."
@@ -46,6 +57,24 @@
         (ai-code-eca--menu-suffixes-added nil))
     (ai-code-eca--add-menu-suffixes)
     (should-not ai-code-eca--menu-suffixes-added)))
+
+(ert-deftest ai-code-test-eca-list-sessions-formats-plist-sessions ()
+  "Ensure ECA session listings handle plist session metadata."
+  (let (message-text)
+    (cl-letf (((symbol-function 'eca-list-sessions)
+               (lambda ()
+                 (list (list :id 1
+                             :status 'ready
+                             :workspace-folders '("/repo" "/lib")
+                             :chat-count 2))))
+              ((symbol-function 'message)
+               (lambda (fmt &rest args)
+                 (setq message-text (apply #'format fmt args)))))
+      (ai-code-eca-list-sessions)
+      (should (string-match-p "Session 1" message-text))
+      (should (string-match-p "/repo, /lib" message-text))
+      (should (string-match-p "ready" message-text))
+      (should (string-match-p "2 chats" message-text)))))
 
 (provide 'test_ai-code-eca)
 

--- a/test/test_eca-ext.el
+++ b/test/test_eca-ext.el
@@ -11,6 +11,8 @@
 (require 'ert)
 (require 'cl-lib)
 
+(setq load-prefer-newer t)
+
 (require 'eca-ext)
 
 (ert-deftest eca-ext-test-workspace-folder-for-file-matches-parent ()
@@ -64,6 +66,38 @@
       (should (equal file-calls '("/tmp/a.txt")))
       (should (equal repo-map-calls '(t)))
       (should (equal workspace-adds '("/tmp/project"))))))
+
+(ert-deftest eca-ext-test-clipboard-context-uses-make-temp-file ()
+  "Ensure clipboard context uses `make-temp-file' in the temp directory."
+  (let (make-temp-file-args registered-path added-context opened-session)
+    (cl-letf (((symbol-function 'eca-assert-session-running) (lambda (_session) t))
+              ((symbol-function 'make-temp-file)
+               (lambda (&rest args)
+                 (setq make-temp-file-args args)
+                 "/tmp/eca-clipboard-test.txt"))
+              ((symbol-function 'with-temp-file)
+               (lambda (file &rest body)
+                 (setq registered-path file)
+                 (eval `(progn ,@body))))
+              ((symbol-function 'eca--register-temp-file)
+               (lambda (file session)
+                 (setq registered-path (cons file session))))
+              ((symbol-function 'eca-chat--get-last-buffer) (lambda (_session) (current-buffer)))
+              ((symbol-function 'eca-chat--with-current-buffer)
+               (lambda (_buffer &rest _body) nil))
+              ((symbol-function 'eca-chat--add-context)
+               (lambda (context)
+                 (setq added-context context)))
+              ((symbol-function 'eca-chat-open)
+               (lambda (session)
+                 (setq opened-session session)))
+              ((symbol-function 'eca-info) (lambda (&rest _args) nil)))
+      (let ((temporary-file-directory "/tmp/"))
+        (eca-chat-add-clipboard-context 'mock-session "secret")
+        (should (equal make-temp-file-args '("/tmp/eca-clipboard-" nil ".txt")))
+        (should (equal registered-path '("/tmp/eca-clipboard-test.txt" . mock-session)))
+        (should (equal added-context '(:type "file" :path "/tmp/eca-clipboard-test.txt")))
+        (should (eq opened-session 'mock-session))))))
 
 (provide 'test_eca-ext)
 


### PR DESCRIPTION
## Summary
This follow-up PR extracts the post-review fixes from the earlier investigation and rebases them on top of the merged `#229` state.

It makes four focused adjustments:
- fix `ai-code-eca-list-sessions` so it formats plist-based ECA session metadata instead of treating session entries as plain strings
- tighten overstated ECA capability comments in `ai-code-eca.el` so the file header matches the actual implementation
- make clipboard context temp-file handling safer by using `temporary-file-directory` and `make-temp-file`
- harden the ECA test files so they explicitly load the code under test and cover the session-list formatting regression

## Context
These changes were originally prepared while reviewing `#229`, but `#229` has already been merged, so this PR submits the fixes as a clean follow-up on current `main`.

## Notes
- I did not run or add tests in this follow-up session per request.
- The branch for this PR is `pr-229-follow-up`.
