### PR TITLE
[codex] Preserve copy-mode viewport under scrollback trimming

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -263,13 +263,13 @@ The timer is reset only after meaningful output is observed."
   (if (not (bound-and-true-p vterm-copy-mode))
       (funcall render-fn)
     (let ((point-marker (copy-marker (point) t))
-          ;; Use an advancing marker so output inserted at the saved point
-          ;; keeps the restored position aligned with the user's viewport.
+          ;; Use advancing markers so output inserted at saved positions
+          ;; keeps the restored viewport aligned with the same content.
           (window-states
            (mapcar (lambda (window)
                      (list window
-                           (window-start window)
-                           (window-point window)))
+                           (copy-marker (window-start window) t)
+                           (copy-marker (window-point window) t)))
                    (get-buffer-window-list (current-buffer) nil t))))
       (unwind-protect
           ;; Suppress intermediate redisplay until restoring the captured
@@ -277,10 +277,12 @@ The timer is reset only after meaningful output is observed."
           (let ((inhibit-redisplay t))
             (funcall render-fn))
         (dolist (state window-states)
-          (pcase-let ((`(,window ,start ,window-point) state))
+          (pcase-let ((`(,window ,start-marker ,window-point-marker) state))
             (when (window-live-p window)
-              (set-window-start window start t)
-              (set-window-point window window-point))))
+              (set-window-start window start-marker t)
+              (set-window-point window window-point-marker))
+            (set-marker start-marker nil)
+            (set-marker window-point-marker nil)))
         (goto-char point-marker)
         (set-marker point-marker nil)))))
 

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -1208,6 +1208,41 @@
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ai-code-backends-infra-vterm-render-preserving-copy-mode-view-tracks-head-deletions ()
+  "Copy-mode rendering should preserve viewport content after head deletions."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-copy-mode-trim*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode t)
+            (dotimes (line 80)
+              (insert (format "line %02d\n" line)))
+            (cl-labels ((line-at (position)
+                          (save-excursion
+                            (goto-char position)
+                            (buffer-substring-no-properties
+                             (line-beginning-position)
+                             (line-end-position)))))
+              (goto-char (point-min))
+              (forward-line 25)
+              (set-window-start (selected-window) (point))
+              (forward-line 4)
+              (set-window-point (selected-window) (point))
+              (let ((original-start-line (line-at (window-start)))
+                    (original-window-point-line (line-at (window-point))))
+                (ai-code-backends-infra--vterm-render-preserving-copy-mode-view
+                 (lambda ()
+                   (goto-char (point-min))
+                   (forward-line 10)
+                   (delete-region (point-min) (point))))
+                (should (equal (line-at (window-start))
+                               original-start-line))
+                (should (equal (line-at (window-point))
+                               original-window-point-line))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest test-ai-code-backends-infra-vterm-render-queued-output-skips-dead-process ()
   "Queued output should be dropped when the buffer has no live process."
   (with-temp-buffer


### PR DESCRIPTION
## Summary

This follow-up fixes a remaining copy-mode viewport issue after PR #285.

## What changed

- store saved `window-start` and `window-point` as markers instead of raw integers during copy-mode rendering
- keep the existing point marker behavior unchanged
- add a regression test that simulates buffer-head deletion during rendering and asserts the viewport still tracks the same content

## Why it changed

The merged copy-mode renderer preserved window positions using raw buffer offsets. That works while the buffer only grows after the saved positions, but it can drift when `vterm` trims scrollback from the buffer head.

With local `vterm` 20240825.133, scrollback maintenance does delete lines from the start of the buffer during redraw/refresh. When that happens, restoring raw integers can move the viewport to different lines than the user was reading in copy mode.

Markers follow those buffer edits, so restoring with markers keeps the viewport anchored to the same content.

## Impact

- copy-mode viewport restoration stays stable in long-running sessions where scrollback churn trims older lines
- no public API or configuration changes

## Validation

- `emacs -Q -batch -L . -l ert -l test/test_ai-code-backends-infra.el -f ert-run-tests-batch-and-exit`
- `emacs -Q -batch -L . -f batch-byte-compile ai-code-backends-infra.el test/test_ai-code-backends-infra.el`

## Related

- follow-up to merged PR #285
- addresses the remaining marker-related review concern after the queued-render fix