### PR TITLE
Feat: Add optional editor-session MCP tools

### DIFF
--- a/README.org
+++ b/README.org
@@ -221,6 +221,24 @@ AI Code includes an Emacs MCP server with these built-in tools:
 - =xref_find_definitions_at_point=: find definitions at a file location
 - =treesit_info=: inspect tree-sitter node information for a file location
 
+Optional editor-session tools are available when you explicitly enable them:
+
+#+begin_src emacs-lisp
+(setq ai-code-mcp-editor-tools-enabled t)
+#+end_src
+
+When enabled, AI Code also registers:
+- =editor_state=: inspect the currently selected buffer, point, mode, region, and buffer flags
+- =visible_buffers=: list the buffers visible in the selected frame windows
+- =messages_tail=: return the latest lines from =*Messages*=
+- =eval_elisp=: evaluate a single Emacs Lisp form in a chosen buffer context
+
+By default, =eval_elisp= only allows =query= mode. To allow editor-local side effects too, opt in explicitly:
+
+#+begin_src emacs-lisp
+(setq ai-code-mcp-editor-tools-allow-effect-eval t)
+#+end_src
+
 screenshot inside Codex cli:
 
 [[file:./emacs_mcp_tools.png]]

--- a/ai-code-mcp-editor-tools.el
+++ b/ai-code-mcp-editor-tools.el
@@ -276,9 +276,8 @@
    ((consp form)
     (let ((head (car form)))
       (cond
-       ((memq head '(quote function)) nil)
        ((and (symbolp head)
-             (memq head denied-symbols))
+              (memq head denied-symbols))
         head)
        (t
         (or (ai-code-mcp-editor-tools--symbol-denied-p head denied-symbols)

--- a/ai-code-mcp-editor-tools.el
+++ b/ai-code-mcp-editor-tools.el
@@ -1,0 +1,512 @@
+;;; ai-code-mcp-editor-tools.el --- Optional editor-session MCP tools -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Optional Emacs-session MCP tools that expose editor-specific state.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(require 'subr-x)
+
+(declare-function ai-code-mcp-make-tool "ai-code-mcp-server")
+
+(defvar ai-code-mcp-server-tool-setup-functions nil)
+
+(defgroup ai-code-mcp-editor-tools nil
+  "Optional editor-session MCP tools."
+  :group 'ai-code-mcp-server
+  :prefix "ai-code-mcp-editor-tools-")
+
+(defcustom ai-code-mcp-editor-tools-enabled nil
+  "When non-nil, register optional editor-session MCP tools."
+  :type 'boolean
+  :group 'ai-code-mcp-editor-tools)
+
+(defcustom ai-code-mcp-editor-tools-allow-effect-eval nil
+  "When non-nil, allow `eval_elisp' to run in effect mode."
+  :type 'boolean
+  :group 'ai-code-mcp-editor-tools)
+
+(defconst ai-code-mcp-editor-tools--specs
+  '((:function ai-code-mcp-editor-state
+     :name "editor_state"
+     :description "Get the current editor state."
+     :args nil)
+    (:function ai-code-mcp-visible-buffers
+     :name "visible_buffers"
+     :description "List buffers visible in the selected frame."
+     :args nil)
+    (:function ai-code-mcp-messages-tail
+     :name "messages_tail"
+     :description "Get recent Emacs messages."
+     :args ((:name "limit"
+             :type integer
+             :description "Maximum number of messages to return."
+             :optional t)))
+    (:function ai-code-mcp-eval-elisp
+     :name "eval_elisp"
+     :description "Evaluate a single Emacs Lisp form."
+     :args ((:name "code"
+             :type string
+             :description "Single Emacs Lisp form to evaluate.")
+            (:name "mode"
+             :type string
+             :description "Evaluation mode."
+             :optional t)
+            (:name "buffer_name"
+             :type string
+             :description "Optional buffer context."
+             :optional t)
+            (:name "file_path"
+             :type string
+             :description "Optional file buffer context."
+             :optional t)
+            (:name "capture_messages"
+             :type boolean
+             :description "When non-nil, capture new messages."
+             :optional t)
+            (:name "include_backtrace"
+             :type boolean
+             :description "When non-nil, include a backtrace on failure."
+             :optional t)
+            (:name "timeout_ms"
+             :type integer
+             :description "Maximum time budget for the evaluation."
+             :optional t))))
+  "Optional editor-session MCP tool specifications.")
+
+(defconst ai-code-mcp-editor-tools--always-denied-symbols
+  '(append-to-file async-shell-command call-interactively call-process
+    command-execute compile copy-file delete-file delete-frame
+    delete-window eval funcall kill-buffer load load-file
+    make-directory make-network-process make-process rename-file
+    recompile require save-buffer save-buffers-kill-emacs shell-command
+    start-process url-retrieve write-file write-region)
+  "Symbols that `eval_elisp' rejects in every mode.")
+
+(defconst ai-code-mcp-editor-tools--query-denied-symbols
+  '(add-hook delete-region erase-buffer indent-region insert kill-region
+    newline put remove-hook replace-buffer-contents set setf setq
+    setq-local switch-to-buffer yank)
+  "Additional symbols that `eval_elisp' rejects in query mode.")
+
+(defun ai-code-mcp-editor-tools-setup ()
+  "Register optional editor-session MCP tools when enabled."
+  (when ai-code-mcp-editor-tools-enabled
+    (dolist (tool ai-code-mcp-editor-tools--specs)
+      (apply #'ai-code-mcp-make-tool tool))))
+
+(defun ai-code-mcp-editor-tools--json-bool (value)
+  "Return VALUE as a JSON boolean token."
+  (if value t :json-false))
+
+(defun ai-code-mcp-editor-tools--bool-arg (value default)
+  "Return boolean VALUE, falling back to DEFAULT when VALUE is omitted."
+  (cond
+   ((null value) default)
+   ((eq value :json-false) nil)
+   (t (not (null value)))))
+
+(defun ai-code-mcp-editor-tools--selected-window ()
+  "Return the selected window, falling back to the frame root window."
+  (or (and (window-live-p (selected-window))
+           (selected-window))
+      (frame-root-window)))
+
+(defun ai-code-mcp-editor-tools--resolve-buffer (&optional buffer-name file-path)
+  "Return the requested live buffer from BUFFER-NAME or FILE-PATH."
+  (when (and buffer-name file-path)
+    (error "Arguments buffer_name and file_path are mutually exclusive"))
+  (cond
+   (buffer-name
+    (or (get-buffer buffer-name)
+        (error "Buffer not found: %s" buffer-name)))
+   (file-path
+    (find-file-noselect (expand-file-name file-path) t))
+   (t
+    (window-buffer (ai-code-mcp-editor-tools--selected-window)))))
+
+(defun ai-code-mcp-editor-tools--point-line-column (buffer point)
+  "Return line and column for POINT in BUFFER."
+  (with-current-buffer buffer
+    (save-excursion
+      (goto-char point)
+      `((line . ,(line-number-at-pos))
+        (column . ,(current-column))))))
+
+(defun ai-code-mcp-editor-tools--region-state (buffer point)
+  "Return region metadata for BUFFER at POINT."
+  (with-current-buffer buffer
+    (let ((mark (mark t)))
+      (if (and mark mark-active)
+          (let* ((start (min point mark))
+                 (end (max point mark))
+                 (start-pos (ai-code-mcp-editor-tools--point-line-column
+                             buffer start))
+                 (end-pos (ai-code-mcp-editor-tools--point-line-column
+                           buffer end)))
+            `((region_active . t)
+              (region . ((start . ,start-pos)
+                         (end . ,end-pos)))))
+        '((region_active . :json-false)
+          (region . nil))))))
+
+(defun ai-code-mcp-editor-tools--editor-state-data ()
+  "Return an alist describing the selected window buffer."
+  (let* ((window (ai-code-mcp-editor-tools--selected-window))
+         (buffer (window-buffer window))
+         (point (window-point window))
+         (position (ai-code-mcp-editor-tools--point-line-column buffer point))
+         (region-state (ai-code-mcp-editor-tools--region-state buffer point)))
+    (with-current-buffer buffer
+      `((ok . t)
+        (buffer_name . ,(buffer-name buffer))
+        (file_path . ,(buffer-file-name buffer))
+        (major_mode . ,(symbol-name major-mode))
+        (modified . ,(ai-code-mcp-editor-tools--json-bool
+                      (buffer-modified-p)))
+        (read_only . ,(ai-code-mcp-editor-tools--json-bool buffer-read-only))
+        (narrowed . ,(ai-code-mcp-editor-tools--json-bool
+                      (buffer-narrowed-p)))
+        (point . ,point)
+        (line . ,(alist-get 'line position))
+        (column . ,(alist-get 'column position))
+        (region_active . ,(alist-get 'region_active region-state))
+        (region . ,(alist-get 'region region-state))
+        (default_directory . ,default-directory)))))
+
+(defun ai-code-mcp-editor-state ()
+  "Return a JSON payload for the current editor state."
+  (json-encode (ai-code-mcp-editor-tools--editor-state-data)))
+
+(defun ai-code-mcp-editor-tools--visible-buffer-entry (window index)
+  "Return a visible buffer entry for WINDOW at INDEX."
+  (let* ((buffer (window-buffer window))
+         (point (window-point window))
+         (position (ai-code-mcp-editor-tools--point-line-column buffer point)))
+    (with-current-buffer buffer
+      `((index . ,index)
+        (buffer_name . ,(buffer-name buffer))
+        (file_path . ,(buffer-file-name buffer))
+        (major_mode . ,(symbol-name major-mode))
+        (modified . ,(ai-code-mcp-editor-tools--json-bool
+                      (buffer-modified-p)))
+        (line . ,(alist-get 'line position))
+        (column . ,(alist-get 'column position))))))
+
+(defun ai-code-mcp-visible-buffers ()
+  "Return a JSON payload for visible buffers."
+  (let* ((selected-window (ai-code-mcp-editor-tools--selected-window))
+         (windows (window-list (selected-frame) 'no-minibuffer))
+         (entries (cl-mapcar #'ai-code-mcp-editor-tools--visible-buffer-entry
+                             windows
+                             (number-sequence 0 (1- (length windows)))))
+         (selected-index (or (cl-position selected-window windows) 0)))
+    (json-encode
+     `((ok . t)
+       (selected_index . ,selected-index)
+       (items . ,(vconcat entries))))))
+
+(defun ai-code-mcp-editor-tools--message-lines ()
+  "Return the current `*Messages*' contents as a list of lines."
+  (if-let ((buffer (get-buffer "*Messages*")))
+      (with-current-buffer buffer
+        (split-string (buffer-substring-no-properties (point-min) (point-max))
+                      "\n"
+                      t))
+    '()))
+
+(defun ai-code-mcp-messages-tail (&optional limit)
+  "Return a JSON payload for recent messages using LIMIT."
+  (let* ((limit (or limit 50))
+         (messages (ai-code-mcp-editor-tools--message-lines)))
+    (unless (and (integerp limit) (> limit 0))
+      (error "Argument limit must be a positive integer"))
+    (setq messages (last messages (min limit (length messages))))
+    (json-encode
+     `((ok . t)
+       (limit . ,limit)
+       (messages . ,(vconcat messages))))))
+
+(defun ai-code-mcp-editor-tools--modified-buffer-snapshot ()
+  "Return an alist of live buffers and their modified states."
+  (mapcar (lambda (buffer)
+            (cons buffer
+                  (with-current-buffer buffer
+                    (buffer-modified-p))))
+          (buffer-list)))
+
+(defun ai-code-mcp-editor-tools--changed-buffers (before)
+  "Return a list of buffers whose modified state changed after BEFORE."
+  (let ((before-table (make-hash-table :test 'eq))
+        changed)
+    (dolist (entry before)
+      (puthash (car entry) (cdr entry) before-table))
+    (dolist (buffer (buffer-list) (nreverse changed))
+      (let ((before-modified (gethash buffer before-table :missing))
+            (after-modified (with-current-buffer buffer
+                              (buffer-modified-p))))
+        (when (or (eq before-modified :missing)
+                  (not (eq before-modified after-modified)))
+          (push `((buffer_name . ,(buffer-name buffer))
+                  (file_path . ,(buffer-file-name buffer))
+                  (modified . ,(ai-code-mcp-editor-tools--json-bool
+                                after-modified)))
+                changed))))))
+
+(defun ai-code-mcp-editor-tools--context-summary (buffer)
+  "Return a summary of BUFFER after an evaluation."
+  (let ((position (ai-code-mcp-editor-tools--point-line-column
+                   buffer
+                   (with-current-buffer buffer (point)))))
+    `((buffer_name . ,(buffer-name buffer))
+      (file_path . ,(buffer-file-name buffer))
+      (line . ,(alist-get 'line position))
+      (column . ,(alist-get 'column position)))))
+
+(defun ai-code-mcp-editor-tools--symbol-denied-p (form denied-symbols)
+  "Return the first symbol in FORM that appears in DENIED-SYMBOLS."
+  (cond
+   ((symbolp form)
+    (and (memq form denied-symbols) form))
+   ((consp form)
+    (let ((head (car form)))
+      (cond
+       ((memq head '(quote function)) nil)
+       ((and (symbolp head)
+             (memq head denied-symbols))
+        head)
+       (t
+        (or (ai-code-mcp-editor-tools--symbol-denied-p head denied-symbols)
+            (cl-some
+             (lambda (item)
+               (ai-code-mcp-editor-tools--symbol-denied-p
+                item denied-symbols))
+             (cdr form)))))))
+   ((vectorp form)
+    (cl-some
+     (lambda (item)
+       (ai-code-mcp-editor-tools--symbol-denied-p item denied-symbols))
+     (append form nil)))
+   (t nil)))
+
+(defun ai-code-mcp-editor-tools--parse-single-form (code)
+  "Parse CODE and return exactly one top-level Emacs Lisp form."
+  (let* ((read-result (read-from-string code))
+         (form (car read-result))
+         (position (cdr read-result))
+         (rest (substring code position)))
+    (unless (string-match-p "\\`[[:space:]\n\r\t]*\\'" rest)
+      (error "Argument code must contain exactly one top-level form"))
+    form))
+
+(defun ai-code-mcp-editor-tools--evaluation-messages (before capture-messages)
+  "Return messages added after BEFORE when CAPTURE-MESSAGES."
+  (if capture-messages
+      (nthcdr (length before) (ai-code-mcp-editor-tools--message-lines))
+    '()))
+
+(defun ai-code-mcp-editor-tools--error-alist (type message)
+  "Return a JSON-ready error payload for TYPE and MESSAGE."
+  `((type . ,type)
+    (message . ,message)))
+
+(defun ai-code-mcp-editor-tools--backtrace-string ()
+  "Return the current backtrace as a string."
+  (with-temp-buffer
+    (let ((standard-output (current-buffer)))
+      (backtrace))
+    (buffer-string)))
+
+(defun ai-code-mcp-editor-tools--encode-eval-result
+    (mode target-buffer before-messages capture-messages timed-out
+          value changed-buffers &optional error-object backtrace)
+  "Return a JSON response for MODE in TARGET-BUFFER.
+BEFORE-MESSAGES and CAPTURE-MESSAGES control message collection.
+TIMED-OUT records timeout state, VALUE carries the result,
+CHANGED-BUFFERS lists modified buffers, and ERROR-OBJECT or BACKTRACE
+describe failures."
+  (json-encode
+   `((ok . ,(ai-code-mcp-editor-tools--json-bool (null error-object)))
+     (mode . ,mode)
+     (value_repr . ,(and (null error-object) (prin1-to-string value)))
+     (value_type . ,(and (null error-object)
+                         (symbol-name (type-of value))))
+     (messages . ,(vconcat
+                   (ai-code-mcp-editor-tools--evaluation-messages
+                    before-messages
+                    capture-messages)))
+     (error . ,error-object)
+     (backtrace . ,backtrace)
+     (changed_buffers . ,(vconcat changed-buffers))
+     (context_after . ,(ai-code-mcp-editor-tools--context-summary
+                        target-buffer))
+     (timed_out . ,(ai-code-mcp-editor-tools--json-bool timed-out)))))
+
+(defun ai-code-mcp-editor-tools--run-eval (form mode target-buffer timeout-ms
+                                                capture-messages
+                                                include-backtrace)
+  "Evaluate FORM in MODE within TARGET-BUFFER using TIMEOUT-MS.
+CAPTURE-MESSAGES controls message collection, and INCLUDE-BACKTRACE
+keeps the backtrace on failures."
+  (let ((before-messages (ai-code-mcp-editor-tools--message-lines))
+        (before-snapshot (ai-code-mcp-editor-tools--modified-buffer-snapshot))
+        (value nil)
+        (timed-out nil)
+        (error-object nil)
+        (backtrace nil))
+    (condition-case err
+        (catch 'ai-code-mcp-editor-tools-timeout
+          (with-timeout ((/ (float timeout-ms) 1000.0)
+                         (setq timed-out t)
+                         (throw 'ai-code-mcp-editor-tools-timeout nil))
+            (setq value
+                  (if (string= mode "query")
+                      (save-current-buffer
+                        (with-current-buffer target-buffer
+                          (save-excursion
+                            (save-match-data
+                              (save-restriction
+                                (eval form t))))))
+                    (save-current-buffer
+                      (with-current-buffer target-buffer
+                        (eval form t)))))))
+      (error
+       (setq error-object
+             (ai-code-mcp-editor-tools--error-alist
+              (symbol-name (car err))
+              (error-message-string err)))
+       (when include-backtrace
+         (setq backtrace (ai-code-mcp-editor-tools--backtrace-string)))))
+    (when timed-out
+      (setq error-object
+            (ai-code-mcp-editor-tools--error-alist
+             "timeout"
+             "Evaluation exceeded the configured timeout")))
+    (ai-code-mcp-editor-tools--encode-eval-result
+     mode
+     target-buffer
+     before-messages
+     capture-messages
+     timed-out
+     value
+     (ai-code-mcp-editor-tools--changed-buffers before-snapshot)
+     error-object
+     backtrace)))
+
+(defun ai-code-mcp-eval-elisp (code &optional mode buffer-name file-path
+                                    capture-messages include-backtrace
+                                    timeout-ms)
+  "Evaluate CODE as a single form using MODE and BUFFER-NAME.
+Return a JSON payload for BUFFER-NAME, FILE-PATH,
+CAPTURE-MESSAGES, INCLUDE-BACKTRACE, and TIMEOUT-MS."
+  (let* ((mode (or mode "query"))
+         (capture-messages (ai-code-mcp-editor-tools--bool-arg
+                            capture-messages
+                            t))
+         (include-backtrace (ai-code-mcp-editor-tools--bool-arg
+                             include-backtrace
+                             nil))
+         (timeout-ms (or timeout-ms 1000))
+         (target-buffer (ai-code-mcp-editor-tools--resolve-buffer
+                         buffer-name
+                         file-path))
+         (parse-error nil)
+         form
+         always-denied
+         query-denied)
+    (unless (member mode '("query" "effect"))
+      (error "Argument mode must be either query or effect"))
+    (unless (and (integerp timeout-ms) (> timeout-ms 0))
+      (error "Argument timeout_ms must be a positive integer"))
+    (condition-case err
+        (setq form (ai-code-mcp-editor-tools--parse-single-form code))
+      (error
+       (setq parse-error err)))
+    (cond
+     (parse-error
+      (ai-code-mcp-editor-tools--encode-eval-result
+       mode
+       target-buffer
+       (ai-code-mcp-editor-tools--message-lines)
+       capture-messages
+       nil
+       nil
+       '()
+       (ai-code-mcp-editor-tools--error-alist
+        (symbol-name (car parse-error))
+        (error-message-string parse-error))
+       (and include-backtrace
+            (ai-code-mcp-editor-tools--backtrace-string))))
+     (t
+      (setq always-denied
+            (ai-code-mcp-editor-tools--symbol-denied-p
+             form
+             ai-code-mcp-editor-tools--always-denied-symbols))
+      (setq query-denied
+            (and (string= mode "query")
+                 (ai-code-mcp-editor-tools--symbol-denied-p
+                  form
+                  ai-code-mcp-editor-tools--query-denied-symbols)))
+      (cond
+       (always-denied
+        (ai-code-mcp-editor-tools--encode-eval-result
+         mode
+         target-buffer
+         (ai-code-mcp-editor-tools--message-lines)
+         capture-messages
+         nil
+         nil
+         '()
+         (ai-code-mcp-editor-tools--error-alist
+          "symbol_denied"
+          (format "Symbol `%s' is not allowed in eval_elisp"
+                  always-denied))
+         nil))
+       (query-denied
+        (ai-code-mcp-editor-tools--encode-eval-result
+         mode
+         target-buffer
+         (ai-code-mcp-editor-tools--message-lines)
+         capture-messages
+         nil
+         nil
+         '()
+         (ai-code-mcp-editor-tools--error-alist
+          "query_symbol_denied"
+          (format "Symbol `%s' is not allowed in query mode"
+                  query-denied))
+         nil))
+       ((and (string= mode "effect")
+             (not ai-code-mcp-editor-tools-allow-effect-eval))
+        (ai-code-mcp-editor-tools--encode-eval-result
+         mode
+         target-buffer
+         (ai-code-mcp-editor-tools--message-lines)
+         capture-messages
+         nil
+         nil
+         '()
+         (ai-code-mcp-editor-tools--error-alist
+          "effect_mode_disabled"
+          "Effect mode is disabled by configuration")
+         nil))
+       (t
+        (ai-code-mcp-editor-tools--run-eval
+         form
+         mode
+         target-buffer
+         timeout-ms
+         capture-messages
+         include-backtrace)))))))
+
+(add-to-list 'ai-code-mcp-server-tool-setup-functions
+             #'ai-code-mcp-editor-tools-setup)
+
+(provide 'ai-code-mcp-editor-tools)
+
+;;; ai-code-mcp-editor-tools.el ends here

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -73,6 +73,9 @@ Use `auto' to prefer Flycheck and then Flymake when available."
                  (const :tag "Flymake" flymake))
   :group 'ai-code-mcp-server)
 
+(defvar ai-code-mcp-server-tool-setup-functions nil
+  "Functions that register optional MCP tool groups.")
+
 (defvar ai-code-mcp--sessions (make-hash-table :test 'equal)
   "Hash table mapping MCP session ids to session metadata.")
 
@@ -251,7 +254,9 @@ Required keys are `:function', `:name', and `:description'."
   "Register the built-in common Emacs MCP tools."
   (interactive)
   (dolist (tool ai-code-mcp--builtin-tool-specs)
-    (apply #'ai-code-mcp-make-tool tool)))
+    (apply #'ai-code-mcp-make-tool tool))
+  (dolist (setup-fn ai-code-mcp-server-tool-setup-functions)
+    (funcall setup-fn)))
 
 (defun ai-code-mcp--ensure-builtins ()
   "Ensure built-in MCP tools are registered."
@@ -420,7 +425,9 @@ When START-LINE and NUM-LINES are non-nil, return only that line range."
 
 (defun ai-code-mcp--make-diagnostic (start-line start-column end-line end-column
                                                 severity source message)
-  "Return an MCP diagnostics entry for START-LINE, START-COLUMN, END-LINE, END-COLUMN, SEVERITY, SOURCE, and MESSAGE."
+  "Return an MCP diagnostics entry.
+Use START-LINE, START-COLUMN, END-LINE, END-COLUMN, SEVERITY,
+SOURCE, and MESSAGE to describe the diagnostic payload."
   `((range . ((start . ((line . ,start-line)
                         (character . ,start-column)))
               (end . ((line . ,end-line)
@@ -787,6 +794,8 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
     (forward-line (1- line))
     (move-to-column column)
     (point)))
+
+(require 'ai-code-mcp-editor-tools nil t)
 
 (provide 'ai-code-mcp-server)
 

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -119,6 +119,12 @@ Use `auto' to prefer Flycheck and then Flymake when available."
      :name "get_project_buffers"
      :description "List open buffers that belong to the current project."
      :args nil)
+    (:function ai-code-mcp-notify-user
+     :name "notify_user"
+     :description "Show a notification to the Emacs user."
+     :args ((:name "message_text"
+             :type string
+             :description "Notification text to show in Emacs.")))
     (:function ai-code-mcp-imenu-list-symbols
      :name "imenu_list_symbols"
      :description "List useful symbols in a file via imenu."
@@ -172,6 +178,7 @@ The default tool list includes:
 - `get_diagnostics'
 - `get_project_files'
 - `get_project_buffers'
+- `notify_user'
 - `imenu_list_symbols'
 - `xref_find_references'
 - `xref_find_definitions_at_point'
@@ -794,6 +801,12 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
     (forward-line (1- line))
     (move-to-column column)
     (point)))
+
+(defun ai-code-mcp-notify-user (message-text)
+  "Show MESSAGE-TEXT to the Emacs user and beep."
+  (message "%s" message-text)
+  (beep)
+  (format "Notified user: %s" message-text))
 
 (require 'ai-code-mcp-editor-tools nil t)
 

--- a/docs/emacs-mcp-use-cases.org
+++ b/docs/emacs-mcp-use-cases.org
@@ -1,0 +1,423 @@
+#+title: Emacs MCP Use Cases with AI Coding CLIs
+
+* Overview
+
+This document captures the main use cases for the Emacs MCP tools in
+AI Code Interface when they are paired with AI coding CLIs such as
+GitHub Copilot CLI, OpenAI Codex CLI, and Claude Code.
+
+The key idea is simple:
+
+- AI coding CLIs are already good at repository search, disk file
+  editing, diff analysis, and shell-driven workflows.
+- Emacs MCP should therefore focus on what those agents do *not* see
+  by default: the *live Emacs session*.
+
+In practice, Emacs MCP is most useful as a combination of:
+
+- a *session sensor* that exposes the current editor context, and
+- an *Emacs-side validation layer* for checks that only make sense
+  inside the running Emacs session.
+
+
+* Positioning
+
+Emacs MCP is most valuable when it helps an external AI coding CLI
+answer questions like:
+
+- What is the user looking at *right now*?
+- Is the current buffer modified but not yet saved?
+- Which buffers are visible in the current frame?
+- What did Emacs just report in =*Messages*=?
+- What is the current Emacs Lisp state for this buffer or session?
+
+Emacs MCP is *less* valuable when it duplicates capabilities that the
+AI coding CLI already has, such as:
+
+- editing normal files on disk
+- running shell commands
+- doing broad repository search
+- acting as a second general-purpose execution environment
+
+
+* Current Tool Layers
+
+** Core built-in MCP tools
+
+The existing built-in tools already cover repository and code-structure
+questions well:
+
+- =project_info=
+- =buffer_query=
+- =get_diagnostics=
+- =get_project_files=
+- =get_project_buffers=
+- =imenu_list_symbols=
+- =xref_find_references=
+- =xref_find_definitions_at_point=
+- =treesit_info=
+
+These are useful for code understanding, navigation, and diagnostics.
+
+** Optional editor-session MCP tools
+
+The optional editor-session tools extend the built-in layer with
+live-editor awareness:
+
+- =editor_state=
+- =visible_buffers=
+- =messages_tail=
+- =eval_elisp=
+
+These tools should be understood as *Emacs-aware context and
+validation tools*, not as a replacement for the AI CLI's normal
+editing and shell workflow.
+
+
+* Why Emacs MCP Matters Even When the Agent Can Edit Files
+
+The strongest argument for Emacs MCP is that the live Emacs session
+contains information that does not exist in the repository or on disk.
+
+** Unsaved buffers
+
+An AI coding CLI may read the file from disk, but the user may be
+looking at a modified buffer that has not been saved yet.
+
+Use case:
+
+- The user asks the agent about a bug in the current function before
+  saving.
+- The correct source of truth is the current Emacs buffer, not the file
+  on disk.
+
+Useful tools:
+
+- =editor_state=
+- =buffer_query=
+
+** Current point, region, and narrowing
+
+The user is often focused on a very specific place in the file.
+The repository alone does not tell the agent:
+
+- where point is
+- whether a region is active
+- whether the buffer is narrowed
+
+Use case:
+
+- The user says "explain what is wrong here" or "review the selected
+  code" without manually copying the exact location.
+
+Useful tools:
+
+- =editor_state=
+- =buffer_query=
+- =xref_find_definitions_at_point=
+
+** Visible working set
+
+Users often work with multiple windows at once:
+
+- implementation on the left
+- test on the right
+- =*Messages*= or scratch buffer below
+
+The repository cannot tell the agent which files or buffers the user is
+currently comparing.
+
+Use case:
+
+- The agent should interpret the current visible buffers as the user's
+  active working set instead of scanning the whole project first.
+
+Useful tools:
+
+- =visible_buffers=
+
+** Emacs-side runtime feedback
+
+Many Emacs problems surface in =*Messages*=, not in the shell.
+
+Use case:
+
+- package load issues
+- mode hook failures
+- parser or navigation backends not activating
+- command warnings that are only visible in Emacs
+
+Useful tools:
+
+- =messages_tail=
+
+** Live Emacs Lisp validation
+
+Some questions can only be answered from inside the running Emacs
+session:
+
+- is this function actually bound?
+- is this feature loaded?
+- what is the current buffer-local value?
+- is this parser or backend available in this buffer?
+
+Use case:
+
+- debugging Emacs Lisp package behavior
+- validating assumptions about the current editor session
+
+Useful tools:
+
+- =eval_elisp= in =query= mode
+
+
+* High-Value Use Cases
+
+** 1. Current-location-aware explanation
+
+The user is in a buffer and wants an explanation about the code at
+point or in the active region.
+
+Recommended flow:
+
+1. Call =editor_state=
+2. If needed, call =buffer_query=
+3. Use =imenu_list_symbols= or =xref_find_definitions_at_point=
+4. Explain based on the live buffer context
+
+Why this matters:
+
+- The answer is anchored to what the user is currently reading, not
+  just to a file path.
+
+** 2. Debugging an unsaved change
+
+The user has changed a buffer but has not saved it yet, and wants to
+know why the change is wrong or incomplete.
+
+Recommended flow:
+
+1. Call =editor_state=
+2. If =modified= is true, use =buffer_query=
+3. Optionally combine with =get_diagnostics=
+4. Explain or suggest a patch
+
+Why this matters:
+
+- Disk content is stale; only Emacs knows the real current text.
+
+** 3. Working-set-aware review
+
+The user has split windows for implementation and tests and wants a
+review or debugging pass.
+
+Recommended flow:
+
+1. Call =visible_buffers=
+2. Read the visible source and test buffers first
+3. Only then widen the investigation to the project if necessary
+
+Why this matters:
+
+- The current frame layout often represents the user's actual problem
+  boundary better than the whole repository.
+
+** 4. Emacs-side failure diagnosis
+
+The user reports that something "does not work in Emacs", but the code
+looks fine on disk.
+
+Recommended flow:
+
+1. Call =messages_tail=
+2. If needed, call =editor_state=
+3. Use =eval_elisp= in =query= mode for state checks
+4. Suggest the fix
+
+Why this matters:
+
+- The root cause may be a mode issue, hook problem, missing feature, or
+  runtime state mismatch rather than a plain source bug.
+
+** 5. Emacs Lisp package and mode debugging
+
+This is one of the strongest use cases for Emacs MCP.
+
+Recommended flow:
+
+1. Use the structural tools for source understanding
+2. Use =messages_tail= for runtime evidence
+3. Use =eval_elisp= in =query= mode for live checks
+
+Why this matters:
+
+- Emacs Lisp behavior depends heavily on live session state, buffer
+  local values, and loaded features.
+
+** 6. Lightweight runtime verification
+
+The agent has a hypothesis and wants to confirm it before suggesting a
+change.
+
+Examples:
+
+- check whether a variable is bound
+- check whether a feature is loaded
+- inspect the current major mode
+- inspect whether a backend is available
+
+Recommended flow:
+
+- Use =eval_elisp= in =query= mode for short, explicit checks
+
+Why this matters:
+
+- The agent can move from speculation to evidence while staying inside
+  the editor session boundary.
+
+
+* Lower-Value or Lower-Priority Use Cases
+
+These are possible, but should not be the first focus of Emacs MCP.
+
+** Normal file editing
+
+Why lower priority:
+
+- The AI coding CLI already edits files on disk well.
+- A second editing path in Emacs creates more overlap and more room for
+  confusion.
+
+** Shell, process, or network execution through Emacs
+
+Why lower priority:
+
+- The AI coding CLI already has a more natural shell-facing execution
+  model.
+- Using Emacs MCP for OS-level execution blurs the responsibility
+  boundary.
+
+** General project crawling
+
+Why lower priority:
+
+- The core MCP tools plus the AI CLI's normal search capabilities are
+  already strong here.
+- The unique value of Emacs MCP is the live session, not another search
+  engine.
+
+
+* Recommended Tool Priorities
+
+| Priority | Tool | Main purpose |
+|----------+------+--------------|
+| High | =editor_state= | Anchor the agent to the current live editing context |
+| High | =messages_tail= | Expose Emacs-side runtime feedback and errors |
+| High | =eval_elisp= in =query= mode | Validate live Emacs assumptions |
+| Medium | =visible_buffers= | Expose the user's current visible working set |
+| Low | effectful =eval_elisp= | Powerful, but should remain explicitly gated |
+
+
+* Backend-Specific Notes
+
+** GitHub Copilot CLI
+
+GitHub Copilot CLI benefits from exact editor context when the user
+already knows the task and wants the agent to stay tightly anchored to
+the current buffer or visible working set.
+
+Best fit:
+
+- =editor_state=
+- =visible_buffers=
+- =messages_tail=
+
+Typical pattern:
+
+- "Use the Emacs MCP tools to inspect what I am currently looking at,
+  then explain the bug in the selected code."
+
+** OpenAI Codex CLI
+
+Codex CLI is naturally strong at repository reasoning and code search.
+Emacs MCP is most valuable when it gives Codex the *missing live
+context* that the repository does not contain.
+
+Best fit:
+
+- =editor_state=
+- =buffer_query=
+- =eval_elisp= in =query= mode
+
+Typical pattern:
+
+- "Use the Emacs MCP tools to inspect the current buffer and tell me if
+  my unsaved change is consistent with the surrounding code."
+
+** Claude Code
+
+Claude Code is especially strong when it can move through a
+hypothesis-check loop.
+Emacs MCP makes that loop stronger by exposing live editor state and
+allowing controlled session-side validation.
+
+Best fit:
+
+- =messages_tail=
+- =eval_elisp= in =query= mode
+- =editor_state=
+
+Typical pattern:
+
+- "Use the Emacs MCP tools to check the current mode, inspect the
+  latest messages, and verify whether the function I expect is actually
+  bound."
+
+
+* Recommended Workflow Pattern
+
+For the current toolset, the best general-purpose workflow is:
+
+1. Start with =editor_state=
+2. If the buffer is modified or the question is local, call
+   =buffer_query=
+3. If the issue is about code structure, use the built-in structural
+   tools such as =imenu_list_symbols=, =xref_find_definitions_at_point=,
+   or =get_diagnostics=
+4. If the issue may be Emacs-runtime-specific, call =messages_tail=
+5. If a live check is needed, use =eval_elisp= in =query= mode
+
+This keeps the AI CLI focused on the repository and filesystem while
+using Emacs MCP only where it adds unique value.
+
+
+* Anti-Goals
+
+Emacs MCP should *not* become:
+
+- a second general-purpose file editor
+- a second shell execution layer
+- a replacement for the AI CLI's repository search
+- a wide-open remote execution channel
+
+Its best identity is:
+
+#+begin_quote
+An editor-aware context and validation layer for AI coding CLIs.
+#+end_quote
+
+
+* Summary
+
+The most useful Emacs MCP use cases are the ones that expose what only
+Emacs knows at runtime:
+
+- current live buffer state
+- current point or selection
+- current visible working set
+- latest Emacs runtime messages
+- live Emacs Lisp session facts
+
+That is where Emacs MCP can make GitHub Copilot CLI, Codex CLI, and
+Claude Code feel significantly more native inside Emacs without
+duplicating the strengths they already have.

--- a/test/test_ai-code-mcp-editor-tools.el
+++ b/test/test_ai-code-mcp-editor-tools.el
@@ -44,19 +44,20 @@
                                        (alist-get 'name tool))
                                      (alist-get 'tools tools-result))
                              #'string<)))
-      (should (equal '("buffer_query"
-                       "editor_state"
-                       "eval_elisp"
-                       "get_diagnostics"
-                       "get_project_buffers"
-                       "get_project_files"
-                       "imenu_list_symbols"
-                       "messages_tail"
-                       "project_info"
-                       "treesit_info"
-                       "visible_buffers"
-                       "xref_find_definitions_at_point"
-                       "xref_find_references")
+       (should (equal '("buffer_query"
+                        "editor_state"
+                        "eval_elisp"
+                        "get_diagnostics"
+                        "get_project_buffers"
+                        "get_project_files"
+                        "imenu_list_symbols"
+                        "messages_tail"
+                        "notify_user"
+                        "project_info"
+                        "treesit_info"
+                        "visible_buffers"
+                        "xref_find_definitions_at_point"
+                        "xref_find_references")
                      tool-names)))))
 
 (ert-deftest ai-code-test-mcp-editor-state-reports-selected-buffer ()

--- a/test/test_ai-code-mcp-editor-tools.el
+++ b/test/test_ai-code-mcp-editor-tools.el
@@ -1,0 +1,166 @@
+;;; test_ai-code-mcp-editor-tools.el --- Tests for ai-code-mcp-editor-tools -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for optional Emacs session MCP tools.
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'seq)
+(unless (featurep 'magit)
+  (defun magit-toplevel (&optional _dir) nil)
+  (defun magit-get-current-branch () nil)
+  (defun magit-git-lines (&rest _args) nil)
+  (provide 'magit))
+
+(require 'ai-code-mcp-server nil t)
+
+(defun ai-code-test-mcp-editor-tools--content-text (result)
+  "Extract the first text content entry from RESULT."
+  (alist-get 'text
+             (car (alist-get 'content result))))
+
+(defun ai-code-test-mcp-editor-tools--read-payload (tool-name &optional arguments)
+  "Call TOOL-NAME with ARGUMENTS and decode its JSON payload."
+  (let ((json-object-type 'alist)
+        (json-array-type 'vector)
+        (json-key-type 'symbol))
+    (json-read-from-string
+     (ai-code-test-mcp-editor-tools--content-text
+      (ai-code-mcp-dispatch
+       "tools/call"
+       `((name . ,tool-name)
+         (arguments . ,(or arguments '()))))))))
+
+(ert-deftest ai-code-test-mcp-editor-tools-register-when-enabled ()
+  "Optional editor tools should be registered when explicitly enabled."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t))
+    (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
+           (tool-names (sort (mapcar (lambda (tool)
+                                       (alist-get 'name tool))
+                                     (alist-get 'tools tools-result))
+                             #'string<)))
+      (should (equal '("buffer_query"
+                       "editor_state"
+                       "eval_elisp"
+                       "get_diagnostics"
+                       "get_project_buffers"
+                       "get_project_files"
+                       "imenu_list_symbols"
+                       "messages_tail"
+                       "project_info"
+                       "treesit_info"
+                       "visible_buffers"
+                       "xref_find_definitions_at_point"
+                       "xref_find_references")
+                     tool-names)))))
+
+(ert-deftest ai-code-test-mcp-editor-state-reports-selected-buffer ()
+  "Editor state should describe the selected window buffer."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t)
+        (buffer (generate-new-buffer " *ai-code-mcp-editor-state*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (emacs-lisp-mode)
+            (setq-local default-directory "/tmp/")
+            (insert "alpha\nbeta\n")
+            (goto-char (point-min))
+            (forward-line 1)
+            (move-to-column 2))
+          (let ((payload (ai-code-test-mcp-editor-tools--read-payload
+                          "editor_state")))
+            (should (equal t (alist-get 'ok payload)))
+            (should (equal (buffer-name buffer)
+                           (alist-get 'buffer_name payload)))
+            (should (equal "emacs-lisp-mode"
+                           (alist-get 'major_mode payload)))
+            (should (equal t (alist-get 'modified payload)))
+            (should (= 2 (alist-get 'line payload)))
+            (should (= 2 (alist-get 'column payload)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest ai-code-test-mcp-visible-buffers-lists-current-windows ()
+  "Visible buffers should mirror the selected frame windows."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t)
+        (left-buffer (generate-new-buffer " *ai-code-mcp-left*"))
+        (right-buffer (generate-new-buffer " *ai-code-mcp-right*")))
+    (unwind-protect
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer left-buffer)
+          (set-window-buffer (split-window-right) right-buffer)
+          (let* ((payload (ai-code-test-mcp-editor-tools--read-payload
+                           "visible_buffers"))
+                 (items (alist-get 'items payload))
+                 (names (sort (mapcar (lambda (item)
+                                        (alist-get 'buffer_name item))
+                                      (append items nil))
+                              #'string<)))
+            (should (equal t (alist-get 'ok payload)))
+            (should (equal '(" *ai-code-mcp-left*" " *ai-code-mcp-right*")
+                           names))))
+      (when (buffer-live-p left-buffer)
+        (kill-buffer left-buffer))
+      (when (buffer-live-p right-buffer)
+        (kill-buffer right-buffer)))))
+
+(ert-deftest ai-code-test-mcp-messages-tail-returns-latest-messages ()
+  "Messages tail should return the latest entries from *Messages*."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t))
+    (message "ai-code-mcp-editor-tools-test-message")
+    (let* ((payload (ai-code-test-mcp-editor-tools--read-payload
+                     "messages_tail"
+                     '((limit . 1))))
+           (messages (alist-get 'messages payload)))
+      (should (equal t (alist-get 'ok payload)))
+      (should (= 1 (length messages)))
+      (should (string-match-p "ai-code-mcp-editor-tools-test-message"
+                              (aref messages 0))))))
+
+(ert-deftest ai-code-test-mcp-eval-elisp-query-uses-target-buffer ()
+  "Query evaluation should run against the requested buffer context."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t)
+        (buffer (generate-new-buffer " *ai-code-mcp-eval*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (insert "hello\n"))
+          (let ((payload
+                 (ai-code-test-mcp-editor-tools--read-payload
+                  "eval_elisp"
+                  `((code . "(buffer-name)")
+                    (buffer_name . ,(buffer-name buffer))))))
+            (should (equal t (alist-get 'ok payload)))
+            (should (equal "\" *ai-code-mcp-eval*\""
+                           (alist-get 'value_repr payload)))
+            (should (equal "string"
+                           (alist-get 'value_type payload)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest ai-code-test-mcp-eval-elisp-query-rejects-denied-symbols ()
+  "Query evaluation should reject denied symbols before running them."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t))
+    (let* ((payload (ai-code-test-mcp-editor-tools--read-payload
+                     "eval_elisp"
+                     '((code . "(insert \"boom\")"))))
+           (error-object (alist-get 'error payload)))
+      (should (equal :json-false (alist-get 'ok payload)))
+      (should (equal "query_symbol_denied"
+                     (alist-get 'type error-object))))))
+
+(provide 'test_ai-code-mcp-editor-tools)
+
+;;; test_ai-code-mcp-editor-tools.el ends here

--- a/test/test_ai-code-mcp-editor-tools.el
+++ b/test/test_ai-code-mcp-editor-tools.el
@@ -162,6 +162,54 @@
       (should (equal "query_symbol_denied"
                      (alist-get 'type error-object))))))
 
+(ert-deftest ai-code-test-mcp-eval-elisp-query-rejects-indirect-insert ()
+  "Query evaluation should reject indirect calls to denied mutators."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t)
+        (buffer (generate-new-buffer " *ai-code-mcp-indirect*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (insert "hello\n"))
+          (let* ((payload
+                  (ai-code-test-mcp-editor-tools--read-payload
+                   "eval_elisp"
+                   `((code . "(apply #'insert '(\"boom\"))")
+                     (buffer_name . ,(buffer-name buffer)))))
+                 (error-object (alist-get 'error payload)))
+            (should (equal :json-false (alist-get 'ok payload)))
+            (should (equal "query_symbol_denied"
+                           (alist-get 'type error-object)))
+            (should (equal "hello\n"
+                           (with-current-buffer buffer
+                             (buffer-string))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest ai-code-test-mcp-eval-elisp-query-rejects-symbol-function-indirection ()
+  "Query evaluation should reject quoted mutators passed through `symbol-function'."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-editor-tools-enabled t)
+        (buffer (generate-new-buffer " *ai-code-mcp-symbol-function*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (insert "hello\n"))
+          (let* ((payload
+                  (ai-code-test-mcp-editor-tools--read-payload
+                   "eval_elisp"
+                   `((code . "(apply (symbol-function 'insert) '(\"boom\"))")
+                     (buffer_name . ,(buffer-name buffer)))))
+                 (error-object (alist-get 'error payload)))
+            (should (equal :json-false (alist-get 'ok payload)))
+            (should (equal "query_symbol_denied"
+                           (alist-get 'type error-object)))
+            (should (equal "hello\n"
+                           (with-current-buffer buffer
+                             (buffer-string))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (provide 'test_ai-code-mcp-editor-tools)
 
 ;;; test_ai-code-mcp-editor-tools.el ends here

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -29,6 +29,19 @@
 (cl-defstruct ai-code-test-mcp-mock-diagnostic
   beg end type text backend)
 
+(defconst ai-code-test-mcp--builtin-tool-names
+  '("buffer_query"
+    "get_diagnostics"
+    "get_project_buffers"
+    "get_project_files"
+    "imenu_list_symbols"
+    "notify_user"
+    "project_info"
+    "treesit_info"
+    "xref_find_definitions_at_point"
+    "xref_find_references")
+  "Expected built-in MCP tool names.")
+
 (ert-deftest ai-code-test-mcp-dispatch-initialize-returns-server-info ()
   "Initialize should expose MCP protocol metadata."
   (should (fboundp 'ai-code-mcp-dispatch))
@@ -124,6 +137,7 @@
                        "get_project_buffers"
                        "get_project_files"
                        "imenu_list_symbols"
+                       "notify_user"
                        "project_info"
                        "treesit_info"
                        "xref_find_definitions_at_point"
@@ -138,16 +152,30 @@
                                        (alist-get 'name tool))
                                      (alist-get 'tools tools-result))
                              #'string<)))
-      (should (equal '("buffer_query"
-                       "get_diagnostics"
-                       "get_project_buffers"
-                       "get_project_files"
-                       "imenu_list_symbols"
-                       "project_info"
-                       "treesit_info"
-                       "xref_find_definitions_at_point"
-                       "xref_find_references")
+      (should (equal ai-code-test-mcp--builtin-tool-names
                      tool-names)))))
+
+(ert-deftest ai-code-test-mcp-notify-user-calls-message-and-beep ()
+  "Notification tool should relay the message text and beep."
+  (let ((ai-code-mcp-server-tools nil)
+        captured-message
+        beep-called)
+    (cl-letf (((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (setq captured-message
+                       (apply #'format format-string args))
+                 captured-message))
+              ((symbol-function 'beep)
+               (lambda (&rest _args)
+                 (setq beep-called t))))
+      (let ((result (ai-code-mcp-dispatch
+                     "tools/call"
+                     '((name . "notify_user")
+                       (arguments . ((message_text . "Build finished")))))))
+        (should (equal "Build finished" captured-message))
+        (should beep-called)
+        (should (equal "Notified user: Build finished"
+                       (ai-code-test-mcp--content-text result)))))))
 
 (ert-deftest ai-code-test-mcp-tools-list-encodes-empty-input-schema-properties ()
   "No-argument tools should encode empty schema properties as an object."

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -451,7 +451,7 @@
 
 (ert-deftest ai-code-test-menu-ai-cli-session-includes-select-terminal-entry ()
   "Test that the AI CLI session menu exposes terminal backend selection."
-  (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "T")))
+  (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "l")))
     (should suffix)
     (should (eq (plist-get (cdr suffix) :command)
                 'ai-code-select-terminal))))


### PR DESCRIPTION
## Summary

AI coding CLIs can already read and write files, but they still lack access to live Emacs session context. This PR adds an opt-in set of editor-session MCP tools so agents can inspect the active editor state, visible working set, recent *Messages* output, and run targeted Emacs Lisp queries from inside Emacs. The implementation keeps the default MCP surface unchanged by registering the new tools from a separate module only when explicitly enabled, and it keeps effectful evaluation behind a second explicit opt-in.

## Highlights

- add ai-code-mcp-editor-tools.el with editor_state, visible_buffers, messages_tail, and eval_elisp
- add ai-code-mcp-editor-tools-enabled and ai-code-mcp-editor-tools-allow-effect-eval, both defaulting to nil
- extend ai-code-mcp-server.el with optional tool registration hooks and add a small notify_user built-in for Emacs-side notifications
- add focused MCP coverage in test/test_ai-code-mcp-editor-tools.el and update test/test_ai-code-mcp-server.el
- document setup and usage in README.org, and add docs/emacs-mcp-use-cases.org to capture the intended workflow and scope

## User-visible impact

- no behavior change unless the new editor-session tools are explicitly enabled
- once enabled, AI agents can see live Emacs context instead of relying only on files on disk
- eval_elisp supports a query/effect split, with effect mode still disabled by default
- MCP clients also get notify_user for lightweight in-editor notification and beep feedback

## Testing

- Passed locally: emacs -Q -batch -L . -L test -l test/test_00-bootstrap.el -l ert -l test/test_ai-code-mcp-server.el -l test/test_ai-code-mcp-http-server.el -l test/test_ai-code-mcp-agent.el -f ert-run-tests-batch-and-exit
- Passed locally: byte-compiling the touched MCP files (ai-code-mcp-server.el, ai-code-mcp-editor-tools.el, test/test_ai-code-mcp-server.el, test/test_ai-code-mcp-editor-tools.el)
- Current gap: the combined MCP run that includes test/test_ai-code-mcp-editor-tools.el still fails in ai-code-test-mcp-editor-tools-register-when-enabled, because that expectation still reflects the pre-notify_user built-in tool set
- GitHub currently shows two failing ert jobs and one in-progress Prepare check; both failing ert jobs include ai-code-test-mcp-editor-tools-register-when-enabled, and both also report ai-code-test-menu-ai-cli-session-includes-select-terminal-entry
