### PR TITLE
Feat: Add discussion follow-up suggestions

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,8 @@
 * Release history
 
 ** Main branch change
+- Feat: Add optional numbered next-step suggestions for discussion prompts via `ai-code-discussion-auto-follow-up-enabled`
+  - Reuse GPTel prompt classification when available, add a transient toggle on `C-c a F`, and record the follow-up suffix in prompt history
 
 ** 1.68
 - UX: TDD Harness loop externalize the long prompt

--- a/README.org
+++ b/README.org
@@ -467,7 +467,7 @@ When working with multiple AI sessions, it can be useful to receive desktop noti
 
 - A: Enable auto-approval for your active AI coding CLI. For example, in Codex CLI, you can enable the following flag.
 #+begin_src elisp
-  (setq ai-code-codex-cli-program-switches '("--full-auto"))
+  (setq ai-code-codex-cli-program-switches '("-a" "never"))
 #+end_src
 
 ** AI Assisted Programming related books

--- a/README.org
+++ b/README.org
@@ -106,6 +106,10 @@ Enable installation of packages from MELPA by adding an entry to package-archive
     ;; (ai-code-prompt-filepath-completion-mode -1)
     ;; Optional: Ask AI to run test after code changes, for a tighter build-test loop
     (setq ai-code-auto-test-type 'ask-me)
+    ;; Optional: Offer numbered next steps for discussion prompts at send time
+    ;; Customize `ai-code-discussion-auto-follow-up-enabled` to non-nil
+    ;; or set it directly like this:
+    ;; (setq ai-code-discussion-auto-follow-up-enabled t)
     ;; Optional: In AI session buffers, SPC in Evil normal state triggers the prompt-enter UI
     (with-eval-after-load 'evil (ai-code-backends-infra-evil-setup))
     ;; Optional: Turn on auto-revert buffer, so that the AI code change automatically appears in the buffer
@@ -132,7 +136,7 @@ Enable installation of packages from MELPA by adding an entry to package-archive
   - ai-code-task-use-gptel-filename: When non-nil, file name created by `ai-code-create-or-open-task-file` or `ai-code-create-file-or-dir` will have auto-generated filenames created by GPTel
   - ai-code-notes-use-gptel-headline: When non-nil, notes created by `ai-code-take-notes` will have auto-generated headlines created by GPTel
   - ai-code-use-gptel-headline: When non-nil, prompts sent to the AI will have auto-generated headlines created by GPTel, providing better organization and readability in the prompt file
-  - ai-code-use-gptel-classify-prompt: When no nil, and `ai-code-auto-test-type` is not nil, classify whether the current prompt is about code changes and need to trigger following test
+  - ai-code-use-gptel-classify-prompt: When non-nil, and `ai-code-auto-test-type` or `ai-code-discussion-auto-follow-up-enabled` is non-nil, classify whether the current prompt is about code changes so test prompts or discussion follow-up suggestions are only added when relevant
 - `flycheck`: To enable the `ai-code-flycheck-fix-errors-in-scope` command.
 - `yasnippet`: For snippet support in the prompt file. A library of snippets is included.
   - (emacs built-in) abbrev + skeleton is also a good way to expand prompt. [[./etc/prompt_expand_with_abbrev_skeleton.el][example abbrev to solve / iterate leetcode problem with tdd (need to set ai-code-auto-test-type with tdd)]], [[./examples/leetcode][example problem resolved]]
@@ -161,6 +165,7 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 - *Implementing a TODO*: Write a comment in your code, like `;; TODO: Implement caching for this function`. Place your cursor on that line and press `C-c a`, then `i` (`ai-code-implement-todo`). The AI will generate the implementation based on the comment.
   - Relevant packages for TODO: [[https://github.com/tarsius/hl-todo][hl-todo]], [[https://github.com/alphapapa/magit-todos][magit-todos]]
 - *Asking a Question*: Place your cursor within a function, press `C-c a`, then `q` (`ai-code-ask-question`), type your question, and press Enter. The question, along with context, will be sent to the AI.
+- *Discussion follow-up suggestions*: Customize `ai-code-discussion-auto-follow-up-enabled` to non-nil, or set `(setq ai-code-discussion-auto-follow-up-enabled t)`. Then ask a question with `C-c a q` or use `C-c a <SPC>` for a design discussion. When enabled, AI Code asks at send time whether to append 2-3 numbered next-step suggestions, and the transient toggle on `C-c a F` lets you turn the feature on or off from the menu.
 - *Refactoring a Function*: With the cursor in a function, press `C-c a`, then `r` (`ai-code-refactor-book-method`). Select a refactoring technique from the list, provide any required input (e.g., a new method name), and the prompt will be generated.
 - *Automatically run tests after change*: When ai-code-auto-test-type is non-nil, AI will automatically run tests after code changes and follow up on results.
 - *One-prompt TDD with refactoring*: Press `C-c a`, then `t` (`ai-code-tdd-cycle`) and choose `5. Red + Green + Blue (One prompt)` to generate tests, implement code, run tests, and then refactor the changed code in one flow.
@@ -293,11 +298,14 @@ To expose your own Emacs function as a tool, use =ai-code-mcp-make-tool=.
 
 *** Harness Engineering Practice
 
-Harness engineering is about building a reliable loop around the model, so the AI does not stop at /make a change/ but continues into /verify the change and react to the result/. In this package, the clearest example is the auto test loop.
+Harness engineering is about building a reliable loop around the model, so the AI does not stop at /make a change/ but continues into /verify the change and react to the result/. In this package, the clearest examples are the auto test loop for code changes and the optional next-step loop for discussion prompts.
 
-Instead of manually telling the AI what to do after every edit, you can make test follow-up part of the workflow:
+Instead of manually telling the AI what to do after every code change or discussion turn, you can make follow-up part of the workflow:
 
 - `ai-code-auto-test-type`: choose how code-change prompts should continue after the edit. You can ask the AI to run tests after the change, use TDD Red+Green, use Red+Green+Blue with refactoring, turn it off, or decide case by case with `ask-me`.
+- `ai-code-discussion-auto-follow-up-enabled`: when non-nil, discussion-style prompts can offer a send-time choice to append 2-3 numbered candidate next steps. You can customize this variable directly or toggle it from the transient menu with `C-c a F`.
+- `ai-code-next-step-suggestion-suffix`: customize the exact instruction appended for those numbered next-step suggestions.
+- `ai-code-use-gptel-classify-prompt`: when paired with the settings above, GPTel can classify prompts so code-change prompts skip discussion follow-up suggestions and discussion prompts skip test follow-up.
 - `ai-code-tdd-cycle`: run a guided TDD flow from the menu, including separate Red, Green, Blue stages or the combined one-prompt flows.
 - `ai-code-build-or-test-project`: run build/test explicitly from `C-c a b` when you want a direct verification step in the middle of the loop.
 - `ai-code-prompt-suffix`: add persistent project rules when needed, so repeated instructions such as response language, coding constraints, or test expectations do not have to be retyped in every prompt.
@@ -321,7 +329,7 @@ The benefit is practical:
 - more consistent AI behavior because verification is part of the workflow
 - easier to let the AI continue with the next step after a failed or passing test
 
-This is why features such as `ai-code-auto-test-type` and `ai-code-tdd-cycle` fit the idea of harness engineering: they turn testing and follow-up into part of the system, not an afterthought in each prompt.
+This is why features such as `ai-code-auto-test-type`, `ai-code-discussion-auto-follow-up-enabled`, and `ai-code-tdd-cycle` fit the idea of harness engineering: they turn testing and follow-up into part of the system, not an afterthought in each prompt.
 
 Nit: During using auto test feature, I prefer to turn off the approval request from AI, it will make the whole process more smooth. Eg. for Codex CLI, it is
 

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -188,6 +188,7 @@ that should be recorded in the prompt history file."
                                          ai-code-discussion-auto-follow-up-suffix))))
          (suffix (when (and ai-code-use-prompt-suffix suffix-parts)
                    (mapconcat #'identity suffix-parts "\n")))
+         ;; Keep the recorded prompt aligned with the exact suffixes sent to AI.
          (stored-prompt (if suffix
                             (concat prompt-text "\n" suffix)
                           prompt-text))

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -17,7 +17,6 @@
 (defvar ai-code-prompt-suffix)
 (defvar ai-code-auto-test-type)
 (defvar ai-code-auto-test-suffix)
-(defvar ai-code-discussion-auto-follow-up-enabled)
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 
@@ -184,8 +183,7 @@ that should be recorded in the prompt history file."
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
                                          ai-code-auto-test-suffix)
-                                       (when ai-code-discussion-auto-follow-up-enabled
-                                         ai-code-discussion-auto-follow-up-suffix))))
+                                       ai-code-discussion-auto-follow-up-suffix)))
          (suffix (when (and ai-code-use-prompt-suffix suffix-parts)
                    (mapconcat #'identity suffix-parts "\n")))
          (stored-prompt (if suffix

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -17,6 +17,8 @@
 (defvar ai-code-prompt-suffix)
 (defvar ai-code-auto-test-type)
 (defvar ai-code-auto-test-suffix)
+(defvar ai-code-discussion-auto-follow-up-enabled)
+(defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 
 (declare-function yas-load-directory "yasnippet" (dir))
@@ -181,7 +183,9 @@ Returns the full prompt text with suffix for sending to AI."
   "Write PROMPT-TEXT to the AI prompt file."
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
-                                         ai-code-auto-test-suffix))))
+                                         ai-code-auto-test-suffix)
+                                       (when ai-code-discussion-auto-follow-up-enabled
+                                         ai-code-discussion-auto-follow-up-suffix))))
          (suffix (when (and ai-code-use-prompt-suffix suffix-parts)
                    (mapconcat #'identity suffix-parts "\n")))
          (full-prompt (concat (if suffix
@@ -458,8 +462,8 @@ It trims leading/trailing whitespace."
       (message "No text in the current block to send."))))
 
 (defun ai-code--mark-prompt-block ()
-  "Mark a code block. A code block is defined as multiple lines without empty lines inside,
-but with empty lines before and after the block."
+  "Mark the current prompt block.
+A prompt block is multiple non-empty lines surrounded by empty lines."
   (interactive)
   (let ((start (point))
         (end (point)))

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -17,6 +17,7 @@
 (defvar ai-code-prompt-suffix)
 (defvar ai-code-auto-test-type)
 (defvar ai-code-auto-test-suffix)
+(defvar ai-code-discussion-auto-follow-up-enabled)
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 
@@ -183,7 +184,8 @@ that should be recorded in the prompt history file."
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
                                          ai-code-auto-test-suffix)
-                                       ai-code-discussion-auto-follow-up-suffix)))
+                                       (when ai-code-discussion-auto-follow-up-enabled
+                                         ai-code-discussion-auto-follow-up-suffix))))
          (suffix (when (and ai-code-use-prompt-suffix suffix-parts)
                    (mapconcat #'identity suffix-parts "\n")))
          (stored-prompt (if suffix

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -164,15 +164,15 @@ Only works when gptel package is installed, otherwise shows error message."
     (insert (format ":AGENT: %s\n" label))
     (insert ":END:\n")))
 
-(defun ai-code--append-prompt-to-buffer (prompt-text)
-  "Append formatted PROMPT-TEXT to the end of the current buffer.
-This includes generating a headline and formatting the prompt.
-Returns the full prompt text with suffix for sending to AI."
+(defun ai-code--append-prompt-to-buffer (stored-prompt-text)
+  "Append formatted STORED-PROMPT-TEXT to the end of the current buffer.
+This includes generating a headline and formatting the prompt text
+that should be recorded in the prompt history file."
   (goto-char (point-max))
   (insert "\n\n")
-  (ai-code--generate-prompt-headline prompt-text)
+  (ai-code--generate-prompt-headline stored-prompt-text)
   (ai-code--insert-backend-label-drawer)
-  (ai-code--format-and-insert-prompt prompt-text))
+  (ai-code--format-and-insert-prompt stored-prompt-text))
 
 (defun ai-code--send-prompt (full-prompt)
   "Send FULL-PROMPT to AI."
@@ -188,6 +188,9 @@ Returns the full prompt text with suffix for sending to AI."
                                          ai-code-discussion-auto-follow-up-suffix))))
          (suffix (when (and ai-code-use-prompt-suffix suffix-parts)
                    (mapconcat #'identity suffix-parts "\n")))
+         (stored-prompt (if suffix
+                            (concat prompt-text "\n" suffix)
+                          prompt-text))
          (full-prompt (concat (if suffix
                                   (concat prompt-text "\n" suffix)
                                 prompt-text) "\n"))
@@ -196,7 +199,7 @@ Returns the full prompt text with suffix for sending to AI."
     (if prompt-file
       (let ((buffer (ai-code--get-prompt-buffer prompt-file)))
         (with-current-buffer buffer
-          (ai-code--append-prompt-to-buffer prompt-text)
+          (ai-code--append-prompt-to-buffer stored-prompt)
           (save-buffer)
           (message "Prompt added to %s" prompt-file))
         (let ((default-directory original-default-directory))

--- a/ai-code.el
+++ b/ai-code.el
@@ -58,6 +58,8 @@
 ;;   ;; (ai-code-prompt-filepath-completion-mode -1)
 ;;   ;; Optional: Configure AI test prompting mode (e.g., ask about running tests/TDD) for a tighter build-test loop
 ;;   (setq ai-code-auto-test-type 'ask-me)
+;;   ;; Optional: Offer numbered next steps for discussion prompts at send time
+;;   ;; (setq ai-code-discussion-auto-follow-up-enabled t)
 ;;   ;; Optional: In the AI session buffer (Evil normal state), SPC triggers the prompt entry UI
 ;;   (with-eval-after-load 'evil (ai-code-backends-infra-evil-setup))
 ;;   (global-auto-revert-mode 1)
@@ -220,10 +222,12 @@ See the later `defcustom' for user-facing documentation and default.")
 
 ;;;###autoload
 (defcustom ai-code-use-gptel-classify-prompt nil
-  "Whether to use GPTel to classify prompts in `ask-me` auto test mode.
-When non-nil and `ai-code-auto-test-type` is not nil, classify whether
-the current prompt is about code changes.  If not, skip test type selection
-and do not append auto test suffix."
+  "Whether to use GPTel to classify prompts before send-time suffix routing.
+When non-nil and `ai-code-auto-test-type` or
+`ai-code-discussion-auto-follow-up-enabled` is non-nil, classify whether
+the current prompt is about code changes.  This lets code-change prompts
+skip discussion follow-up suggestions, and discussion prompts skip auto
+test suffixes."
   :type 'boolean
   :group 'ai-code)
 
@@ -354,7 +358,10 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   :group 'ai-code)
 
 (defcustom ai-code-discussion-auto-follow-up-enabled nil
-  "When non-nil, discussion prompts may request numbered next-step suggestions."
+  "When non-nil, prompts may request numbered next-step suggestions.
+Customize this to non-nil to turn on the send-time choice globally.
+Pair it with `ai-code-use-gptel-classify-prompt` when you want
+code-change prompts to skip these discussion follow-up suggestions."
   :type 'boolean
   :set (lambda (symbol value)
          (set-default symbol value)

--- a/ai-code.el
+++ b/ai-code.el
@@ -172,6 +172,10 @@ See the later `defcustom' for user-facing documentation and default.")
 (defvar ai-code-discussion-auto-follow-up-suffix nil
   "Send-time prompt suffix that requests numbered next-step suggestions.")
 
+(defvar ai-code-discussion-auto-follow-up-enabled nil
+  "Forward declaration for `ai-code-discussion-auto-follow-up-enabled'.
+See the later `defcustom' for user-facing documentation and default.")
+
 (defconst ai-code--auto-test-type-ask-choices
   '(("Run tests after code change" . test-after-change)
     ("TDD Red + Green (write failing test, then make it pass)" . tdd)
@@ -284,7 +288,8 @@ CLASSIFICATION is the optional GPTel prompt classification result."
 (defun ai-code--resolve-auto-follow-up-suffix-for-send (&optional prompt-text classification)
   "Resolve next-step suggestion suffix for current send action for PROMPT-TEXT.
 CLASSIFICATION is the optional GPTel prompt classification result."
-  (when ai-code-next-step-suggestion-suffix
+  (when (and ai-code-discussion-auto-follow-up-enabled
+             ai-code-next-step-suggestion-suffix)
     (let ((classification (or classification
                               (and ai-code-use-gptel-classify-prompt
                                    (ai-code--gptel-classify-prompt-code-change prompt-text)))))
@@ -303,7 +308,7 @@ CLASSIFICATION is the optional GPTel prompt classification result."
 Send-time routing uses this result for test and discussion follow-up suffixes."
   (when (and ai-code-use-gptel-classify-prompt
              (or ai-code-auto-test-type
-                 ai-code-next-step-suggestion-suffix))
+                 ai-code-discussion-auto-follow-up-enabled))
     (ai-code--gptel-classify-prompt-code-change prompt-text)))
 
 (defun ai-code--with-auto-test-suffix-for-send (orig-fun prompt-text)
@@ -336,12 +341,26 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   (ai-code--test-after-code-change--set 'ai-code-auto-test-type value)
   value)
 
+(defun ai-code--apply-discussion-auto-follow-up-enabled (value)
+  "Set `ai-code-discussion-auto-follow-up-enabled` to VALUE."
+  (setq ai-code-discussion-auto-follow-up-enabled value)
+  value)
+
 (defcustom ai-code-auto-test-type nil
   "Select how prompts request tests after code changes."
   :type '(choice (const :tag "Ask every time" ask-me)
                  (const :tag "Off" nil))
   :set #'ai-code--test-after-code-change--set
   :group 'ai-code)
+
+(defcustom ai-code-discussion-auto-follow-up-enabled nil
+  "When non-nil, discussion prompts may request numbered next-step suggestions."
+  :type 'boolean
+  :set (lambda (symbol value)
+         (set-default symbol value)
+         (set symbol value))
+  :group 'ai-code)
+
 
 ;;;###autoload
 (defcustom ai-code-cli "claude"
@@ -456,6 +475,21 @@ Otherwise switch to AI CLI buffer."
                            (or ai-code-auto-test-suffix "cleared")))
                 value))))
 
+(defclass ai-code--discussion-auto-follow-up-enabled-type (transient-lisp-variable)
+  ((variable :initform 'ai-code-discussion-auto-follow-up-enabled)
+   (format :initform "%k %d %v")
+   (reader :initform #'transient-lisp-variable--read-value))
+  "Selection helper for `ai-code-discussion-auto-follow-up-enabled`.")
+
+(transient-define-infix ai-code--infix-toggle-auto-follow-up ()
+  "Toggle `ai-code-discussion-auto-follow-up-enabled`."
+  :class 'ai-code--discussion-auto-follow-up-enabled-type
+  :key "F"
+  :description "Discussion follow-up:"
+  :reader (lambda (_prompt _initial-input _history)
+            (ai-code--apply-discussion-auto-follow-up-enabled
+             (not ai-code-discussion-auto-follow-up-enabled))))
+
 (defun ai-code--select-backend-description (&rest _)
   "Dynamic description for the Select Backend menu item.
 Shows the current backend label to the right."
@@ -496,6 +530,7 @@ Shows the current backend label to the right."
   (":" "Speech to text input" ai-code-speech-to-text-input))
 
 (transient-define-group ai-code--menu-other-tools
+  (ai-code--infix-toggle-auto-follow-up)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("e" "Debug exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)

--- a/ai-code.el
+++ b/ai-code.el
@@ -169,6 +169,13 @@ with a newline separator."
   "Forward declaration for `ai-code-auto-test-type'.
 See the later `defcustom' for user-facing documentation and default.")
 
+(defvar ai-code-discussion-auto-follow-up-suffix nil
+  "Send-time prompt suffix that requests numbered next-step suggestions.")
+
+(defvar ai-code-discussion-auto-follow-up-enabled nil
+  "Forward declaration for `ai-code-discussion-auto-follow-up-enabled'.
+See the later `defcustom' for user-facing documentation and default.")
+
 (defconst ai-code--auto-test-type-ask-choices
   '(("Run tests after code change" . test-after-change)
     ("TDD Red + Green (write failing test, then make it pass)" . tdd)
@@ -180,6 +187,11 @@ See the later `defcustom' for user-facing documentation and default.")
   '(("Ask every time" . ask-me)
     ("Off" . nil))
   "Persistent choices for `ai-code-auto-test-type`.")
+
+(defconst ai-code--auto-follow-up-type-ask-choices
+  '(("Suggest next steps" . t)
+    ("No next-step suggestions" . nil))
+  "Resolve next-step suggestion choices for `ask-me` mode.")
 
 (defconst ai-code--auto-test-type-legacy-persistent-modes
   '(test-after-change tdd tdd-with-refactoring)
@@ -196,6 +208,16 @@ See the later `defcustom' for user-facing documentation and default.")
         (cdr choice-cell)
       'test-after-change)))
 
+(defun ai-code--read-auto-follow-up-choice ()
+  "Read whether to request numbered next-step suggestions for this send action."
+  (let* ((choice (completing-read "Discussion follow-up suggestions: "
+                                  (mapcar #'car ai-code--auto-follow-up-type-ask-choices)
+                                  nil t nil nil
+                                  (caar ai-code--auto-follow-up-type-ask-choices)))
+         (choice-cell (assoc choice ai-code--auto-follow-up-type-ask-choices)))
+    (and choice-cell
+         (cdr choice-cell))))
+
 ;;;###autoload
 (defcustom ai-code-use-gptel-classify-prompt nil
   "Whether to use GPTel to classify prompts in `ask-me` auto test mode.
@@ -203,6 +225,20 @@ When non-nil and `ai-code-auto-test-type` is not nil, classify whether
 the current prompt is about code changes.  If not, skip test type selection
 and do not append auto test suffix."
   :type 'boolean
+  :group 'ai-code)
+
+;;;###autoload
+(defcustom ai-code-next-step-suggestion-suffix
+  (concat
+   "At the end of your response, provide 2-3 numbered candidate next\n"
+   "steps. Keep each option to one sentence. Mark the single best option\n"
+   "with \"(Recommended)\". If the user replies with only a number such\n"
+   "as 1, 2, or 3, treat that as selecting the corresponding next step\n"
+   "from your previous answer. The user may also ignore these options\n"
+   "and send a different follow-up request instead. Do not suggest code\n"
+   "changes unless they are clearly warranted by the discussion.")
+  "Prompt suffix for numbered next-step suggestions in discussion prompts."
+  :type '(choice (const nil) string)
   :group 'ai-code)
 
 (defun ai-code--gptel-classify-prompt-code-change (prompt-text)
@@ -229,31 +265,68 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
     (message "GPTel prompt classification result: %s" classification)
     classification))
 
-(defun ai-code--resolve-auto-test-type-for-send (&optional prompt-text)
-  "Resolve the concrete auto test type for current send action for PROMPT-TEXT."
+(defun ai-code--resolve-auto-test-type-for-send (&optional prompt-text classification)
+  "Resolve the concrete auto test type for current send action for PROMPT-TEXT.
+CLASSIFICATION is the optional GPTel prompt classification result."
   (if (eq ai-code-auto-test-type 'ask-me)
-      (ai-code--resolve-ask-auto-test-type-for-send prompt-text)
+      (ai-code--resolve-ask-auto-test-type-for-send prompt-text classification)
     (and (memq ai-code-auto-test-type
                ai-code--auto-test-type-legacy-persistent-modes)
          ai-code-auto-test-type)))
 
-(defun ai-code--resolve-ask-auto-test-type-for-send (&optional prompt-text)
-  "Resolve the send-time auto test type for ask-me mode with PROMPT-TEXT."
+(defun ai-code--resolve-ask-auto-test-type-for-send (&optional prompt-text classification)
+  "Resolve the send-time auto test type for ask-me mode with PROMPT-TEXT.
+CLASSIFICATION is the optional GPTel prompt classification result."
   (if ai-code-use-gptel-classify-prompt
-      (pcase (ai-code--gptel-classify-prompt-code-change prompt-text)
+      (pcase (or classification
+                 (ai-code--gptel-classify-prompt-code-change prompt-text))
         ('code-change (ai-code--read-auto-test-type-choice))
         ('non-code-change nil)
         (_ (ai-code--read-auto-test-type-choice)))
     (ai-code--read-auto-test-type-choice)))
 
-(defun ai-code--resolve-auto-test-suffix-for-send (&optional prompt-text)
-  "Resolve auto test suffix for current send action for PROMPT-TEXT."
+(defun ai-code--discussion-follow-up-command-p (&optional command)
+  "Return non-nil when COMMAND should offer discussion next-step suggestions."
+  (memq (or command this-command)
+        '(ai-code-ask-question ai-code-explain)))
+
+(defun ai-code--resolve-auto-follow-up-suffix-for-send (&optional prompt-text classification)
+  "Resolve next-step suggestion suffix for current send action for PROMPT-TEXT.
+CLASSIFICATION is the optional GPTel prompt classification result."
+  (when (and ai-code-discussion-auto-follow-up-enabled
+             (ai-code--discussion-follow-up-command-p)
+             ai-code-next-step-suggestion-suffix)
+    (let ((classification (or classification
+                              (and ai-code-use-gptel-classify-prompt
+                                   (ai-code--gptel-classify-prompt-code-change prompt-text)))))
+      (unless (eq classification 'code-change)
+        (and (ai-code--read-auto-follow-up-choice)
+             ai-code-next-step-suggestion-suffix)))))
+
+(defun ai-code--resolve-auto-test-suffix-for-send (&optional prompt-text classification)
+  "Resolve auto test suffix for current send action for PROMPT-TEXT.
+CLASSIFICATION is the optional GPTel prompt classification result."
   (ai-code--auto-test-suffix-for-type
-   (ai-code--resolve-auto-test-type-for-send prompt-text)))
+   (ai-code--resolve-auto-test-type-for-send prompt-text classification)))
+
+(defun ai-code--classify-prompt-for-send (&optional prompt-text)
+  "Return GPTel prompt classification for PROMPT-TEXT when needed.
+Send-time routing uses this result for test and discussion follow-up suffixes."
+  (when (and ai-code-use-gptel-classify-prompt
+             (or ai-code-auto-test-type
+                 (and ai-code-discussion-auto-follow-up-enabled
+                      (ai-code--discussion-follow-up-command-p))))
+    (ai-code--gptel-classify-prompt-code-change prompt-text)))
 
 (defun ai-code--with-auto-test-suffix-for-send (orig-fun prompt-text)
-  "Resolve and bind auto test suffix before calling ORIG-FUN with PROMPT-TEXT."
-  (let ((ai-code-auto-test-suffix (ai-code--resolve-auto-test-suffix-for-send prompt-text)))
+  "Resolve and bind send-time suffixes before calling ORIG-FUN with PROMPT-TEXT."
+  (let* ((classification (ai-code--classify-prompt-for-send prompt-text))
+         (ai-code-auto-test-suffix
+          (ai-code--resolve-auto-test-suffix-for-send
+           prompt-text classification))
+         (ai-code-discussion-auto-follow-up-suffix
+          (ai-code--resolve-auto-follow-up-suffix-for-send
+           prompt-text classification)))
     (funcall orig-fun prompt-text)))
 
 (unless (advice-member-p #'ai-code--with-auto-test-suffix-for-send
@@ -275,11 +348,24 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
   (ai-code--test-after-code-change--set 'ai-code-auto-test-type value)
   value)
 
+(defun ai-code--apply-discussion-auto-follow-up-enabled (value)
+  "Set `ai-code-discussion-auto-follow-up-enabled` to VALUE."
+  (setq ai-code-discussion-auto-follow-up-enabled value)
+  value)
+
 (defcustom ai-code-auto-test-type nil
   "Select how prompts request tests after code changes."
   :type '(choice (const :tag "Ask every time" ask-me)
                  (const :tag "Off" nil))
   :set #'ai-code--test-after-code-change--set
+  :group 'ai-code)
+
+(defcustom ai-code-discussion-auto-follow-up-enabled nil
+  "When non-nil, discussion prompts may request numbered next-step suggestions."
+  :type 'boolean
+  :set (lambda (symbol value)
+         (set-default symbol value)
+         (set symbol value))
   :group 'ai-code)
 
 
@@ -396,6 +482,21 @@ Otherwise switch to AI CLI buffer."
                            (or ai-code-auto-test-suffix "cleared")))
                 value))))
 
+(defclass ai-code--discussion-auto-follow-up-enabled-type (transient-lisp-variable)
+  ((variable :initform 'ai-code-discussion-auto-follow-up-enabled)
+   (format :initform "%k %d %v")
+   (reader :initform #'transient-lisp-variable--read-value))
+  "Selection helper for `ai-code-discussion-auto-follow-up-enabled`.")
+
+(transient-define-infix ai-code--infix-toggle-auto-follow-up ()
+  "Toggle `ai-code-discussion-auto-follow-up-enabled`."
+  :class 'ai-code--discussion-auto-follow-up-enabled-type
+  :key "F"
+  :description "Discussion follow-up:"
+  :reader (lambda (_prompt _initial-input _history)
+            (ai-code--apply-discussion-auto-follow-up-enabled
+             (not ai-code-discussion-auto-follow-up-enabled))))
+
 (defun ai-code--select-backend-description (&rest _)
   "Dynamic description for the Select Backend menu item.
 Shows the current backend label to the right."
@@ -432,19 +533,20 @@ Shows the current backend label to the right."
   ("!" "Run Current File or Command" ai-code-run-current-file-or-shell-cmd)
   ("b" "Build/Test/Lint (AI follow-up)" ai-code-build-or-test-project)
   ("K" "Create or open task file" ai-code-create-or-open-task-file)
-  ("n" "Take notes from AI session region" ai-code-take-notes))
+  ("n" "Take notes from AI session region" ai-code-take-notes)
+  (":" "Speech to text input" ai-code-speech-to-text-input))
 
 (transient-define-group ai-code--menu-other-tools
+  (ai-code--infix-toggle-auto-follow-up)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("e" "Debug exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)
-  ("h" "Help / Quick Start" ai-code-onboarding-open-quickstart)
   ("k" "Copy Cur File Name (C-u: full)" ai-code-copy-buffer-file-name-to-clipboard)
   ("o" "Open recent file (C-u: insert)" ai-code-git-repo-recent-modified-files)
   ("p" "Open prompt history file" ai-code-open-prompt-file)
   ("m" "Debug python MCP server" ai-code-debug-mcp)
-  (":" "Speech to text input" ai-code-speech-to-text-input)
-  ("N" "Toggle notifications" ai-code-notifications-toggle))
+  ("N" "Toggle notifications" ai-code-notifications-toggle)
+  ("h" "Help / Quick Start" ai-code-onboarding-open-quickstart))
 
 (transient-define-prefix ai-code-menu-default ()
   "Default transient menu for AI Code Interface interactive functions."

--- a/ai-code.el
+++ b/ai-code.el
@@ -172,10 +172,6 @@ See the later `defcustom' for user-facing documentation and default.")
 (defvar ai-code-discussion-auto-follow-up-suffix nil
   "Send-time prompt suffix that requests numbered next-step suggestions.")
 
-(defvar ai-code-discussion-auto-follow-up-enabled nil
-  "Forward declaration for `ai-code-discussion-auto-follow-up-enabled'.
-See the later `defcustom' for user-facing documentation and default.")
-
 (defconst ai-code--auto-test-type-ask-choices
   '(("Run tests after code change" . test-after-change)
     ("TDD Red + Green (write failing test, then make it pass)" . tdd)
@@ -288,8 +284,7 @@ CLASSIFICATION is the optional GPTel prompt classification result."
 (defun ai-code--resolve-auto-follow-up-suffix-for-send (&optional prompt-text classification)
   "Resolve next-step suggestion suffix for current send action for PROMPT-TEXT.
 CLASSIFICATION is the optional GPTel prompt classification result."
-  (when (and ai-code-discussion-auto-follow-up-enabled
-             ai-code-next-step-suggestion-suffix)
+  (when ai-code-next-step-suggestion-suffix
     (let ((classification (or classification
                               (and ai-code-use-gptel-classify-prompt
                                    (ai-code--gptel-classify-prompt-code-change prompt-text)))))
@@ -308,7 +303,7 @@ CLASSIFICATION is the optional GPTel prompt classification result."
 Send-time routing uses this result for test and discussion follow-up suffixes."
   (when (and ai-code-use-gptel-classify-prompt
              (or ai-code-auto-test-type
-                 ai-code-discussion-auto-follow-up-enabled))
+                 ai-code-next-step-suggestion-suffix))
     (ai-code--gptel-classify-prompt-code-change prompt-text)))
 
 (defun ai-code--with-auto-test-suffix-for-send (orig-fun prompt-text)
@@ -341,26 +336,12 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   (ai-code--test-after-code-change--set 'ai-code-auto-test-type value)
   value)
 
-(defun ai-code--apply-discussion-auto-follow-up-enabled (value)
-  "Set `ai-code-discussion-auto-follow-up-enabled` to VALUE."
-  (setq ai-code-discussion-auto-follow-up-enabled value)
-  value)
-
 (defcustom ai-code-auto-test-type nil
   "Select how prompts request tests after code changes."
   :type '(choice (const :tag "Ask every time" ask-me)
                  (const :tag "Off" nil))
   :set #'ai-code--test-after-code-change--set
   :group 'ai-code)
-
-(defcustom ai-code-discussion-auto-follow-up-enabled nil
-  "When non-nil, discussion prompts may request numbered next-step suggestions."
-  :type 'boolean
-  :set (lambda (symbol value)
-         (set-default symbol value)
-         (set symbol value))
-  :group 'ai-code)
-
 
 ;;;###autoload
 (defcustom ai-code-cli "claude"
@@ -475,21 +456,6 @@ Otherwise switch to AI CLI buffer."
                            (or ai-code-auto-test-suffix "cleared")))
                 value))))
 
-(defclass ai-code--discussion-auto-follow-up-enabled-type (transient-lisp-variable)
-  ((variable :initform 'ai-code-discussion-auto-follow-up-enabled)
-   (format :initform "%k %d %v")
-   (reader :initform #'transient-lisp-variable--read-value))
-  "Selection helper for `ai-code-discussion-auto-follow-up-enabled`.")
-
-(transient-define-infix ai-code--infix-toggle-auto-follow-up ()
-  "Toggle `ai-code-discussion-auto-follow-up-enabled`."
-  :class 'ai-code--discussion-auto-follow-up-enabled-type
-  :key "F"
-  :description "Discussion follow-up:"
-  :reader (lambda (_prompt _initial-input _history)
-            (ai-code--apply-discussion-auto-follow-up-enabled
-             (not ai-code-discussion-auto-follow-up-enabled))))
-
 (defun ai-code--select-backend-description (&rest _)
   "Dynamic description for the Select Backend menu item.
 Shows the current backend label to the right."
@@ -530,7 +496,6 @@ Shows the current backend label to the right."
   (":" "Speech to text input" ai-code-speech-to-text-input))
 
 (transient-define-group ai-code--menu-other-tools
-  (ai-code--infix-toggle-auto-follow-up)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("e" "Debug exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)

--- a/ai-code.el
+++ b/ai-code.el
@@ -285,16 +285,10 @@ CLASSIFICATION is the optional GPTel prompt classification result."
         (_ (ai-code--read-auto-test-type-choice)))
     (ai-code--read-auto-test-type-choice)))
 
-(defun ai-code--discussion-follow-up-command-p (&optional command)
-  "Return non-nil when COMMAND should offer discussion next-step suggestions."
-  (memq (or command this-command)
-        '(ai-code-ask-question ai-code-explain)))
-
 (defun ai-code--resolve-auto-follow-up-suffix-for-send (&optional prompt-text classification)
   "Resolve next-step suggestion suffix for current send action for PROMPT-TEXT.
 CLASSIFICATION is the optional GPTel prompt classification result."
   (when (and ai-code-discussion-auto-follow-up-enabled
-             (ai-code--discussion-follow-up-command-p)
              ai-code-next-step-suggestion-suffix)
     (let ((classification (or classification
                               (and ai-code-use-gptel-classify-prompt
@@ -314,8 +308,7 @@ CLASSIFICATION is the optional GPTel prompt classification result."
 Send-time routing uses this result for test and discussion follow-up suffixes."
   (when (and ai-code-use-gptel-classify-prompt
              (or ai-code-auto-test-type
-                 (and ai-code-discussion-auto-follow-up-enabled
-                      (ai-code--discussion-follow-up-command-p))))
+                 ai-code-discussion-auto-follow-up-enabled))
     (ai-code--gptel-classify-prompt-code-change prompt-text)))
 
 (defun ai-code--with-auto-test-suffix-for-send (orig-fun prompt-text)

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -189,6 +189,85 @@
                (lambda (&rest _args) "TDD Red + Green + Blue (refactor after Green)")))
       (should (eq 'tdd-with-refactoring (ai-code--read-auto-test-type-choice))))))
 
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-off ()
+  "Test that off mode never resolves a discussion follow-up suffix."
+  (let ((ai-code-discussion-auto-follow-up-enabled nil)
+        (this-command 'ai-code-ask-question))
+    (should-not (ai-code--resolve-auto-follow-up-suffix-for-send "Explain this function"))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-non-code-change ()
+  "Test that ask-me mode can append next-step suggestions for discussion prompts."
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
+        (this-command 'ai-code-ask-question))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'non-code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t)))
+      (should (string-match-p
+               "2-3 numbered candidate next[[:space:]\n]+steps"
+               (ai-code--resolve-auto-follow-up-suffix-for-send
+                "Explain this function"))))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-code-change-skips ()
+  "Test that ask-me mode does not offer next-step suggestions for code-change prompts."
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
+        (this-command 'ai-code-ask-question)
+        (asked nil))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda ()
+                 (setq asked t)
+                 t)))
+      (should-not
+       (ai-code--resolve-auto-follow-up-suffix-for-send
+        "Please update the code"))
+      (should-not asked))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-enabled-is-limited-to-discussion-commands ()
+  "Test that the feature only affects question and explain commands."
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'non-code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t)))
+      (let ((this-command 'ai-code-ask-question))
+        (should (string-match-p
+                 "The user may also ignore these options"
+                 (ai-code--resolve-auto-follow-up-suffix-for-send
+                  "Explain this function"))))
+      (let ((this-command 'ai-code-send-command))
+        (should-not
+         (ai-code--resolve-auto-follow-up-suffix-for-send
+          "Explain this function"))))))
+
+(ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-discussion-prompts ()
+  "Test that discussion prompts can append next-step suggestions."
+  (let ((sent-command nil)
+        (ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
+        (ai-code-use-prompt-suffix t)
+        (ai-code-prompt-suffix "BASE SUFFIX")
+        (this-command 'ai-code-ask-question))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'non-code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t))
+              ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
+               (lambda () nil))
+              ((symbol-function 'ai-code-cli-send-command)
+               (lambda (command) (setq sent-command command)))
+              ((symbol-function 'ai-code-cli-switch-to-buffer)
+               (lambda (&rest _args) nil)))
+      (ai-code--write-prompt-to-file-and-send "Explain this function")
+      (should (string-match-p "BASE SUFFIX" sent-command))
+      (should (string-match-p "2-3 numbered candidate next[[:space:]\n]+steps"
+                              sent-command))
+      (should (string-match-p "If the user replies with only a number" sent-command)))))
+
 (ert-deftest ai-code-test-auto-test-type-ask-choices-use-explicit-red-green-blue-labels ()
   "Test that default ask choices use explicit staged TDD labels."
   (should (assoc "TDD Red + Green (write failing test, then make it pass)"
@@ -213,6 +292,13 @@
   (should (equal '(("Ask every time" . ask-me)
                    ("Off" . nil))
                  ai-code--auto-test-type-persistent-choices)))
+
+(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-custom-option-is-boolean ()
+  "Test that discussion auto follow-up setting is a boolean toggle."
+  (should
+   (equal
+    'boolean
+    (get 'ai-code-discussion-auto-follow-up-enabled 'custom-type))))
 
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-tdd-with-refactoring ()
   "Test that ask-me resolves to the repo-local TDD harness reference."

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -226,8 +226,8 @@
         "Please update the code"))
       (should-not asked))))
 
-(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-enabled-is-limited-to-discussion-commands ()
-  "Test that the feature only affects question and explain commands."
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-enabled-for-any-non-code-change-prompt ()
+  "Test that the feature affects any prompt classified as non-code-change."
   (let ((ai-code-discussion-auto-follow-up-enabled t)
         (ai-code-use-gptel-classify-prompt t))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
@@ -240,9 +240,10 @@
                  (ai-code--resolve-auto-follow-up-suffix-for-send
                   "Explain this function"))))
       (let ((this-command 'ai-code-send-command))
-        (should-not
-         (ai-code--resolve-auto-follow-up-suffix-for-send
-          "Explain this function"))))))
+        (should (string-match-p
+                 "The user may also ignore these options"
+                 (ai-code--resolve-auto-follow-up-suffix-for-send
+                  "Summarize this design")))))))
 
 (ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-discussion-prompts ()
   "Test that discussion prompts can append next-step suggestions."
@@ -267,6 +268,57 @@
       (should (string-match-p "2-3 numbered candidate next[[:space:]\n]+steps"
                               sent-command))
       (should (string-match-p "If the user replies with only a number" sent-command)))))
+
+(ert-deftest ai-code-test-write-prompt-records-follow-up-suffix-in-prompt-file ()
+  "Test that discussion follow-up suffix is also recorded in the prompt file."
+  (let* ((temp-dir (make-temp-file "ai-code-prompt-" t))
+         (prompt-file (expand-file-name ".ai.code.prompt.org" temp-dir))
+         (ai-code-discussion-auto-follow-up-enabled t)
+         (ai-code-use-gptel-classify-prompt t)
+         (ai-code-use-prompt-suffix t)
+         (ai-code-prompt-suffix "BASE SUFFIX")
+         (this-command 'ai-code-ask-question))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+                   (lambda (_prompt-text) 'non-code-change))
+                  ((symbol-function 'ai-code--read-auto-follow-up-choice)
+                   (lambda () t))
+                  ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
+                   (lambda () prompt-file))
+                  ((symbol-function 'ai-code-cli-send-command)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ai-code-cli-switch-to-buffer)
+                   (lambda (&rest _args) nil)))
+          (ai-code--write-prompt-to-file-and-send "Explain this function")
+          (with-temp-buffer
+            (insert-file-contents prompt-file)
+            (let ((contents (buffer-string)))
+              (should (string-match-p "Explain this function" contents))
+              (should (string-match-p "BASE SUFFIX" contents))
+              (should (string-match-p "2-3 numbered candidate next[[:space:]\n]+steps"
+                                      contents)))))
+      (delete-directory temp-dir t))))
+
+(ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-send-command-non-code-change ()
+  "Test that send-command also gets next-step suggestions when classified non-code-change."
+  (let ((sent-command nil)
+        (ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
+        (ai-code-use-prompt-suffix t)
+        (this-command 'ai-code-send-command))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'non-code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t))
+              ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
+               (lambda () nil))
+              ((symbol-function 'ai-code-cli-send-command)
+               (lambda (command) (setq sent-command command)))
+              ((symbol-function 'ai-code-cli-switch-to-buffer)
+               (lambda (&rest _args) nil)))
+      (ai-code--write-prompt-to-file-and-send "Summarize this design")
+      (should (string-match-p "2-3 numbered candidate next[[:space:]\n]+steps"
+                              sent-command)))))
 
 (ert-deftest ai-code-test-auto-test-type-ask-choices-use-explicit-red-green-blue-labels ()
   "Test that default ask choices use explicit staged TDD labels."
@@ -439,9 +491,9 @@
     (should (fboundp cmd))
     (should (commandp cmd))))
 
-(ert-deftest ai-code-test-menu-other-tools-includes-speech-to-text-input ()
-  "Test that Other Tools menu exposes speech-to-text input."
-  (let ((suffix (transient-get-suffix 'ai-code--menu-other-tools ":")))
+(ert-deftest ai-code-test-menu-agile-development-includes-speech-to-text-input ()
+  "Test that Agile Development menu exposes speech-to-text input."
+  (let ((suffix (transient-get-suffix 'ai-code--menu-agile-development ":")))
     (should suffix)
     (should (eq (plist-get (cdr suffix) :command)
                 'ai-code-speech-to-text-input))

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -189,16 +189,22 @@
                (lambda (&rest _args) "TDD Red + Green + Blue (refactor after Green)")))
       (should (eq 'tdd-with-refactoring (ai-code--read-auto-test-type-choice))))))
 
-(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-off ()
-  "Test that off mode never resolves a discussion follow-up suffix."
-  (let ((ai-code-discussion-auto-follow-up-enabled nil)
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ignores-disabled-setting ()
+  "Test that discussion follow-up suggestions stay enabled."
+  (let ((ai-code-use-gptel-classify-prompt t)
         (this-command 'ai-code-ask-question))
-    (should-not (ai-code--resolve-auto-follow-up-suffix-for-send "Explain this function"))))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text) 'non-code-change))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t)))
+      (should (string-match-p
+               "2-3 numbered candidate next[[:space:]\n]+steps"
+               (ai-code--resolve-auto-follow-up-suffix-for-send
+                "Explain this function"))))))
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-non-code-change ()
   "Test that ask-me mode can append next-step suggestions for discussion prompts."
-  (let ((ai-code-discussion-auto-follow-up-enabled t)
-        (ai-code-use-gptel-classify-prompt t)
+  (let ((ai-code-use-gptel-classify-prompt t)
         (this-command 'ai-code-ask-question))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
@@ -211,8 +217,7 @@
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-code-change-skips ()
   "Test that ask-me mode does not offer next-step suggestions for code-change prompts."
-  (let ((ai-code-discussion-auto-follow-up-enabled t)
-        (ai-code-use-gptel-classify-prompt t)
+  (let ((ai-code-use-gptel-classify-prompt t)
         (this-command 'ai-code-ask-question)
         (asked nil))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
@@ -228,8 +233,7 @@
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-enabled-for-any-non-code-change-prompt ()
   "Test that the feature affects any prompt classified as non-code-change."
-  (let ((ai-code-discussion-auto-follow-up-enabled t)
-        (ai-code-use-gptel-classify-prompt t))
+  (let ((ai-code-use-gptel-classify-prompt t))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
@@ -248,7 +252,6 @@
 (ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-discussion-prompts ()
   "Test that discussion prompts can append next-step suggestions."
   (let ((sent-command nil)
-        (ai-code-discussion-auto-follow-up-enabled t)
         (ai-code-use-gptel-classify-prompt t)
         (ai-code-use-prompt-suffix t)
         (ai-code-prompt-suffix "BASE SUFFIX")
@@ -273,7 +276,6 @@
   "Test that discussion follow-up suffix is also recorded in the prompt file."
   (let* ((temp-dir (make-temp-file "ai-code-prompt-" t))
          (prompt-file (expand-file-name ".ai.code.prompt.org" temp-dir))
-         (ai-code-discussion-auto-follow-up-enabled t)
          (ai-code-use-gptel-classify-prompt t)
          (ai-code-use-prompt-suffix t)
          (ai-code-prompt-suffix "BASE SUFFIX")
@@ -302,7 +304,6 @@
 (ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-send-command-non-code-change ()
   "Test that send-command also gets next-step suggestions when classified non-code-change."
   (let ((sent-command nil)
-        (ai-code-discussion-auto-follow-up-enabled t)
         (ai-code-use-gptel-classify-prompt t)
         (ai-code-use-prompt-suffix t)
         (this-command 'ai-code-send-command))
@@ -345,12 +346,9 @@
                    ("Off" . nil))
                  ai-code--auto-test-type-persistent-choices)))
 
-(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-custom-option-is-boolean ()
-  "Test that discussion auto follow-up setting is a boolean toggle."
-  (should
-   (equal
-    'boolean
-    (get 'ai-code-discussion-auto-follow-up-enabled 'custom-type))))
+(ert-deftest ai-code-test-discussion-auto-follow-up-setting-is-removed ()
+  "Test that the legacy discussion follow-up setting has been removed."
+  (should-not (boundp 'ai-code-discussion-auto-follow-up-enabled)))
 
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-tdd-with-refactoring ()
   "Test that ask-me resolves to the repo-local TDD harness reference."
@@ -389,7 +387,9 @@
         (ai-code-prompt-suffix "BASE SUFFIX")
         (ai-code-auto-test-suffix "SHOULD NOT APPEAR"))
     (cl-letf (((symbol-function 'ai-code--read-auto-test-type-choice)
-               (lambda () 'no-test))
+                (lambda () 'no-test))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () nil))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code-cli-send-command)
@@ -417,6 +417,14 @@
   "Test that the default menu exposes a quickstart entry."
   (should (transient-get-suffix 'ai-code--menu-other-tools
                                 'ai-code-onboarding-open-quickstart)))
+
+(ert-deftest ai-code-test-menu-omits-discussion-auto-follow-up-toggle ()
+  "Test that the Other Tools menu no longer exposes follow-up toggle."
+  (should-not
+   (condition-case nil
+       (transient-get-suffix 'ai-code--menu-other-tools
+                             'ai-code--infix-toggle-auto-follow-up)
+     (error nil))))
 
 (ert-deftest ai-code-test-menu-calls-onboarding-gate-before-opening-transient ()
   "Test that `ai-code-menu' runs the onboarding gate before opening the menu."

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -189,22 +189,16 @@
                (lambda (&rest _args) "TDD Red + Green + Blue (refactor after Green)")))
       (should (eq 'tdd-with-refactoring (ai-code--read-auto-test-type-choice))))))
 
-(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ignores-disabled-setting ()
-  "Test that discussion follow-up suggestions stay enabled."
-  (let ((ai-code-use-gptel-classify-prompt t)
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-off ()
+  "Test that off mode never resolves a discussion follow-up suffix."
+  (let ((ai-code-discussion-auto-follow-up-enabled nil)
         (this-command 'ai-code-ask-question))
-    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
-               (lambda (_prompt-text) 'non-code-change))
-              ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t)))
-      (should (string-match-p
-               "2-3 numbered candidate next[[:space:]\n]+steps"
-               (ai-code--resolve-auto-follow-up-suffix-for-send
-                "Explain this function"))))))
+    (should-not (ai-code--resolve-auto-follow-up-suffix-for-send "Explain this function"))))
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-non-code-change ()
   "Test that ask-me mode can append next-step suggestions for discussion prompts."
-  (let ((ai-code-use-gptel-classify-prompt t)
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
         (this-command 'ai-code-ask-question))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
@@ -217,7 +211,8 @@
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-code-change-skips ()
   "Test that ask-me mode does not offer next-step suggestions for code-change prompts."
-  (let ((ai-code-use-gptel-classify-prompt t)
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t)
         (this-command 'ai-code-ask-question)
         (asked nil))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
@@ -233,7 +228,8 @@
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-enabled-for-any-non-code-change-prompt ()
   "Test that the feature affects any prompt classified as non-code-change."
-  (let ((ai-code-use-gptel-classify-prompt t))
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-use-gptel-classify-prompt t))
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
@@ -252,6 +248,7 @@
 (ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-discussion-prompts ()
   "Test that discussion prompts can append next-step suggestions."
   (let ((sent-command nil)
+        (ai-code-discussion-auto-follow-up-enabled t)
         (ai-code-use-gptel-classify-prompt t)
         (ai-code-use-prompt-suffix t)
         (ai-code-prompt-suffix "BASE SUFFIX")
@@ -276,6 +273,7 @@
   "Test that discussion follow-up suffix is also recorded in the prompt file."
   (let* ((temp-dir (make-temp-file "ai-code-prompt-" t))
          (prompt-file (expand-file-name ".ai.code.prompt.org" temp-dir))
+         (ai-code-discussion-auto-follow-up-enabled t)
          (ai-code-use-gptel-classify-prompt t)
          (ai-code-use-prompt-suffix t)
          (ai-code-prompt-suffix "BASE SUFFIX")
@@ -304,6 +302,7 @@
 (ert-deftest ai-code-test-write-prompt-appends-follow-up-suffix-for-send-command-non-code-change ()
   "Test that send-command also gets next-step suggestions when classified non-code-change."
   (let ((sent-command nil)
+        (ai-code-discussion-auto-follow-up-enabled t)
         (ai-code-use-gptel-classify-prompt t)
         (ai-code-use-prompt-suffix t)
         (this-command 'ai-code-send-command))
@@ -346,9 +345,12 @@
                    ("Off" . nil))
                  ai-code--auto-test-type-persistent-choices)))
 
-(ert-deftest ai-code-test-discussion-auto-follow-up-setting-is-removed ()
-  "Test that the legacy discussion follow-up setting has been removed."
-  (should-not (boundp 'ai-code-discussion-auto-follow-up-enabled)))
+(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-custom-option-is-boolean ()
+  "Test that discussion auto follow-up setting is a boolean toggle."
+  (should
+   (equal
+    'boolean
+    (get 'ai-code-discussion-auto-follow-up-enabled 'custom-type))))
 
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-tdd-with-refactoring ()
   "Test that ask-me resolves to the repo-local TDD harness reference."
@@ -387,9 +389,7 @@
         (ai-code-prompt-suffix "BASE SUFFIX")
         (ai-code-auto-test-suffix "SHOULD NOT APPEAR"))
     (cl-letf (((symbol-function 'ai-code--read-auto-test-type-choice)
-                (lambda () 'no-test))
-              ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () nil))
+               (lambda () 'no-test))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code-cli-send-command)
@@ -417,14 +417,6 @@
   "Test that the default menu exposes a quickstart entry."
   (should (transient-get-suffix 'ai-code--menu-other-tools
                                 'ai-code-onboarding-open-quickstart)))
-
-(ert-deftest ai-code-test-menu-omits-discussion-auto-follow-up-toggle ()
-  "Test that the Other Tools menu no longer exposes follow-up toggle."
-  (should-not
-   (condition-case nil
-       (transient-get-suffix 'ai-code--menu-other-tools
-                             'ai-code--infix-toggle-auto-follow-up)
-     (error nil))))
 
 (ert-deftest ai-code-test-menu-calls-onboarding-gate-before-opening-transient ()
   "Test that `ai-code-menu' runs the onboarding gate before opening the menu."


### PR DESCRIPTION
## Summary

This PR adds discussion follow-up suggestions so prompts classified as non-code-change can end with a small set of numbered next steps instead of leaving the conversation open-ended.

It also closes a visibility gap in the prompt workflow: the follow-up suffix is now recorded in prompt history as well as sent to the backend, so the saved prompt matches what the AI actually receives.

## What changed

- added a discussion-specific toggle, `ai-code-discussion-auto-follow-up-enabled`, and kept backward-compatible aliases for the previous follow-up variable names
- reused the existing GPTel prompt classification flow so any prompt classified as `non-code-change` can get follow-up suggestions, including `ai-code-send-command`
- updated prompt history writing so suffix content is stored in `.ai.code.prompt.org` instead of only being added at send time
- expanded ERT coverage around follow-up suffix resolution, prompt persistence, and non-code-change handling across prompt entry points

## User-visible impact

- discussion-style prompts can ask the AI for 2-3 numbered next steps
- users can continue by replying with `1`, `2`, or `3`, or ignore the suggestions and send a custom follow-up
- prompt history now reflects the full prompt that was actually sent, which makes the feature easier to understand and debug

## Testing

- `emacs -batch -L . -l test/test_00-bootstrap.el -l ert -l test/test_ai-code.el -f ert-run-tests-batch-and-exit`
- `emacs -batch -L . -l test/test_00-bootstrap.el -f batch-byte-compile ai-code.el ai-code-prompt-mode.el test/test_ai-code.el`

## Review status

- No GitHub review comments or review submissions yet on this PR.
