### PR TITLE
UX: TDD Harness loop externalize the long prompt

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,9 @@
 * Release history
 
 ** Main branch change
+
+** 1.68
+- UX: TDD Harness loop externalize the long prompt
 - UX: Add onboarding quickstart and menu integration
   - Also improve the Github PR action feature. It can look into CI checks status and provide analysis
 - Feat: Add diagnostics mcp support with Flycheck and Flymake

--- a/ai-code-autoloads.el
+++ b/ai-code-autoloads.el
@@ -31,9 +31,6 @@ with a newline separator.")
 (defvar ai-code-use-prompt-suffix t "\
 When non-nil, append `ai-code-prompt-suffix` where supported.")
 (custom-autoload 'ai-code-use-prompt-suffix "ai-code" t)
-(defvar ai-code-test-after-code-change-suffix "If any program code changes, run unit-tests and follow up on the test-result (fix code if there is an error)." "\
-User-provided prompt suffix for test-after-code-change.")
-(custom-autoload 'ai-code-test-after-code-change-suffix "ai-code" t)
 (defvar ai-code-auto-test-suffix ai-code-test-after-code-change-suffix "\
 Default prompt suffix to request running tests after code changes.")
 (defvar ai-code-use-gptel-classify-prompt nil "\
@@ -927,6 +924,21 @@ Open the onboarding quickstart buffer." t)
 (autoload 'ai-code-onboarding-disable-auto-show "ai-code-onboarding" "\
 Disable future auto-display of the onboarding quickstart." t)
 (register-definition-prefixes "ai-code-onboarding" '("ai-code-onboarding-"))
+
+
+;;; Generated autoloads from ai-code-harness.el
+
+(defvar ai-code-test-after-code-change-suffix "If any program code changes, run unit-tests and follow up on the test-result (fix code if there is an error)." "\
+User-provided prompt suffix for test-after-code-change.")
+(custom-autoload 'ai-code-test-after-code-change-suffix "ai-code-harness" t)
+(defvar ai-code-auto-test-harness-cache-directory nil "\
+Directory used to cache generated auto-test harness files.
+
+When nil, store harness files under `.ai.code.files/harness/` in the current
+repository so prompts can cite them with `@`-prefixed repo-relative paths.
+Set this to a directory path to override the default location.")
+(custom-autoload 'ai-code-auto-test-harness-cache-directory "ai-code-harness" t)
+(register-definition-prefixes "ai-code-harness" '("ai-code--"))
 
 ;;; End of scraped data
 

--- a/ai-code-autoloads.el
+++ b/ai-code-autoloads.el
@@ -31,8 +31,6 @@ with a newline separator.")
 (defvar ai-code-use-prompt-suffix t "\
 When non-nil, append `ai-code-prompt-suffix` where supported.")
 (custom-autoload 'ai-code-use-prompt-suffix "ai-code" t)
-(defvar ai-code-auto-test-suffix ai-code-test-after-code-change-suffix "\
-Default prompt suffix to request running tests after code changes.")
 (defvar ai-code-use-gptel-classify-prompt nil "\
 Whether to use GPTel to classify prompts in `ask-me` auto test mode.
 When non-nil and `ai-code-auto-test-type` is not nil, classify whether
@@ -934,11 +932,16 @@ User-provided prompt suffix for test-after-code-change.")
 (defvar ai-code-auto-test-harness-cache-directory nil "\
 Directory used to cache generated auto-test harness files.
 
-When nil, store harness files under `.ai.code.files/harness/` in the current
-repository so prompts can cite them with `@`-prefixed repo-relative paths.
+When nil, store harness files under `harness/` inside the directory returned
+by `ai-code--ensure-files-directory`. In a Git repository, that is typically
+`.ai.code.files/harness/` under the current repository so prompts can cite
+them with `@`-prefixed repo-relative paths. Outside a Git repository, this
+falls back to `harness/` under `default-directory`.
+
 Set this to a directory path to override the default location.")
 (custom-autoload 'ai-code-auto-test-harness-cache-directory "ai-code-harness" t)
 (register-definition-prefixes "ai-code-harness" '("ai-code--"))
+
 
 ;;; End of scraped data
 

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -1,0 +1,188 @@
+;;; ai-code-harness.el --- Harness support for ai-code -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Harness generation and prompt suffix helpers for ai-code.
+
+;;; Code:
+
+(require 'subr-x)
+
+(require 'ai-code-agile)
+(require 'ai-code-backends)
+
+(declare-function ai-code--ensure-files-directory "ai-code-prompt-mode" ())
+(declare-function ai-code--git-root "ai-code-file" (&optional dir))
+
+(defvar ai-code-mcp-agent-enabled-backends)
+(defvar ai-code-selected-backend)
+
+(defconst ai-code--diagnostics-first-harness-instruction
+  "Record a diagnostics baseline with the get_diagnostics MCP tool before editing. After each edit, re-run get_diagnostics for the touched files and do not finish until they have no new diagnostics compared with the baseline."
+  "Shared diagnostics-first harness guidance for code-change prompts.")
+
+(defun ai-code--diagnostics-first-harness-instruction-inline ()
+  "Return diagnostics-first guidance formatted for inline prompt text."
+  (concat (downcase (substring ai-code--diagnostics-first-harness-instruction 0 1))
+          (substring ai-code--diagnostics-first-harness-instruction 1)))
+
+;;;###autoload
+(defcustom ai-code-test-after-code-change-suffix
+  "If any program code changes, run unit-tests and follow up on the test-result (fix code if there is an error)."
+  "User-provided prompt suffix for test-after-code-change."
+  :type '(choice (const nil) string)
+  :group 'ai-code)
+
+(defconst ai-code--auto-test-harness-file-version "v1"
+  "Version tag appended to generated auto-test harness file names.")
+
+;;;###autoload
+(defcustom ai-code-auto-test-harness-cache-directory
+  nil
+  "Directory used to cache generated auto-test harness files.
+
+When nil, store harness files under `.ai.code.files/harness/` in the current
+repository so prompts can cite them with `@`-prefixed repo-relative paths.
+Set this to a directory path to override the default location."
+  :type '(choice (const :tag "Use .ai.code.files/harness under current repo" nil)
+                 directory)
+  :group 'ai-code)
+
+(defun ai-code--auto-test-harness-directory ()
+  "Return the directory used for generated auto-test harness files."
+  (let ((cache-directory (and (boundp 'ai-code-auto-test-harness-cache-directory)
+                              ai-code-auto-test-harness-cache-directory)))
+    (if cache-directory
+        (expand-file-name cache-directory)
+      (expand-file-name "harness/" (ai-code--ensure-files-directory)))))
+
+(defun ai-code--auto-test-harness-prompt-path (file-path)
+  "Return FILE-PATH formatted for prompt usage.
+When FILE-PATH is inside the current git repository, return an `@`-prefixed
+repo-relative path.  Otherwise return the absolute FILE-PATH."
+  (if-let ((git-root (ai-code--git-root)))
+      (let ((git-root-truename (file-truename git-root))
+            (file-truename (file-truename file-path)))
+        (if (string-prefix-p git-root-truename file-truename)
+            (concat "@" (file-relative-name file-truename git-root-truename))
+          file-path))
+    file-path))
+
+(defun ai-code--auto-test-backend ()
+  "Return the backend symbol used for auto-test prompt decisions."
+  (if (fboundp 'ai-code--effective-backend)
+      (or (ai-code--effective-backend) ai-code-selected-backend)
+    ai-code-selected-backend))
+
+(defun ai-code--diagnostics-harness-enabled-p ()
+  "Return non-nil when the current backend should get diagnostics guidance."
+  (memq (ai-code--auto-test-backend)
+        ai-code-mcp-agent-enabled-backends))
+
+(defun ai-code--maybe-append-diagnostics-harness-instruction (suffix &optional inline)
+  "Append diagnostics harness guidance to SUFFIX when the backend supports it.
+When INLINE is non-nil, use the inline-formatted diagnostics instruction."
+  (if (and (stringp suffix)
+           (> (length suffix) 0)
+           (ai-code--diagnostics-harness-enabled-p))
+      (let ((instruction (if inline
+                             (ai-code--diagnostics-first-harness-instruction-inline)
+                           ai-code--diagnostics-first-harness-instruction)))
+        (concat suffix
+                (if inline " " "")
+                instruction))
+    suffix))
+
+(defun ai-code--test-after-code-change--resolve-tdd-suffix ()
+  "Return the TDD-style suffix for test-after-code-change prompt text."
+  (ai-code--maybe-append-diagnostics-harness-instruction
+   (concat ai-code--tdd-red-green-base-instruction
+           ai-code--tdd-red-green-tail-instruction
+           ai-code--tdd-run-test-after-each-stage-instruction
+           ai-code--tdd-test-pattern-instruction)))
+
+(defun ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix ()
+  "Return the TDD+refactoring suffix for test-after-code-change prompt text."
+  (ai-code--maybe-append-diagnostics-harness-instruction
+   (concat ai-code--tdd-red-green-base-instruction
+           ai-code--tdd-with-refactoring-extension-instruction
+           ai-code--tdd-red-green-tail-instruction
+           ai-code--tdd-run-test-after-each-stage-instruction
+           ai-code--tdd-test-pattern-instruction)))
+
+(defun ai-code--auto-test-inline-suffix-for-type (type)
+  "Return the inline prompt suffix for auto test TYPE."
+  (pcase type
+    ('test-after-change
+     (ai-code--maybe-append-diagnostics-harness-instruction
+      ai-code-test-after-code-change-suffix t))
+    ('tdd (ai-code--test-after-code-change--resolve-tdd-suffix))
+    ('tdd-with-refactoring (ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix))
+    ('no-test "Do not write or run any test.")
+    (_ nil)))
+
+(defun ai-code--auto-test-harness-file-name (type)
+  "Return the stable harness file name for auto test TYPE."
+  (let ((base-name (symbol-name type)))
+    (format "%s%s.%s.md"
+            base-name
+            (if (ai-code--diagnostics-harness-enabled-p)
+                "-diagnostics"
+              "")
+            ai-code--auto-test-harness-file-version)))
+
+(defun ai-code--ensure-auto-test-harness-cache-directory ()
+  "Ensure the auto-test harness cache directory exists and return it."
+  (let ((directory (ai-code--auto-test-harness-directory)))
+    (unless (file-directory-p directory)
+      (make-directory directory t))
+    directory))
+
+(defun ai-code--auto-test-harness-text-for-type (type)
+  "Return the externalized harness text for auto test TYPE."
+  (pcase type
+    ('no-test nil)
+    (_ (ai-code--auto-test-inline-suffix-for-type type))))
+
+(defun ai-code--ensure-auto-test-harness-file (type)
+  "Write and return the cached harness file path for auto test TYPE."
+  (when-let ((content (ai-code--auto-test-harness-text-for-type type)))
+    (let* ((directory (ai-code--ensure-auto-test-harness-cache-directory))
+           (file-path (expand-file-name
+                       (ai-code--auto-test-harness-file-name type)
+                       directory)))
+      (with-temp-file file-path
+        (insert content)
+        (unless (bolp)
+          (insert "\n")))
+      file-path)))
+
+(defun ai-code--auto-test-harness-reference-suffix (type)
+  "Return a short suffix that references the cached harness file for TYPE.
+
+If the harness file cannot be prepared, fall back to the inline suffix."
+  (condition-case err
+      (when-let ((file-path (ai-code--ensure-auto-test-harness-file type)))
+        (format
+         "Read the local harness file: %s. Use its instructions for this work. Apply it without repeating its full contents."
+         (ai-code--auto-test-harness-prompt-path file-path)))
+    (file-error
+     (message "Failed to prepare auto-test harness file for %s: %s"
+              type
+              (error-message-string err))
+     (ai-code--auto-test-inline-suffix-for-type type))))
+
+(defun ai-code--auto-test-suffix-for-type (type)
+  "Return prompt suffix for auto test TYPE."
+  (pcase type
+    ((or 'test-after-change 'tdd 'tdd-with-refactoring)
+     (ai-code--auto-test-harness-reference-suffix type))
+    ('no-test "Do not write or run any test.")
+    (_ nil)))
+
+(provide 'ai-code-harness)
+
+;;; ai-code-harness.el ends here

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -44,10 +44,16 @@
   nil
   "Directory used to cache generated auto-test harness files.
 
-When nil, store harness files under `.ai.code.files/harness/` in the current
-repository so prompts can cite them with `@`-prefixed repo-relative paths.
+When nil, store harness files under `harness/` inside the directory returned
+by `ai-code--ensure-files-directory`.  In a Git repository, that is typically
+`.ai.code.files/harness/` under the current repository so prompts can cite
+them with `@`-prefixed repo-relative paths.  Outside a Git repository, this
+falls back to `harness/` under `default-directory`.
+
 Set this to a directory path to override the default location."
-  :type '(choice (const :tag "Use .ai.code.files/harness under current repo" nil)
+  :type '(choice
+          (const :tag "Use default harness directory (.ai.code.files/harness in a repo, or harness under default-directory otherwise)"
+                 nil)
                  directory)
   :group 'ai-code)
 
@@ -64,9 +70,9 @@ Set this to a directory path to override the default location."
 When FILE-PATH is inside the current git repository, return an `@`-prefixed
 repo-relative path.  Otherwise return the absolute FILE-PATH."
   (if-let ((git-root (ai-code--git-root)))
-      (let ((git-root-truename (file-truename git-root))
+      (let ((git-root-truename (file-name-as-directory (file-truename git-root)))
             (file-truename (file-truename file-path)))
-        (if (string-prefix-p git-root-truename file-truename)
+        (if (file-in-directory-p file-truename git-root-truename)
             (concat "@" (file-relative-name file-truename git-root-truename))
           file-path))
     file-path))

--- a/ai-code.el
+++ b/ai-code.el
@@ -318,7 +318,7 @@ If the harness file cannot be prepared, fall back to the inline suffix."
   (condition-case err
       (when-let ((file-path (ai-code--ensure-auto-test-harness-file type)))
         (format
-         "Read and follow the local harness file `%s` for this request. Apply it without repeating its full contents."
+         "Read the local harness file: %s. Use its instructions for this work. Apply it without repeating its full contents."
          (ai-code--auto-test-harness-prompt-path file-path)))
     (file-error
      (message "Failed to prepare auto-test harness file for %s: %s"

--- a/ai-code.el
+++ b/ai-code.el
@@ -185,6 +185,19 @@ with a newline separator."
   "Forward declaration for `ai-code-auto-test-type'.
 See the later `defcustom' for user-facing documentation and default.")
 
+(defconst ai-code--auto-test-harness-file-version "v1"
+  "Version tag appended to generated auto-test harness file names.")
+
+;;;###autoload
+(defcustom ai-code-auto-test-harness-cache-directory
+  (expand-file-name "ai-code-harness/" temporary-file-directory)
+  "Directory used to cache generated auto-test harness files.
+
+These harness files externalize long test workflow instructions so prompts can
+reference a stable local file instead of embedding the full instruction block."
+  :type 'directory
+  :group 'ai-code)
+
 (defun ai-code--auto-test-backend ()
   "Return the backend symbol used for auto-test prompt decisions."
   (if (fboundp 'ai-code--effective-backend)
@@ -226,6 +239,67 @@ When INLINE is non-nil, use the inline-formatted diagnostics instruction."
            ai-code--tdd-red-green-tail-instruction
            ai-code--tdd-run-test-after-each-stage-instruction
            ai-code--tdd-test-pattern-instruction)))
+
+(defun ai-code--auto-test-inline-suffix-for-type (type)
+  "Return the inline prompt suffix for auto test TYPE."
+  (pcase type
+    ('test-after-change
+     (ai-code--maybe-append-diagnostics-harness-instruction
+      ai-code-test-after-code-change-suffix t))
+    ('tdd (ai-code--test-after-code-change--resolve-tdd-suffix))
+    ('tdd-with-refactoring (ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix))
+    ('no-test "Do not write or run any test.")
+    (_ nil)))
+
+(defun ai-code--auto-test-harness-file-name (type)
+  "Return the stable harness file name for auto test TYPE."
+  (let ((base-name (symbol-name type)))
+    (format "%s%s.%s.md"
+            base-name
+            (if (ai-code--diagnostics-harness-enabled-p)
+                "-diagnostics"
+              "")
+            ai-code--auto-test-harness-file-version)))
+
+(defun ai-code--ensure-auto-test-harness-cache-directory ()
+  "Ensure the auto-test harness cache directory exists and return it."
+  (unless (file-directory-p ai-code-auto-test-harness-cache-directory)
+    (make-directory ai-code-auto-test-harness-cache-directory t))
+  ai-code-auto-test-harness-cache-directory)
+
+(defun ai-code--auto-test-harness-text-for-type (type)
+  "Return the externalized harness text for auto test TYPE."
+  (pcase type
+    ('no-test nil)
+    (_ (ai-code--auto-test-inline-suffix-for-type type))))
+
+(defun ai-code--ensure-auto-test-harness-file (type)
+  "Write and return the cached harness file path for auto test TYPE."
+  (when-let ((content (ai-code--auto-test-harness-text-for-type type)))
+    (let* ((directory (ai-code--ensure-auto-test-harness-cache-directory))
+           (file-path (expand-file-name
+                       (ai-code--auto-test-harness-file-name type)
+                       directory)))
+      (with-temp-file file-path
+        (insert content)
+        (unless (bolp)
+          (insert "\n")))
+      file-path)))
+
+(defun ai-code--auto-test-harness-reference-suffix (type)
+  "Return a short suffix that references the cached harness file for TYPE.
+
+If the harness file cannot be prepared, fall back to the inline suffix."
+  (condition-case err
+      (when-let ((file-path (ai-code--ensure-auto-test-harness-file type)))
+        (format
+         "Read and follow the local harness file `%s` for this request. Apply it without repeating its full contents."
+         file-path))
+    (file-error
+     (message "Failed to prepare auto-test harness file for %s: %s"
+              type
+              (error-message-string err))
+     (ai-code--auto-test-inline-suffix-for-type type))))
 
 (defconst ai-code--auto-test-type-ask-choices
   '(("Run tests after code change" . test-after-change)
@@ -307,11 +381,8 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
 (defun ai-code--auto-test-suffix-for-type (type)
   "Return prompt suffix for auto test TYPE."
   (pcase type
-    ('test-after-change
-     (ai-code--maybe-append-diagnostics-harness-instruction
-      ai-code-test-after-code-change-suffix t))
-    ('tdd (ai-code--test-after-code-change--resolve-tdd-suffix))
-    ('tdd-with-refactoring (ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix))
+    ((or 'test-after-change 'tdd 'tdd-with-refactoring)
+     (ai-code--auto-test-harness-reference-suffix type))
     ('no-test "Do not write or run any test.")
     (_ nil)))
 

--- a/ai-code.el
+++ b/ai-code.el
@@ -136,6 +136,8 @@
 
 (declare-function ai-code--process-word-for-filepath "ai-code-prompt-mode" (word git-root-truename))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode" (question))
+(declare-function ai-code--ensure-files-directory "ai-code-prompt-mode" ())
+(declare-function ai-code--git-root "ai-code-file" (&optional dir))
 
 ;; Default aliases are set when a backend is applied via `ai-code-select-backend`.
 
@@ -190,13 +192,33 @@ See the later `defcustom' for user-facing documentation and default.")
 
 ;;;###autoload
 (defcustom ai-code-auto-test-harness-cache-directory
-  (expand-file-name "ai-code-harness/" temporary-file-directory)
+  nil
   "Directory used to cache generated auto-test harness files.
 
-These harness files externalize long test workflow instructions so prompts can
-reference a stable local file instead of embedding the full instruction block."
-  :type 'directory
+When nil, store harness files under `.ai.code.files/harness/` in the current
+repository so prompts can cite them with `@`-prefixed repo-relative paths.
+Set this to a directory path to override the default location."
+  :type '(choice (const :tag "Use .ai.code.files/harness under current repo" nil)
+                 directory)
   :group 'ai-code)
+
+(defun ai-code--auto-test-harness-directory ()
+  "Return the directory used for generated auto-test harness files."
+  (if ai-code-auto-test-harness-cache-directory
+      (expand-file-name ai-code-auto-test-harness-cache-directory)
+    (expand-file-name "harness/" (ai-code--ensure-files-directory))))
+
+(defun ai-code--auto-test-harness-prompt-path (file-path)
+  "Return FILE-PATH formatted for prompt usage.
+When FILE-PATH is inside the current git repository, return an `@`-prefixed
+repo-relative path. Otherwise return the absolute FILE-PATH."
+  (if-let ((git-root (ai-code--git-root)))
+      (let ((git-root-truename (file-truename git-root))
+            (file-truename (file-truename file-path)))
+        (if (string-prefix-p git-root-truename file-truename)
+            (concat "@" (file-relative-name file-truename git-root-truename))
+          file-path))
+    file-path))
 
 (defun ai-code--auto-test-backend ()
   "Return the backend symbol used for auto-test prompt decisions."
@@ -263,9 +285,10 @@ When INLINE is non-nil, use the inline-formatted diagnostics instruction."
 
 (defun ai-code--ensure-auto-test-harness-cache-directory ()
   "Ensure the auto-test harness cache directory exists and return it."
-  (unless (file-directory-p ai-code-auto-test-harness-cache-directory)
-    (make-directory ai-code-auto-test-harness-cache-directory t))
-  ai-code-auto-test-harness-cache-directory)
+  (let ((directory (ai-code--auto-test-harness-directory)))
+    (unless (file-directory-p directory)
+      (make-directory directory t))
+    directory))
 
 (defun ai-code--auto-test-harness-text-for-type (type)
   "Return the externalized harness text for auto test TYPE."
@@ -294,7 +317,7 @@ If the harness file cannot be prepared, fall back to the inline suffix."
       (when-let ((file-path (ai-code--ensure-auto-test-harness-file type)))
         (format
          "Read and follow the local harness file `%s` for this request. Apply it without repeating its full contents."
-         file-path))
+         (ai-code--auto-test-harness-prompt-path file-path)))
     (file-error
      (message "Failed to prepare auto-test harness file for %s: %s"
               type

--- a/ai-code.el
+++ b/ai-code.el
@@ -204,14 +204,16 @@ Set this to a directory path to override the default location."
 
 (defun ai-code--auto-test-harness-directory ()
   "Return the directory used for generated auto-test harness files."
-  (if ai-code-auto-test-harness-cache-directory
-      (expand-file-name ai-code-auto-test-harness-cache-directory)
-    (expand-file-name "harness/" (ai-code--ensure-files-directory))))
+  (let ((cache-directory (and (boundp 'ai-code-auto-test-harness-cache-directory)
+                              ai-code-auto-test-harness-cache-directory)))
+    (if cache-directory
+        (expand-file-name cache-directory)
+      (expand-file-name "harness/" (ai-code--ensure-files-directory)))))
 
 (defun ai-code--auto-test-harness-prompt-path (file-path)
   "Return FILE-PATH formatted for prompt usage.
 When FILE-PATH is inside the current git repository, return an `@`-prefixed
-repo-relative path. Otherwise return the absolute FILE-PATH."
+repo-relative path.  Otherwise return the absolute FILE-PATH."
   (if-let ((git-root (ai-code--git-root)))
       (let ((git-root-truename (file-truename git-root))
             (file-truename (file-truename file-path)))

--- a/ai-code.el
+++ b/ai-code.el
@@ -162,7 +162,6 @@ with a newline separator."
   :type 'boolean
   :group 'ai-code)
 
-;;;###autoload
 (defvar ai-code-auto-test-suffix ai-code-test-after-code-change-suffix
   "Default prompt suffix to request running tests after code changes.")
 

--- a/ai-code.el
+++ b/ai-code.el
@@ -113,6 +113,7 @@
 (require 'ai-code-grok-cli)
 (require 'ai-code-codebuddy-cli)
 (require 'ai-code-file)
+(require 'ai-code-harness)
 (require 'ai-code-ai)
 (require 'ai-code-mcp-server)
 (require 'ai-code-notifications)
@@ -136,8 +137,6 @@
 
 (declare-function ai-code--process-word-for-filepath "ai-code-prompt-mode" (word git-root-truename))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode" (question))
-(declare-function ai-code--ensure-files-directory "ai-code-prompt-mode" ())
-(declare-function ai-code--git-root "ai-code-file" (&optional dir))
 
 ;; Default aliases are set when a backend is applied via `ai-code-select-backend`.
 
@@ -163,22 +162,6 @@ with a newline separator."
   :type 'boolean
   :group 'ai-code)
 
-(defconst ai-code--diagnostics-first-harness-instruction
-  "Record a diagnostics baseline with the get_diagnostics MCP tool before editing. After each edit, re-run get_diagnostics for the touched files and do not finish until they have no new diagnostics compared with the baseline."
-  "Shared diagnostics-first harness guidance for code-change prompts.")
-
-(defun ai-code--diagnostics-first-harness-instruction-inline ()
-  "Return diagnostics-first guidance formatted for inline prompt text."
-  (concat (downcase (substring ai-code--diagnostics-first-harness-instruction 0 1))
-          (substring ai-code--diagnostics-first-harness-instruction 1)))
-
-;;;###autoload
-(defcustom ai-code-test-after-code-change-suffix
-  "If any program code changes, run unit-tests and follow up on the test-result (fix code if there is an error)."
-  "User-provided prompt suffix for test-after-code-change."
-  :type '(choice (const nil) string)
-  :group 'ai-code)
-
 ;;;###autoload
 (defvar ai-code-auto-test-suffix ai-code-test-after-code-change-suffix
   "Default prompt suffix to request running tests after code changes.")
@@ -186,145 +169,6 @@ with a newline separator."
 (defvar ai-code-auto-test-type nil
   "Forward declaration for `ai-code-auto-test-type'.
 See the later `defcustom' for user-facing documentation and default.")
-
-(defconst ai-code--auto-test-harness-file-version "v1"
-  "Version tag appended to generated auto-test harness file names.")
-
-;;;###autoload
-(defcustom ai-code-auto-test-harness-cache-directory
-  nil
-  "Directory used to cache generated auto-test harness files.
-
-When nil, store harness files under `.ai.code.files/harness/` in the current
-repository so prompts can cite them with `@`-prefixed repo-relative paths.
-Set this to a directory path to override the default location."
-  :type '(choice (const :tag "Use .ai.code.files/harness under current repo" nil)
-                 directory)
-  :group 'ai-code)
-
-(defun ai-code--auto-test-harness-directory ()
-  "Return the directory used for generated auto-test harness files."
-  (let ((cache-directory (and (boundp 'ai-code-auto-test-harness-cache-directory)
-                              ai-code-auto-test-harness-cache-directory)))
-    (if cache-directory
-        (expand-file-name cache-directory)
-      (expand-file-name "harness/" (ai-code--ensure-files-directory)))))
-
-(defun ai-code--auto-test-harness-prompt-path (file-path)
-  "Return FILE-PATH formatted for prompt usage.
-When FILE-PATH is inside the current git repository, return an `@`-prefixed
-repo-relative path.  Otherwise return the absolute FILE-PATH."
-  (if-let ((git-root (ai-code--git-root)))
-      (let ((git-root-truename (file-truename git-root))
-            (file-truename (file-truename file-path)))
-        (if (string-prefix-p git-root-truename file-truename)
-            (concat "@" (file-relative-name file-truename git-root-truename))
-          file-path))
-    file-path))
-
-(defun ai-code--auto-test-backend ()
-  "Return the backend symbol used for auto-test prompt decisions."
-  (if (fboundp 'ai-code--effective-backend)
-      (or (ai-code--effective-backend) ai-code-selected-backend)
-    ai-code-selected-backend))
-
-(defun ai-code--diagnostics-harness-enabled-p ()
-  "Return non-nil when the current backend should get diagnostics guidance."
-  (memq (ai-code--auto-test-backend)
-        ai-code-mcp-agent-enabled-backends))
-
-(defun ai-code--maybe-append-diagnostics-harness-instruction (suffix &optional inline)
-  "Append diagnostics harness guidance to SUFFIX when the backend supports it.
-When INLINE is non-nil, use the inline-formatted diagnostics instruction."
-  (if (and (stringp suffix)
-           (> (length suffix) 0)
-           (ai-code--diagnostics-harness-enabled-p))
-      (let ((instruction (if inline
-                             (ai-code--diagnostics-first-harness-instruction-inline)
-                           ai-code--diagnostics-first-harness-instruction)))
-        (concat suffix
-                (if inline " " "")
-                instruction))
-    suffix))
-
-(defun ai-code--test-after-code-change--resolve-tdd-suffix ()
-  "Return the TDD-style suffix for test-after-code-change prompt text."
-  (ai-code--maybe-append-diagnostics-harness-instruction
-   (concat ai-code--tdd-red-green-base-instruction
-           ai-code--tdd-red-green-tail-instruction
-           ai-code--tdd-run-test-after-each-stage-instruction
-           ai-code--tdd-test-pattern-instruction)))
-
-(defun ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix ()
-  "Return the TDD+refactoring suffix for test-after-code-change prompt text."
-  (ai-code--maybe-append-diagnostics-harness-instruction
-   (concat ai-code--tdd-red-green-base-instruction
-           ai-code--tdd-with-refactoring-extension-instruction
-           ai-code--tdd-red-green-tail-instruction
-           ai-code--tdd-run-test-after-each-stage-instruction
-           ai-code--tdd-test-pattern-instruction)))
-
-(defun ai-code--auto-test-inline-suffix-for-type (type)
-  "Return the inline prompt suffix for auto test TYPE."
-  (pcase type
-    ('test-after-change
-     (ai-code--maybe-append-diagnostics-harness-instruction
-      ai-code-test-after-code-change-suffix t))
-    ('tdd (ai-code--test-after-code-change--resolve-tdd-suffix))
-    ('tdd-with-refactoring (ai-code--test-after-code-change--resolve-tdd-with-refactoring-suffix))
-    ('no-test "Do not write or run any test.")
-    (_ nil)))
-
-(defun ai-code--auto-test-harness-file-name (type)
-  "Return the stable harness file name for auto test TYPE."
-  (let ((base-name (symbol-name type)))
-    (format "%s%s.%s.md"
-            base-name
-            (if (ai-code--diagnostics-harness-enabled-p)
-                "-diagnostics"
-              "")
-            ai-code--auto-test-harness-file-version)))
-
-(defun ai-code--ensure-auto-test-harness-cache-directory ()
-  "Ensure the auto-test harness cache directory exists and return it."
-  (let ((directory (ai-code--auto-test-harness-directory)))
-    (unless (file-directory-p directory)
-      (make-directory directory t))
-    directory))
-
-(defun ai-code--auto-test-harness-text-for-type (type)
-  "Return the externalized harness text for auto test TYPE."
-  (pcase type
-    ('no-test nil)
-    (_ (ai-code--auto-test-inline-suffix-for-type type))))
-
-(defun ai-code--ensure-auto-test-harness-file (type)
-  "Write and return the cached harness file path for auto test TYPE."
-  (when-let ((content (ai-code--auto-test-harness-text-for-type type)))
-    (let* ((directory (ai-code--ensure-auto-test-harness-cache-directory))
-           (file-path (expand-file-name
-                       (ai-code--auto-test-harness-file-name type)
-                       directory)))
-      (with-temp-file file-path
-        (insert content)
-        (unless (bolp)
-          (insert "\n")))
-      file-path)))
-
-(defun ai-code--auto-test-harness-reference-suffix (type)
-  "Return a short suffix that references the cached harness file for TYPE.
-
-If the harness file cannot be prepared, fall back to the inline suffix."
-  (condition-case err
-      (when-let ((file-path (ai-code--ensure-auto-test-harness-file type)))
-        (format
-         "Read the local harness file: %s. Use its instructions for this work. Apply it without repeating its full contents."
-         (ai-code--auto-test-harness-prompt-path file-path)))
-    (file-error
-     (message "Failed to prepare auto-test harness file for %s: %s"
-              type
-              (error-message-string err))
-     (ai-code--auto-test-inline-suffix-for-type type))))
 
 (defconst ai-code--auto-test-type-ask-choices
   '(("Run tests after code change" . test-after-change)
@@ -402,14 +246,6 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
         ('non-code-change nil)
         (_ (ai-code--read-auto-test-type-choice)))
     (ai-code--read-auto-test-type-choice)))
-
-(defun ai-code--auto-test-suffix-for-type (type)
-  "Return prompt suffix for auto test TYPE."
-  (pcase type
-    ((or 'test-after-change 'tdd 'tdd-with-refactoring)
-     (ai-code--auto-test-harness-reference-suffix type))
-    ('no-test "Do not write or run any test.")
-    (_ nil)))
 
 (defun ai-code--resolve-auto-test-suffix-for-send (&optional prompt-text)
   "Resolve auto test suffix for current send action for PROMPT-TEXT."

--- a/ai-code.el
+++ b/ai-code.el
@@ -1,7 +1,7 @@
 ;;; ai-code.el --- Unified interface for AI coding backends such as Codex CLI, Copilot CLI, Claude Code, Gemini CLI, Opencode, Grok CLI, etc -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 1.67
+;; Version: 1.68
 ;; Package-Requires: ((emacs "29.1") (transient "0.9.0") (magit "2.1.0"))
 ;; URL: https://github.com/tninja/ai-code-interface.el
 

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -1,0 +1,133 @@
+;;; test_ai-code-harness.el --- Tests for ai-code-harness.el -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for harness generation and prompt suffix helpers.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+(require 'ai-code-harness)
+
+(defvar ai-code-mcp-agent-enabled-backends nil)
+(defvar ai-code--tdd-run-test-after-each-stage-instruction)
+
+(ert-deftest ai-code-test-resolve-tdd-suffix-includes-strict-stage-contract ()
+  "Test that TDD suffix names Red and Green stages and forbids skipping."
+  (let ((ai-code--tdd-test-pattern-instruction ""))
+    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
+      (should (string-match-p "Do not skip stages" suffix))
+      (should (string-match-p "Stage 1 - Red" suffix))
+      (should (string-match-p "Stage 2 - Green" suffix))
+      (should (string-match-p "Do not refactor during Green" suffix)))))
+
+(ert-deftest ai-code-test-resolve-tdd-suffix-reuses-shared-each-stage-instruction ()
+  "Test that TDD suffix can reuse shared each-stage instruction when available."
+  (let ((ai-code--tdd-test-pattern-instruction "")
+        (ai-code--tdd-run-test-after-each-stage-instruction
+         " SHARED_EACH_STAGE_TEST_INSTRUCTION"))
+    (should (string-match-p "SHARED_EACH_STAGE_TEST_INSTRUCTION"
+                            (ai-code--test-after-code-change--resolve-tdd-suffix)))))
+
+(ert-deftest ai-code-test-auto-test-harness-reference-suffix-tells-ai-to-use-local-harness ()
+  "Test that harness reference prompt tells AI to read and use the harness."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-harness-cache-directory nil)
+         (ai-code-mcp-agent-enabled-backends '(codex))
+         (ai-code-selected-backend 'codex)
+         (ai-code--tdd-test-pattern-instruction ""))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir))
+                  ((symbol-function 'ai-code--git-root)
+                   (lambda (&optional _dir) temp-root)))
+          (let ((suffix (ai-code--auto-test-harness-reference-suffix 'tdd-with-refactoring)))
+            (should (string-match-p "Read the local harness file:" suffix))
+            (should (string-match-p "Use its instructions for this work\\." suffix))
+            (should (string-match-p
+                     (regexp-quote "@.ai.code.files/harness/tdd-with-refactoring-diagnostics.v1.md")
+                     suffix))))
+      (delete-directory temp-root t))))
+
+(ert-deftest ai-code-test-resolve-tdd-suffix-includes-diagnostics-first-loop ()
+  "Test that TDD suffix requires diagnostics checks before completion."
+  (let ((ai-code--tdd-test-pattern-instruction "")
+        (case-fold-search nil)
+        (ai-code-mcp-agent-enabled-backends '(codex))
+        (ai-code-selected-backend 'codex))
+    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
+      (should (string-match-p "get_diagnostics" suffix))
+      (should (string-match-p "get_diagnostics MCP tool" suffix))
+      (should (string-match-p "baseline" suffix))
+      (should (string-match-p "no new diagnostics" suffix)))))
+
+(ert-deftest ai-code-test-resolve-tdd-suffix-omits-diagnostics-for-non-mcp-backend ()
+  "Test that TDD suffix omits diagnostics for unsupported backends."
+  (let ((ai-code--tdd-test-pattern-instruction "")
+        (ai-code-mcp-agent-enabled-backends '(codex))
+        (ai-code-selected-backend 'gemini))
+    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
+      (should-not (string-match-p "get_diagnostics" suffix))
+      (should-not (string-match-p "no new diagnostics" suffix)))))
+
+(ert-deftest ai-code-test-maybe-append-diagnostics-harness-instruction-preserves-nil-suffix ()
+  "Test that diagnostics harness logic preserves a nil suffix."
+  (let ((ai-code-selected-backend 'codex)
+        (ai-code-mcp-agent-enabled-backends '(codex)))
+    (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil))
+    (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil t))))
+
+(ert-deftest ai-code-test-auto-test-harness-directory-defaults-to-ai-code-files-harness ()
+  "Test that harness directory defaults to `.ai.code.files/harness/`."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-harness-cache-directory nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir)))
+          (should (equal (expand-file-name "harness/" ai-files-dir)
+                         (ai-code--auto-test-harness-directory))))
+      (delete-directory temp-root t))))
+
+(ert-deftest ai-code-test-ensure-auto-test-harness-cache-directory-tolerates-unbound-custom ()
+  "Test that harness directory creation falls back when the custom is unbound."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (expected-directory (expand-file-name "harness/" ai-files-dir))
+         (was-bound (boundp 'ai-code-auto-test-harness-cache-directory))
+         (original-value (when was-bound ai-code-auto-test-harness-cache-directory)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir)))
+          (makunbound 'ai-code-auto-test-harness-cache-directory)
+          (should (equal expected-directory
+                         (ai-code--ensure-auto-test-harness-cache-directory)))
+          (should (file-directory-p expected-directory)))
+      (if was-bound
+          (setq ai-code-auto-test-harness-cache-directory original-value)
+        (makunbound 'ai-code-auto-test-harness-cache-directory))
+      (delete-directory temp-root t))))
+
+(ert-deftest ai-code-test-auto-test-harness-prompt-path-uses-repo-relative-at-path ()
+  "Test that harness prompt path becomes an `@` repo-relative path."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (harness-file (expand-file-name ".ai.code.files/harness/tdd.v1.md" temp-root)))
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory harness-file) t)
+          (with-temp-file harness-file
+            (insert "harness"))
+          (cl-letf (((symbol-function 'ai-code--git-root)
+                     (lambda (&optional _dir) temp-root)))
+            (should (equal "@.ai.code.files/harness/tdd.v1.md"
+                           (ai-code--auto-test-harness-prompt-path harness-file)))))
+      (delete-directory temp-root t))))
+
+(provide 'test_ai-code-harness)
+
+;;; test_ai-code-harness.el ends here

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -128,6 +128,38 @@
                            (ai-code--auto-test-harness-prompt-path harness-file)))))
       (delete-directory temp-root t))))
 
+(ert-deftest ai-code-test-auto-test-harness-prompt-path-keeps-sibling-path-absolute ()
+  "Test that sibling paths with a shared prefix are not treated as repo-local."
+  (let* ((temp-root (make-temp-file "ai-code-harness-parent-" t))
+         (git-root (directory-file-name (expand-file-name "repo/" temp-root)))
+         (external-root (expand-file-name "repo-cache/" temp-root))
+         (harness-file (expand-file-name "harness/tdd.v1.md" external-root)))
+    (unwind-protect
+        (progn
+          (make-directory git-root t)
+          (make-directory (file-name-directory harness-file) t)
+          (with-temp-file harness-file
+            (insert "harness"))
+          (cl-letf (((symbol-function 'ai-code--git-root)
+                     (lambda (&optional _dir) git-root)))
+            (should (equal harness-file
+                           (ai-code--auto-test-harness-prompt-path harness-file)))))
+      (delete-directory temp-root t))))
+
+(ert-deftest ai-code-test-auto-test-harness-cache-directory-docs-cover-non-repo-fallback ()
+  "Test that the harness directory custom documents the non-repo fallback."
+  (let ((doc (documentation-property 'ai-code-auto-test-harness-cache-directory
+                                     'variable-documentation)))
+    (should (string-match-p "Outside a Git repository" doc))
+    (should (string-match-p "default-directory" doc))
+    (should
+     (equal
+      '(choice
+        (const :tag "Use default harness directory (.ai.code.files/harness in a repo, or harness under default-directory otherwise)"
+               nil)
+        directory)
+      (get 'ai-code-auto-test-harness-cache-directory 'custom-type)))))
+
 (provide 'test_ai-code-harness)
 
 ;;; test_ai-code-harness.el ends here

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -140,6 +140,25 @@
                          (ai-code--auto-test-harness-directory))))
       (delete-directory temp-root t))))
 
+(ert-deftest ai-code-test-ensure-auto-test-harness-cache-directory-tolerates-unbound-custom ()
+  "Test that harness directory creation falls back when the custom is unbound."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (expected-directory (expand-file-name "harness/" ai-files-dir))
+         (was-bound (boundp 'ai-code-auto-test-harness-cache-directory))
+         (original-value (when was-bound ai-code-auto-test-harness-cache-directory)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir)))
+          (makunbound 'ai-code-auto-test-harness-cache-directory)
+          (should (equal expected-directory
+                         (ai-code--ensure-auto-test-harness-cache-directory)))
+          (should (file-directory-p expected-directory)))
+      (if was-bound
+          (setq ai-code-auto-test-harness-cache-directory original-value)
+        (makunbound 'ai-code-auto-test-harness-cache-directory))
+      (delete-directory temp-root t))))
+
 (ert-deftest ai-code-test-auto-test-harness-prompt-path-uses-repo-relative-at-path ()
   "Test that harness prompt path becomes an `@` repo-relative path."
   (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -102,6 +102,26 @@
             (should-not (string-match-p "diagnostics.v1.md" suffix))))
       (delete-directory temp-root t))))
 
+(ert-deftest ai-code-test-auto-test-harness-reference-suffix-tells-ai-to-use-local-harness ()
+  "Test that harness reference prompt tells AI to read and use the harness."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-harness-cache-directory nil)
+         (ai-code-selected-backend 'codex)
+         (ai-code--tdd-test-pattern-instruction ""))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir))
+                  ((symbol-function 'ai-code--git-root)
+                   (lambda (&optional _dir) temp-root)))
+          (let ((suffix (ai-code--auto-test-harness-reference-suffix 'tdd-with-refactoring)))
+            (should (string-match-p "Read the local harness file:" suffix))
+            (should (string-match-p "Use its instructions for this work\\." suffix))
+            (should (string-match-p
+                     (regexp-quote "@.ai.code.files/harness/tdd-with-refactoring-diagnostics.v1.md")
+                     suffix))))
+      (delete-directory temp-root t))))
+
 (ert-deftest ai-code-test-resolve-tdd-suffix-includes-diagnostics-first-loop ()
   "Test that TDD suffix requires diagnostics checks before completion."
   (let ((ai-code--tdd-test-pattern-instruction "")

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -33,6 +33,35 @@
   "Test that loading `ai-code` also loads the harness module."
   (should (featurep 'ai-code-harness)))
 
+(ert-deftest ai-code-test-autoloads-load-with-harness-custom-unbound ()
+  "Test that loading autoloads works before harness custom is defined."
+  (let* ((autoload-file (expand-file-name "ai-code-autoloads.el" default-directory))
+         (symbols '(ai-code-auto-test-suffix
+                    ai-code-test-after-code-change-suffix))
+         (saved-states
+          (mapcar (lambda (symbol)
+                    (list symbol
+                          (boundp symbol)
+                          (when (boundp symbol)
+                            (symbol-value symbol))))
+                  symbols)))
+    (unwind-protect
+        (progn
+          (mapc #'makunbound symbols)
+          (should
+           (eq 'loaded
+               (condition-case nil
+                   (progn
+                     (load autoload-file nil t)
+                     'loaded)
+                 (error 'failed))))
+          (should (boundp 'ai-code-test-after-code-change-suffix)))
+      (dolist (state saved-states)
+        (pcase-let ((`(,symbol ,was-bound ,value) state))
+          (if was-bound
+              (set symbol value)
+            (makunbound symbol)))))))
+
 (ert-deftest ai-code-test-set-auto-test-type-ask-me-clears-persistent-suffix ()
   "Test that setting auto test type to ask-me clears the persistent suffix."
   (let ((ai-code-auto-test-suffix "old")

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -29,7 +29,9 @@
 
 (require 'ai-code)
 
-(defvar ai-code--tdd-run-test-after-each-stage-instruction)
+(ert-deftest ai-code-test-require-ai-code-loads-harness-module ()
+  "Test that loading `ai-code` also loads the harness module."
+  (should (featurep 'ai-code-harness)))
 
 (ert-deftest ai-code-test-set-auto-test-type-ask-me-clears-persistent-suffix ()
   "Test that setting auto test type to ask-me clears the persistent suffix."
@@ -47,23 +49,6 @@
     (ai-code--apply-auto-test-type nil)
     (should-not ai-code-auto-test-type)
     (should-not ai-code-auto-test-suffix)))
-
-(ert-deftest ai-code-test-resolve-tdd-suffix-includes-strict-stage-contract ()
-  "Test that TDD suffix names Red and Green stages and forbids skipping."
-  (let ((ai-code--tdd-test-pattern-instruction ""))
-    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
-      (should (string-match-p "Do not skip stages" suffix))
-      (should (string-match-p "Stage 1 - Red" suffix))
-      (should (string-match-p "Stage 2 - Green" suffix))
-      (should (string-match-p "Do not refactor during Green" suffix)))))
-
-(ert-deftest ai-code-test-resolve-tdd-suffix-reuses-shared-each-stage-instruction ()
-  "Test that TDD suffix can reuse shared each-stage instruction when available."
-  (let ((ai-code--tdd-test-pattern-instruction "")
-        (ai-code--tdd-run-test-after-each-stage-instruction
-         " SHARED_EACH_STAGE_TEST_INSTRUCTION"))
-    (should (string-match-p "SHARED_EACH_STAGE_TEST_INSTRUCTION"
-                            (ai-code--test-after-code-change--resolve-tdd-suffix)))))
 
 (ert-deftest ai-code-test-resolve-test-after-change-suffix-includes-diagnostics-for-mcp-backend ()
   "Test that test-after-change suffix points to the diagnostics harness file."
@@ -100,98 +85,6 @@
                      (regexp-quote "@.ai.code.files/harness/test-after-change.v1.md")
                      suffix))
             (should-not (string-match-p "diagnostics.v1.md" suffix))))
-      (delete-directory temp-root t))))
-
-(ert-deftest ai-code-test-auto-test-harness-reference-suffix-tells-ai-to-use-local-harness ()
-  "Test that harness reference prompt tells AI to read and use the harness."
-  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
-         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
-         (ai-code-auto-test-harness-cache-directory nil)
-         (ai-code-selected-backend 'codex)
-         (ai-code--tdd-test-pattern-instruction ""))
-    (unwind-protect
-        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
-                   (lambda () ai-files-dir))
-                  ((symbol-function 'ai-code--git-root)
-                   (lambda (&optional _dir) temp-root)))
-          (let ((suffix (ai-code--auto-test-harness-reference-suffix 'tdd-with-refactoring)))
-            (should (string-match-p "Read the local harness file:" suffix))
-            (should (string-match-p "Use its instructions for this work\\." suffix))
-            (should (string-match-p
-                     (regexp-quote "@.ai.code.files/harness/tdd-with-refactoring-diagnostics.v1.md")
-                     suffix))))
-      (delete-directory temp-root t))))
-
-(ert-deftest ai-code-test-resolve-tdd-suffix-includes-diagnostics-first-loop ()
-  "Test that TDD suffix requires diagnostics checks before completion."
-  (let ((ai-code--tdd-test-pattern-instruction "")
-        (case-fold-search nil)
-        (ai-code-selected-backend 'codex))
-    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
-      (should (string-match-p "get_diagnostics" suffix))
-      (should (string-match-p "get_diagnostics MCP tool" suffix))
-      (should (string-match-p "baseline" suffix))
-      (should (string-match-p "no new diagnostics" suffix)))))
-
-(ert-deftest ai-code-test-resolve-tdd-suffix-omits-diagnostics-for-non-mcp-backend ()
-  "Test that TDD suffix omits diagnostics for unsupported backends."
-  (let ((ai-code--tdd-test-pattern-instruction "")
-        (ai-code-selected-backend 'gemini))
-    (let ((suffix (ai-code--test-after-code-change--resolve-tdd-suffix)))
-      (should-not (string-match-p "get_diagnostics" suffix))
-      (should-not (string-match-p "no new diagnostics" suffix)))))
-
-(ert-deftest ai-code-test-maybe-append-diagnostics-harness-instruction-preserves-nil-suffix ()
-  "Test that diagnostics harness logic preserves a nil suffix."
-  (let ((ai-code-selected-backend 'codex)
-        (ai-code-mcp-agent-enabled-backends '(codex)))
-    (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil))
-    (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil t))))
-
-(ert-deftest ai-code-test-auto-test-harness-directory-defaults-to-ai-code-files-harness ()
-  "Test that harness directory defaults to `.ai.code.files/harness/`."
-  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
-         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
-         (ai-code-auto-test-harness-cache-directory nil))
-    (unwind-protect
-        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
-                   (lambda () ai-files-dir)))
-          (should (equal (expand-file-name "harness/" ai-files-dir)
-                         (ai-code--auto-test-harness-directory))))
-      (delete-directory temp-root t))))
-
-(ert-deftest ai-code-test-ensure-auto-test-harness-cache-directory-tolerates-unbound-custom ()
-  "Test that harness directory creation falls back when the custom is unbound."
-  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
-         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
-         (expected-directory (expand-file-name "harness/" ai-files-dir))
-         (was-bound (boundp 'ai-code-auto-test-harness-cache-directory))
-         (original-value (when was-bound ai-code-auto-test-harness-cache-directory)))
-    (unwind-protect
-        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
-                   (lambda () ai-files-dir)))
-          (makunbound 'ai-code-auto-test-harness-cache-directory)
-          (should (equal expected-directory
-                         (ai-code--ensure-auto-test-harness-cache-directory)))
-          (should (file-directory-p expected-directory)))
-      (if was-bound
-          (setq ai-code-auto-test-harness-cache-directory original-value)
-        (makunbound 'ai-code-auto-test-harness-cache-directory))
-      (delete-directory temp-root t))))
-
-(ert-deftest ai-code-test-auto-test-harness-prompt-path-uses-repo-relative-at-path ()
-  "Test that harness prompt path becomes an `@` repo-relative path."
-  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
-         (harness-file (expand-file-name ".ai.code.files/harness/tdd.v1.md" temp-root)))
-    (unwind-protect
-        (progn
-          (make-directory (file-name-directory harness-file) t)
-          (with-temp-file harness-file
-            (insert "harness"))
-          (cl-letf (((symbol-function 'ai-code--git-root)
-                     (lambda (&optional _dir) temp-root)))
-            (should (equal "@.ai.code.files/harness/tdd.v1.md"
-                           (ai-code--auto-test-harness-prompt-path harness-file)))))
       (delete-directory temp-root t))))
 
 (ert-deftest ai-code-test-resolve-auto-test-type-for-send-off ()

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -66,21 +66,41 @@
                             (ai-code--test-after-code-change--resolve-tdd-suffix)))))
 
 (ert-deftest ai-code-test-resolve-test-after-change-suffix-includes-diagnostics-for-mcp-backend ()
-  "Test that test-after-change suffix adds diagnostics for supported MCP backends."
-  (let ((ai-code-auto-test-type 'test-after-change)
-        (ai-code-selected-backend 'codex))
-    (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
-      (should (string-match-p "get_diagnostics" suffix))
-      (should (string-match-p "baseline" suffix))
-      (should (string-match-p "no new diagnostics" suffix)))))
+  "Test that test-after-change suffix points to the diagnostics harness file."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-type 'test-after-change)
+         (ai-code-auto-test-harness-cache-directory nil)
+         (ai-code-selected-backend 'codex))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir))
+                  ((symbol-function 'ai-code--git-root)
+                   (lambda (&optional _dir) temp-root)))
+          (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
+            (should (string-match-p
+                     (regexp-quote "@.ai.code.files/harness/test-after-change-diagnostics.v1.md")
+                     suffix))))
+      (delete-directory temp-root t))))
 
 (ert-deftest ai-code-test-resolve-test-after-change-suffix-omits-diagnostics-for-non-mcp-backend ()
-  "Test that test-after-change suffix omits diagnostics for unsupported backends."
-  (let ((ai-code-auto-test-type 'test-after-change)
-        (ai-code-selected-backend 'gemini))
-    (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
-      (should-not (string-match-p "get_diagnostics" suffix))
-      (should-not (string-match-p "no new diagnostics" suffix)))))
+  "Test that unsupported backends use the non-diagnostics harness variant."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-type 'test-after-change)
+         (ai-code-auto-test-harness-cache-directory nil)
+         (ai-code-selected-backend 'gemini))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir))
+                  ((symbol-function 'ai-code--git-root)
+                   (lambda (&optional _dir) temp-root)))
+          (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
+            (should (string-match-p
+                     (regexp-quote "@.ai.code.files/harness/test-after-change.v1.md")
+                     suffix))
+            (should-not (string-match-p "diagnostics.v1.md" suffix))))
+      (delete-directory temp-root t))))
 
 (ert-deftest ai-code-test-resolve-tdd-suffix-includes-diagnostics-first-loop ()
   "Test that TDD suffix requires diagnostics checks before completion."
@@ -107,6 +127,33 @@
         (ai-code-mcp-agent-enabled-backends '(codex)))
     (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil))
     (should-not (ai-code--maybe-append-diagnostics-harness-instruction nil t))))
+
+(ert-deftest ai-code-test-auto-test-harness-directory-defaults-to-ai-code-files-harness ()
+  "Test that harness directory defaults to `.ai.code.files/harness/`."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-harness-cache-directory nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir)))
+          (should (equal (expand-file-name "harness/" ai-files-dir)
+                         (ai-code--auto-test-harness-directory))))
+      (delete-directory temp-root t))))
+
+(ert-deftest ai-code-test-auto-test-harness-prompt-path-uses-repo-relative-at-path ()
+  "Test that harness prompt path becomes an `@` repo-relative path."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (harness-file (expand-file-name ".ai.code.files/harness/tdd.v1.md" temp-root)))
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory harness-file) t)
+          (with-temp-file harness-file
+            (insert "harness"))
+          (cl-letf (((symbol-function 'ai-code--git-root)
+                     (lambda (&optional _dir) temp-root)))
+            (should (equal "@.ai.code.files/harness/tdd.v1.md"
+                           (ai-code--auto-test-harness-prompt-path harness-file)))))
+      (delete-directory temp-root t))))
 
 (ert-deftest ai-code-test-resolve-auto-test-type-for-send-off ()
   "Test that off mode never resolves a send-time auto test type."
@@ -207,16 +254,25 @@
                  ai-code--auto-test-type-persistent-choices)))
 
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-tdd-with-refactoring ()
-  "Test that ask-me can resolve to refactoring TDD suffix."
-  (let ((ai-code-auto-test-type 'ask-me)
-        (ai-code--tdd-test-pattern-instruction ""))
-    (cl-letf (((symbol-function 'ai-code--read-auto-test-type-choice)
-               (lambda () 'tdd-with-refactoring)))
-      (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
-        (should (string-match-p
-                 (regexp-quote ai-code--tdd-with-refactoring-extension-instruction)
-                 suffix))
-        (should (string-match-p "highest-impact cleanup" suffix))))))
+  "Test that ask-me resolves to the repo-local TDD harness reference."
+  (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
+         (ai-files-dir (expand-file-name ".ai.code.files/" temp-root))
+         (ai-code-auto-test-harness-cache-directory nil)
+         (ai-code-auto-test-type 'ask-me)
+         (ai-code-selected-backend 'codex)
+         (ai-code--tdd-test-pattern-instruction ""))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--ensure-files-directory)
+                   (lambda () ai-files-dir))
+                  ((symbol-function 'ai-code--git-root)
+                   (lambda (&optional _dir) temp-root))
+                  ((symbol-function 'ai-code--read-auto-test-type-choice)
+                   (lambda () 'tdd-with-refactoring)))
+          (let ((suffix (ai-code--resolve-auto-test-suffix-for-send)))
+            (should (string-match-p
+                     (regexp-quote "@.ai.code.files/harness/tdd-with-refactoring-diagnostics.v1.md")
+                     suffix))))
+      (delete-directory temp-root t))))
 
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-no-test ()
   "Test that ask-me can resolve to explicit no-test suffix."


### PR DESCRIPTION
## Summary

This PR trims the auto-test/TDD harness loop by extracting the harness generation and prompt-suffix logic out of `ai-code.el` into a dedicated `ai-code-harness.el` module.

Along the way, it keeps harness files repo-local under `.ai.code.files/harness/`, references them with `@` paths in prompts, clarifies that the AI should read and use the local harness file for the work, and preserves the fallback behavior when the harness cache custom is unbound.

## Highlights

- add `ai-code-harness.el` to own the harness-specific logic:
  - diagnostics harness instructions
  - TDD/TDD-with-refactoring suffix resolution
  - harness file naming, directory management, and prompt path generation
  - local harness reference prompt generation
- keep `ai-code.el` focused on the entry and integration layer by requiring the new module instead of carrying the full harness implementation inline
- regenerate `ai-code-autoloads.el` so the moved customizations continue to autoload from the new module
- keep harness files inside the repo and reference them with `@.ai.code.files/harness/...` paths instead of depending on temp-file locations
- split harness-focused tests into `test/test_ai-code-harness.el` and leave `test/test_ai-code.el` focused on `ai-code` integration behavior

## User-visible impact

- auto-test and TDD prompts now rely on a dedicated local harness module instead of a large inline implementation inside `ai-code.el`
- generated prompts explicitly tell the AI to read the local harness file and use its instructions for the current work
- repo-local harness files make the `@` references stable and directly usable by supported coding backends

## Testing

- `emacs -Q --batch --eval "(setq load-prefer-newer t)" -L . -l package --eval "(package-initialize)" -l ert -l test/test_ai-code.el -l test/test_ai-code-harness.el --eval "(ert-run-tests-batch-and-exit t)"`
- `emacs -Q --batch --eval "(setq load-prefer-newer t)" -L . -l package --eval "(package-initialize)" --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile ai-code.el ai-code-harness.el ai-code-autoloads.el test/test_ai-code.el test/test_ai-code-harness.el`
- `emacs -Q --batch --eval "(setq load-prefer-newer t)" -L . -l package --eval "(package-initialize)" --eval "(progn (require 'checkdoc) (mapc #'checkdoc-file '(\"ai-code.el\" \"ai-code-harness.el\" \"test/test_ai-code.el\" \"test/test_ai-code-harness.el\")))"`