### PR TITLE
Feat: Add emacs debugging and inspection MCP tools

### DIFF
--- a/README.org
+++ b/README.org
@@ -210,17 +210,33 @@ The generated prompt will include the function/region scope, visible file list, 
 
 **** Built-in Emacs MCP Tools
 
-AI Code includes an Emacs MCP server with these built-in tools:
+AI Code includes an Emacs MCP server with these core built-in tools:
 - =project_info=: summarize the current project, active buffer, and file count
 - =buffer_query=: read buffer contents, optionally by line range
 - =get_diagnostics=: return Flycheck or Flymake diagnostics for one file or open project buffers
 - =get_project_files=: list regular files in the current project
 - =get_project_buffers=: list open buffers that belong to the current project
-- =get_variable_value=: return the printed value of an Emacs variable by name
 - =imenu_list_symbols=: list useful symbols from a file via imenu
 - =xref_find_references=: find references to an identifier in project context
 - =xref_find_definitions_at_point=: find definitions at a file location
 - =treesit_info=: inspect tree-sitter node information for a file location
+
+Optional debugging tools are registered from a separate module and are enabled by default:
+
+#+begin_src emacs-lisp
+(setq ai-code-mcp-debug-tools-enabled t)  ;; default
+;; (setq ai-code-mcp-debug-tools-enabled nil) ;; disable them
+#+end_src
+
+When enabled, AI Code also registers:
+- =get_variable_value=: return the printed value of an Emacs variable by name
+- =get_variable_binding_info=: inspect current and default bindings for an Emacs variable
+- =get_function_info=: inspect function metadata such as kind, aliasing, and advice state
+- =get_feature_load_state=: inspect whether an Emacs feature is loaded and where it comes from
+- =get_recent_messages=: return the latest lines from =*Messages*=
+- =get_last_error_backtrace=: return the most recently recorded Emacs command error snapshot
+
+This split keeps the MCP core small while still exposing debugging-oriented tools by default.
 
 Optional editor-session tools are available when you explicitly enable them:
 

--- a/ai-code-mcp-common.el
+++ b/ai-code-mcp-common.el
@@ -1,0 +1,30 @@
+;;; ai-code-mcp-common.el --- Shared MCP helper functions -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Shared helper functions used by optional MCP tool modules.
+
+;;; Code:
+
+(require 'subr-x)
+
+(defvar ai-code-mcp-server-tool-setup-functions nil
+  "Functions that register optional MCP tool groups.")
+
+(defun ai-code-mcp--json-bool (value)
+  "Return VALUE as a JSON boolean token."
+  (if value t :json-false))
+
+(defun ai-code-mcp--message-lines ()
+  "Return the current `*Messages*' contents as a list of lines."
+  (if-let ((buffer (get-buffer "*Messages*")))
+      (with-current-buffer buffer
+        (split-string (buffer-substring-no-properties (point-min) (point-max))
+                      "\n"
+                      t))
+    '()))
+
+(provide 'ai-code-mcp-common)
+
+;;; ai-code-mcp-common.el ends here

--- a/ai-code-mcp-debug-tools.el
+++ b/ai-code-mcp-debug-tools.el
@@ -9,13 +9,12 @@
 ;;; Code:
 
 (require 'json)
+(require 'ai-code-mcp-common)
 (require 'nadvice)
 (require 'seq)
 (require 'subr-x)
 
 (declare-function ai-code-mcp-make-tool "ai-code-mcp-server")
-
-(defvar ai-code-mcp-server-tool-setup-functions nil)
 
 (defgroup ai-code-mcp-debug-tools nil
   "Optional MCP debugging tools."
@@ -81,19 +80,6 @@
     (ai-code-mcp--ensure-error-capture)
     (dolist (tool ai-code-mcp-debug-tools--specs)
       (apply #'ai-code-mcp-make-tool tool))))
-
-(defun ai-code-mcp--json-bool (value)
-  "Return VALUE as a JSON boolean token."
-  (if value t :json-false))
-
-(defun ai-code-mcp--message-lines ()
-  "Return the current `*Messages*' contents as a list of lines."
-  (if-let ((buffer (get-buffer "*Messages*")))
-      (with-current-buffer buffer
-        (split-string (buffer-substring-no-properties (point-min) (point-max))
-                      "\n"
-                      t))
-    '()))
 
 (defun ai-code-mcp--documentation-summary (documentation)
   "Return a trimmed summary line for DOCUMENTATION."

--- a/ai-code-mcp-debug-tools.el
+++ b/ai-code-mcp-debug-tools.el
@@ -1,0 +1,351 @@
+;;; ai-code-mcp-debug-tools.el --- Optional MCP debugging tools -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Optional MCP debugging tools for inspecting Emacs variables,
+;; functions, features, messages, and the most recent command error.
+
+;;; Code:
+
+(require 'json)
+(require 'nadvice)
+(require 'seq)
+(require 'subr-x)
+
+(declare-function ai-code-mcp-make-tool "ai-code-mcp-server")
+
+(defvar ai-code-mcp-server-tool-setup-functions nil)
+
+(defgroup ai-code-mcp-debug-tools nil
+  "Optional MCP debugging tools."
+  :group 'ai-code-mcp-server
+  :prefix "ai-code-mcp-debug-tools-")
+
+(defcustom ai-code-mcp-debug-tools-enabled t
+  "When non-nil, register optional MCP debugging tools."
+  :type 'boolean
+  :group 'ai-code-mcp-debug-tools)
+
+(defvar ai-code-mcp--last-error-record nil
+  "Most recent Emacs error snapshot recorded for MCP diagnostics tools.")
+
+(defvar ai-code-mcp--error-capture-installed nil
+  "Non-nil when MCP error capture advice has been installed.")
+
+(defconst ai-code-mcp-debug-tools--specs
+  '((:function ai-code-mcp-get-variable-binding-info
+     :name "get_variable_binding_info"
+     :description "Get current and default binding details for an Emacs variable."
+     :args ((:name "variable_name"
+             :type string
+             :description "Emacs variable name to inspect.")
+            (:name "buffer_name"
+             :type string
+             :description "Optional buffer name used for buffer-local inspection."
+             :optional t)))
+    (:function ai-code-mcp-get-variable-value
+     :name "get_variable_value"
+     :description "Get the printed representation of an Emacs variable value by name."
+     :args ((:name "variable_name"
+             :type string
+             :description "Emacs variable name to inspect.")))
+    (:function ai-code-mcp-get-function-info
+     :name "get_function_info"
+     :description "Get metadata about an Emacs function by name."
+     :args ((:name "function_name"
+             :type string
+             :description "Emacs function name to inspect.")))
+    (:function ai-code-mcp-get-last-error-backtrace
+     :name "get_last_error_backtrace"
+     :description "Get the most recently recorded Emacs error backtrace."
+     :args nil)
+    (:function ai-code-mcp-get-feature-load-state
+     :name "get_feature_load_state"
+     :description "Get load state details for an Emacs feature."
+     :args ((:name "feature_name"
+             :type string
+             :description "Emacs feature name to inspect.")))
+    (:function ai-code-mcp-get-recent-messages
+     :name "get_recent_messages"
+     :description "Get recent entries from the Emacs *Messages* buffer."
+     :args ((:name "limit"
+             :type integer
+             :description "Maximum number of messages to return."
+             :optional t))))
+  "Optional MCP debugging tool specifications.")
+
+(defun ai-code-mcp-debug-tools-setup ()
+  "Register optional MCP debugging tools when enabled."
+  (when ai-code-mcp-debug-tools-enabled
+    (ai-code-mcp--ensure-error-capture)
+    (dolist (tool ai-code-mcp-debug-tools--specs)
+      (apply #'ai-code-mcp-make-tool tool))))
+
+(defun ai-code-mcp--json-bool (value)
+  "Return VALUE as a JSON boolean token."
+  (if value t :json-false))
+
+(defun ai-code-mcp--message-lines ()
+  "Return the current `*Messages*' contents as a list of lines."
+  (if-let ((buffer (get-buffer "*Messages*")))
+      (with-current-buffer buffer
+        (split-string (buffer-substring-no-properties (point-min) (point-max))
+                      "\n"
+                      t))
+    '()))
+
+(defun ai-code-mcp--documentation-summary (documentation)
+  "Return a trimmed summary line for DOCUMENTATION."
+  (if (stringp documentation)
+      (string-trim (car (split-string documentation "\n" t)))
+    ""))
+
+(defun ai-code-mcp--resolve-buffer (buffer-name)
+  "Return BUFFER-NAME when it names a live buffer, or the current buffer."
+  (if buffer-name
+      (or (get-buffer buffer-name)
+          (error "Buffer not found: %s" buffer-name))
+    (current-buffer)))
+
+(defun ai-code-mcp--backtrace-frame-summary (frame)
+  "Return a readable summary string for backtrace FRAME."
+  (let ((function (nth 1 frame))
+        (arguments (nth 2 frame)))
+    (if arguments
+        (format "%S %S" function arguments)
+      (format "%S" function))))
+
+(defun ai-code-mcp--capture-backtrace-summaries ()
+  "Return the current backtrace as a list of summary strings."
+  (mapcar #'ai-code-mcp--backtrace-frame-summary
+          (backtrace-frames)))
+
+(defun ai-code-mcp--error-message (data)
+  "Return a friendly error message string for DATA."
+  (condition-case nil
+      (error-message-string data)
+    (error
+     (format "%S" data))))
+
+(defun ai-code-mcp--record-command-error (data context signal)
+  "Record the command error DATA, CONTEXT, and SIGNAL for MCP tools."
+  (let ((frames (ai-code-mcp--capture-backtrace-summaries)))
+    (setq ai-code-mcp--last-error-record
+          `((error_symbol . ,(symbol-name (car data)))
+            (error_message . ,(ai-code-mcp--error-message data))
+            (context . ,(format "%s" context))
+            (signal . ,signal)
+            (timestamp . ,(format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+            (frame_count . ,(length frames))
+            (frames . ,frames)))))
+
+(defun ai-code-mcp--ensure-error-capture ()
+  "Install error capture advice once for MCP debugging tools."
+  (unless ai-code-mcp--error-capture-installed
+    (advice-add 'command-error-default-function
+                :before
+                #'ai-code-mcp--record-command-error)
+    (setq ai-code-mcp--error-capture-installed t)))
+
+(defun ai-code-mcp--find-existing-variable-symbol (variable-name)
+  "Return the interned symbol for VARIABLE-NAME, or nil when missing."
+  (and (stringp variable-name)
+       (intern-soft variable-name)))
+
+(defun ai-code-mcp-get-variable-binding-info (variable-name &optional buffer-name)
+  "Return JSON binding details for VARIABLE-NAME in BUFFER-NAME."
+  (let ((symbol (ai-code-mcp--find-existing-variable-symbol variable-name)))
+    (if (not symbol)
+        (json-encode
+         `((exists . :json-false)
+           (variable_name . ,variable-name)
+           (buffer_name . ,buffer-name)
+           (bound . :json-false)
+           (default_bound . :json-false)
+           (buffer_local . :json-false)
+           (current_value_repr . nil)
+           (default_value_repr . nil)
+           (documentation_summary . nil)))
+      (with-current-buffer (ai-code-mcp--resolve-buffer buffer-name)
+        (let ((bound (boundp symbol))
+              (default-bound (default-boundp symbol))
+              (buffer-local (local-variable-p symbol (current-buffer))))
+          (json-encode
+           `((exists . t)
+             (variable_name . ,variable-name)
+             (buffer_name . ,(buffer-name (current-buffer)))
+             (bound . ,(ai-code-mcp--json-bool bound))
+             (default_bound . ,(ai-code-mcp--json-bool default-bound))
+             (buffer_local . ,(ai-code-mcp--json-bool buffer-local))
+             (current_value_repr . ,(and bound
+                                         (format "%S" (symbol-value symbol))))
+             (default_value_repr . ,(and default-bound
+                                         (format "%S" (default-value symbol))))
+             (documentation_summary
+              . ,(ai-code-mcp--documentation-summary
+                  (documentation-property symbol
+                                          'variable-documentation
+                                          t))))))))))
+
+(defun ai-code-mcp-get-variable-value (variable-name)
+  "Return the printed representation of VARIABLE-NAME.
+Return a friendly error string when VARIABLE-NAME does not name an
+existing bound variable."
+  (let ((symbol (ai-code-mcp--find-existing-variable-symbol variable-name)))
+    (cond
+     ((not symbol)
+      (format "Variable not found: %s" variable-name))
+     ((not (boundp symbol))
+      (format "Variable is unbound: %s" variable-name))
+     (t
+      (format "%S" (symbol-value symbol))))))
+
+(defun ai-code-mcp--find-existing-function-symbol (function-name)
+  "Return the interned symbol for FUNCTION-NAME, or nil when missing."
+  (and (stringp function-name)
+       (intern-soft function-name)))
+
+(defun ai-code-mcp--function-advised-p (symbol)
+  "Return non-nil when SYMBOL has active advice."
+  (let (advised)
+    (advice-mapc (lambda (&rest _args)
+                   (setq advised t))
+                 symbol)
+    advised))
+
+(defun ai-code-mcp--function-root-definition (symbol)
+  "Return SYMBOL's root definition with advice wrappers removed."
+  (let ((definition (advice--symbol-function symbol)))
+    (if (advice--p definition)
+        (advice--cd*r definition)
+      definition)))
+
+(defun ai-code-mcp--function-kind (symbol)
+  "Return a string describing SYMBOL's callable kind."
+  (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
+         (resolved-definition (if (symbolp root-definition)
+                                  (indirect-function root-definition)
+                                (indirect-function symbol))))
+    (cond
+     ((macrop symbol) "macro")
+     ((autoloadp root-definition) "autoload")
+     ((subrp resolved-definition) "subr")
+     ((or (functionp resolved-definition)
+          (and (consp resolved-definition)
+               (memq (car resolved-definition) '(lambda closure))))
+      "lambda")
+     (t "unknown"))))
+
+(defun ai-code-mcp-get-function-info (function-name)
+  "Return JSON metadata describing FUNCTION-NAME."
+  (let ((symbol (ai-code-mcp--find-existing-function-symbol function-name)))
+    (if (not (and symbol (fboundp symbol)))
+        (json-encode
+         `((exists . :json-false)
+           (function_name . ,function-name)
+           (kind . nil)
+           (interactive . :json-false)
+           (advised . :json-false)
+           (aliased_to . nil)
+           (source_file . nil)
+           (documentation_summary . nil)))
+      (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
+             (aliased-to (and (symbolp root-definition)
+                              (symbol-name root-definition))))
+        (json-encode
+         `((exists . t)
+           (function_name . ,function-name)
+           (kind . ,(ai-code-mcp--function-kind symbol))
+           (interactive . ,(ai-code-mcp--json-bool (commandp symbol)))
+           (advised . ,(ai-code-mcp--json-bool
+                        (ai-code-mcp--function-advised-p symbol)))
+           (aliased_to . ,aliased-to)
+           (source_file . ,(symbol-file symbol 'defun))
+           (documentation_summary
+            . ,(ai-code-mcp--documentation-summary
+                (documentation symbol t)))))))))
+
+(defun ai-code-mcp--last-error-json-payload (record)
+  "Return a JSON-ready payload for a recorded error RECORD."
+  `((recorded . t)
+    (error_symbol . ,(alist-get 'error_symbol record))
+    (error_message . ,(alist-get 'error_message record))
+    (context . ,(alist-get 'context record))
+    (signal . ,(ai-code-mcp--json-bool (alist-get 'signal record)))
+    (timestamp . ,(alist-get 'timestamp record))
+    (frame_count . ,(alist-get 'frame_count record))
+    (frames . ,(vconcat (alist-get 'frames record)))))
+
+(defun ai-code-mcp--empty-last-error-json-payload ()
+  "Return a JSON-ready payload when no error has been recorded."
+  `((recorded . :json-false)
+    (error_symbol . nil)
+    (error_message . nil)
+    (context . nil)
+    (signal . :json-false)
+    (timestamp . nil)
+    (frame_count . 0)
+    (frames . nil)))
+
+(defun ai-code-mcp-get-last-error-backtrace ()
+  "Return a JSON snapshot of the most recently recorded Emacs error."
+  (json-encode
+   (if ai-code-mcp--last-error-record
+       (ai-code-mcp--last-error-json-payload ai-code-mcp--last-error-record)
+     (ai-code-mcp--empty-last-error-json-payload))))
+
+(defun ai-code-mcp--feature-providers (feature-symbol)
+  "Return `load-history' files that provided FEATURE-SYMBOL."
+  (let (providers)
+    (dolist (entry load-history (delete-dups (nreverse providers)))
+      (when (and (car entry)
+                 (member `(provide . ,feature-symbol) (cdr entry)))
+        (push (car entry) providers)))))
+
+(defun ai-code-mcp--feature-library-matches (feature-name)
+  "Return `load-path' files that look like FEATURE-NAME libraries."
+  (let (matches)
+    (dolist (directory load-path (delete-dups (nreverse matches)))
+      (when (stringp directory)
+        (dolist (suffix '(".el" ".elc" ".eln"))
+          (let ((candidate (expand-file-name (concat feature-name suffix)
+                                             directory)))
+            (when (file-exists-p candidate)
+              (push candidate matches))))))))
+
+(defun ai-code-mcp-get-feature-load-state (feature-name)
+  "Return JSON load-state details for FEATURE-NAME."
+  (let* ((feature-symbol (and (stringp feature-name)
+                              (intern-soft feature-name)))
+         (loaded (and feature-symbol (featurep feature-symbol)))
+         (library-path (locate-library feature-name))
+         (providers (and feature-symbol
+                         (ai-code-mcp--feature-providers feature-symbol))))
+    (json-encode
+     `((feature_name . ,feature-name)
+       (loaded . ,(ai-code-mcp--json-bool loaded))
+       (library_path . ,library-path)
+       (provided_by_files . ,(vconcat providers))
+       (load_history_entries . ,(vconcat providers))
+       (load_path_matches
+        . ,(vconcat (ai-code-mcp--feature-library-matches feature-name)))))))
+
+(defun ai-code-mcp-get-recent-messages (&optional limit)
+  "Return a JSON payload for recent messages using LIMIT."
+  (let* ((limit (or limit 50))
+         (messages (ai-code-mcp--message-lines)))
+    (unless (and (integerp limit) (> limit 0))
+      (error "Argument limit must be a positive integer"))
+    (setq messages (last messages (min limit (length messages))))
+    (json-encode
+     `((ok . t)
+       (limit . ,limit)
+       (messages . ,(vconcat messages))))))
+
+(add-to-list 'ai-code-mcp-server-tool-setup-functions
+             #'ai-code-mcp-debug-tools-setup)
+
+(provide 'ai-code-mcp-debug-tools)
+
+;;; ai-code-mcp-debug-tools.el ends here

--- a/ai-code-mcp-debug-tools.el
+++ b/ai-code-mcp-debug-tools.el
@@ -11,7 +11,6 @@
 (require 'json)
 (require 'ai-code-mcp-common)
 (require 'nadvice)
-(require 'seq)
 (require 'subr-x)
 
 (declare-function ai-code-mcp-make-tool "ai-code-mcp-server")
@@ -209,19 +208,21 @@ existing bound variable."
 
 (defun ai-code-mcp--function-kind (symbol)
   "Return a string describing SYMBOL's callable kind."
-  (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
-         (resolved-definition (if (symbolp root-definition)
-                                  (indirect-function root-definition)
-                                (indirect-function symbol))))
+  (let ((root-definition (ai-code-mcp--function-root-definition symbol)))
     (cond
-     ((macrop symbol) "macro")
      ((autoloadp root-definition) "autoload")
-     ((subrp resolved-definition) "subr")
-     ((or (functionp resolved-definition)
-          (and (consp resolved-definition)
-               (memq (car resolved-definition) '(lambda closure))))
-      "lambda")
-     (t "unknown"))))
+     ((macrop symbol) "macro")
+     (t
+      (let ((resolved-definition (if (symbolp root-definition)
+                                     (indirect-function root-definition)
+                                   (indirect-function symbol))))
+        (cond
+         ((subrp resolved-definition) "subr")
+         ((or (functionp resolved-definition)
+              (and (consp resolved-definition)
+                   (memq (car resolved-definition) '(lambda closure))))
+          "lambda")
+         (t "unknown")))))))
 
 (defun ai-code-mcp-get-function-info (function-name)
   "Return JSON metadata describing FUNCTION-NAME."
@@ -300,22 +301,38 @@ existing bound variable."
             (when (file-exists-p candidate)
               (push candidate matches))))))))
 
+(defun ai-code-mcp--valid-feature-name-p (feature-name)
+  "Return non-nil when FEATURE-NAME is a non-empty string."
+  (and (stringp feature-name)
+       (not (string-empty-p feature-name))))
+
+(defun ai-code-mcp--invalid-feature-load-state-payload (feature-name)
+  "Return a JSON payload for invalid FEATURE-NAME input."
+  `((feature_name . ,feature-name)
+    (loaded . :json-false)
+    (error_message . "feature_name must be a non-empty string")
+    (library_path . nil)
+    (provided_by_files . nil)
+    (load_path_matches . nil)))
+
 (defun ai-code-mcp-get-feature-load-state (feature-name)
   "Return JSON load-state details for FEATURE-NAME."
-  (let* ((feature-symbol (and (stringp feature-name)
-                              (intern-soft feature-name)))
-         (loaded (and feature-symbol (featurep feature-symbol)))
-         (library-path (locate-library feature-name))
-         (providers (and feature-symbol
-                         (ai-code-mcp--feature-providers feature-symbol))))
-    (json-encode
-     `((feature_name . ,feature-name)
-       (loaded . ,(ai-code-mcp--json-bool loaded))
-       (library_path . ,library-path)
-       (provided_by_files . ,(vconcat providers))
-       (load_history_entries . ,(vconcat providers))
-       (load_path_matches
-        . ,(vconcat (ai-code-mcp--feature-library-matches feature-name)))))))
+  (if (not (ai-code-mcp--valid-feature-name-p feature-name))
+      (json-encode
+       (ai-code-mcp--invalid-feature-load-state-payload feature-name))
+    (let* ((feature-symbol (intern-soft feature-name))
+           (loaded (and feature-symbol (featurep feature-symbol)))
+           (library-path (locate-library feature-name))
+           (providers (and feature-symbol
+                           (ai-code-mcp--feature-providers feature-symbol))))
+      (json-encode
+       `((feature_name . ,feature-name)
+         (loaded . ,(ai-code-mcp--json-bool loaded))
+         (error_message . nil)
+         (library_path . ,library-path)
+         (provided_by_files . ,(vconcat providers))
+         (load_path_matches
+          . ,(vconcat (ai-code-mcp--feature-library-matches feature-name))))))))
 
 (defun ai-code-mcp-get-recent-messages (&optional limit)
   "Return a JSON payload for recent messages using LIMIT."

--- a/ai-code-mcp-editor-tools.el
+++ b/ai-code-mcp-editor-tools.el
@@ -9,12 +9,11 @@
 
 (require 'cl-lib)
 (require 'json)
+(require 'ai-code-mcp-common)
 (require 'seq)
 (require 'subr-x)
 
 (declare-function ai-code-mcp-make-tool "ai-code-mcp-server")
-
-(defvar ai-code-mcp-server-tool-setup-functions nil)
 
 (defgroup ai-code-mcp-editor-tools nil
   "Optional editor-session MCP tools."
@@ -100,10 +99,6 @@
     (dolist (tool ai-code-mcp-editor-tools--specs)
       (apply #'ai-code-mcp-make-tool tool))))
 
-(defun ai-code-mcp-editor-tools--json-bool (value)
-  "Return VALUE as a JSON boolean token."
-  (if value t :json-false))
-
 (defun ai-code-mcp-editor-tools--bool-arg (value default)
   "Return boolean VALUE, falling back to DEFAULT when VALUE is omitted."
   (cond
@@ -167,10 +162,10 @@
         (buffer_name . ,(buffer-name buffer))
         (file_path . ,(buffer-file-name buffer))
         (major_mode . ,(symbol-name major-mode))
-        (modified . ,(ai-code-mcp-editor-tools--json-bool
+        (modified . ,(ai-code-mcp--json-bool
                       (buffer-modified-p)))
-        (read_only . ,(ai-code-mcp-editor-tools--json-bool buffer-read-only))
-        (narrowed . ,(ai-code-mcp-editor-tools--json-bool
+        (read_only . ,(ai-code-mcp--json-bool buffer-read-only))
+        (narrowed . ,(ai-code-mcp--json-bool
                       (buffer-narrowed-p)))
         (point . ,point)
         (line . ,(alist-get 'line position))
@@ -193,7 +188,7 @@
         (buffer_name . ,(buffer-name buffer))
         (file_path . ,(buffer-file-name buffer))
         (major_mode . ,(symbol-name major-mode))
-        (modified . ,(ai-code-mcp-editor-tools--json-bool
+        (modified . ,(ai-code-mcp--json-bool
                       (buffer-modified-p)))
         (line . ,(alist-get 'line position))
         (column . ,(alist-get 'column position))))))
@@ -211,19 +206,10 @@
        (selected_index . ,selected-index)
        (items . ,(vconcat entries))))))
 
-(defun ai-code-mcp-editor-tools--message-lines ()
-  "Return the current `*Messages*' contents as a list of lines."
-  (if-let ((buffer (get-buffer "*Messages*")))
-      (with-current-buffer buffer
-        (split-string (buffer-substring-no-properties (point-min) (point-max))
-                      "\n"
-                      t))
-    '()))
-
 (defun ai-code-mcp-messages-tail (&optional limit)
   "Return a JSON payload for recent messages using LIMIT."
   (let* ((limit (or limit 50))
-         (messages (ai-code-mcp-editor-tools--message-lines)))
+         (messages (ai-code-mcp--message-lines)))
     (unless (and (integerp limit) (> limit 0))
       (error "Argument limit must be a positive integer"))
     (setq messages (last messages (min limit (length messages))))
@@ -254,7 +240,7 @@
                   (not (eq before-modified after-modified)))
           (push `((buffer_name . ,(buffer-name buffer))
                   (file_path . ,(buffer-file-name buffer))
-                  (modified . ,(ai-code-mcp-editor-tools--json-bool
+                  (modified . ,(ai-code-mcp--json-bool
                                 after-modified)))
                 changed))))))
 
@@ -306,7 +292,7 @@
 (defun ai-code-mcp-editor-tools--evaluation-messages (before capture-messages)
   "Return messages added after BEFORE when CAPTURE-MESSAGES."
   (if capture-messages
-      (nthcdr (length before) (ai-code-mcp-editor-tools--message-lines))
+      (nthcdr (length before) (ai-code-mcp--message-lines))
     '()))
 
 (defun ai-code-mcp-editor-tools--error-alist (type message)
@@ -330,7 +316,7 @@ TIMED-OUT records timeout state, VALUE carries the result,
 CHANGED-BUFFERS lists modified buffers, and ERROR-OBJECT or BACKTRACE
 describe failures."
   (json-encode
-   `((ok . ,(ai-code-mcp-editor-tools--json-bool (null error-object)))
+   `((ok . ,(ai-code-mcp--json-bool (null error-object)))
      (mode . ,mode)
      (value_repr . ,(and (null error-object) (prin1-to-string value)))
      (value_type . ,(and (null error-object)
@@ -344,7 +330,7 @@ describe failures."
      (changed_buffers . ,(vconcat changed-buffers))
      (context_after . ,(ai-code-mcp-editor-tools--context-summary
                         target-buffer))
-     (timed_out . ,(ai-code-mcp-editor-tools--json-bool timed-out)))))
+     (timed_out . ,(ai-code-mcp--json-bool timed-out)))))
 
 (defun ai-code-mcp-editor-tools--run-eval (form mode target-buffer timeout-ms
                                                 capture-messages
@@ -352,7 +338,7 @@ describe failures."
   "Evaluate FORM in MODE within TARGET-BUFFER using TIMEOUT-MS.
 CAPTURE-MESSAGES controls message collection, and INCLUDE-BACKTRACE
 keeps the backtrace on failures."
-  (let ((before-messages (ai-code-mcp-editor-tools--message-lines))
+  (let ((before-messages (ai-code-mcp--message-lines))
         (before-snapshot (ai-code-mcp-editor-tools--modified-buffer-snapshot))
         (value nil)
         (timed-out nil)
@@ -431,7 +417,7 @@ CAPTURE-MESSAGES, INCLUDE-BACKTRACE, and TIMEOUT-MS."
       (ai-code-mcp-editor-tools--encode-eval-result
        mode
        target-buffer
-       (ai-code-mcp-editor-tools--message-lines)
+       (ai-code-mcp--message-lines)
        capture-messages
        nil
        nil
@@ -454,11 +440,11 @@ CAPTURE-MESSAGES, INCLUDE-BACKTRACE, and TIMEOUT-MS."
       (cond
        (always-denied
         (ai-code-mcp-editor-tools--encode-eval-result
-         mode
-         target-buffer
-         (ai-code-mcp-editor-tools--message-lines)
-         capture-messages
-         nil
+        mode
+        target-buffer
+        (ai-code-mcp--message-lines)
+        capture-messages
+        nil
          nil
          '()
          (ai-code-mcp-editor-tools--error-alist
@@ -468,11 +454,11 @@ CAPTURE-MESSAGES, INCLUDE-BACKTRACE, and TIMEOUT-MS."
          nil))
        (query-denied
         (ai-code-mcp-editor-tools--encode-eval-result
-         mode
-         target-buffer
-         (ai-code-mcp-editor-tools--message-lines)
-         capture-messages
-         nil
+        mode
+        target-buffer
+        (ai-code-mcp--message-lines)
+        capture-messages
+        nil
          nil
          '()
          (ai-code-mcp-editor-tools--error-alist
@@ -483,11 +469,11 @@ CAPTURE-MESSAGES, INCLUDE-BACKTRACE, and TIMEOUT-MS."
        ((and (string= mode "effect")
              (not ai-code-mcp-editor-tools-allow-effect-eval))
         (ai-code-mcp-editor-tools--encode-eval-result
-         mode
-         target-buffer
-         (ai-code-mcp-editor-tools--message-lines)
-         capture-messages
-         nil
+        mode
+        target-buffer
+        (ai-code-mcp--message-lines)
+        capture-messages
+        nil
          nil
          '()
          (ai-code-mcp-editor-tools--error-alist

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -14,7 +14,6 @@
 (require 'cl-lib)
 (require 'json)
 (require 'imenu)
-(require 'nadvice)
 (require 'project)
 (require 'seq)
 (require 'subr-x)
@@ -83,12 +82,6 @@ Use `auto' to prefer Flycheck and then Flymake when available."
 (defvar ai-code-mcp--current-session-id nil
   "Dynamically bound MCP session id for the current tool invocation.")
 
-(defvar ai-code-mcp--last-error-record nil
-  "Most recent Emacs error snapshot recorded for MCP diagnostics tools.")
-
-(defvar ai-code-mcp--error-capture-installed nil
-  "Non-nil when MCP error capture advice has been installed.")
-
 (defconst ai-code-mcp--protocol-version "2024-11-05"
   "Protocol version reported by the MCP core.")
 
@@ -126,45 +119,6 @@ Use `auto' to prefer Flycheck and then Flymake when available."
      :name "get_project_buffers"
      :description "List open buffers that belong to the current project."
      :args nil)
-    (:function ai-code-mcp-get-variable-binding-info
-     :name "get_variable_binding_info"
-     :description "Get current and default binding details for an Emacs variable."
-     :args ((:name "variable_name"
-             :type string
-             :description "Emacs variable name to inspect.")
-            (:name "buffer_name"
-             :type string
-             :description "Optional buffer name used for buffer-local inspection."
-             :optional t)))
-    (:function ai-code-mcp-get-variable-value
-     :name "get_variable_value"
-     :description "Get the printed representation of an Emacs variable value by name."
-     :args ((:name "variable_name"
-             :type string
-             :description "Emacs variable name to inspect.")))
-    (:function ai-code-mcp-get-function-info
-     :name "get_function_info"
-     :description "Get metadata about an Emacs function by name."
-     :args ((:name "function_name"
-             :type string
-             :description "Emacs function name to inspect.")))
-    (:function ai-code-mcp-get-last-error-backtrace
-     :name "get_last_error_backtrace"
-     :description "Get the most recently recorded Emacs error backtrace."
-     :args nil)
-    (:function ai-code-mcp-get-feature-load-state
-     :name "get_feature_load_state"
-     :description "Get load state details for an Emacs feature."
-     :args ((:name "feature_name"
-             :type string
-             :description "Emacs feature name to inspect.")))
-    (:function ai-code-mcp-get-recent-messages
-     :name "get_recent_messages"
-     :description "Get recent entries from the Emacs *Messages* buffer."
-     :args ((:name "limit"
-             :type integer
-             :description "Maximum number of messages to return."
-             :optional t)))
     (:function ai-code-mcp-notify-user
      :name "notify_user"
      :description "Show a notification to the Emacs user."
@@ -224,12 +178,6 @@ The default tool list includes:
 - `get_diagnostics'
 - `get_project_files'
 - `get_project_buffers'
-- `get_variable_binding_info'
-- `get_variable_value'
-- `get_function_info'
-- `get_last_error_backtrace'
-- `get_feature_load_state'
-- `get_recent_messages'
 - `notify_user'
 - `imenu_list_symbols'
 - `xref_find_references'
@@ -314,7 +262,6 @@ Required keys are `:function', `:name', and `:description'."
   (interactive)
   (dolist (tool ai-code-mcp--builtin-tool-specs)
     (apply #'ai-code-mcp-make-tool tool))
-  (ai-code-mcp--ensure-error-capture)
   (dolist (setup-fn ai-code-mcp-server-tool-setup-functions)
     (funcall setup-fn)))
 
@@ -861,267 +808,7 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
   (beep)
   (format "Notified user: %s" message-text))
 
-(defun ai-code-mcp--json-bool (value)
-  "Return VALUE as a JSON boolean token."
-  (if value t :json-false))
-
-(defun ai-code-mcp--message-lines ()
-  "Return the current `*Messages*' contents as a list of lines."
-  (if-let ((buffer (get-buffer "*Messages*")))
-      (with-current-buffer buffer
-        (split-string (buffer-substring-no-properties (point-min) (point-max))
-                      "\n"
-                      t))
-    '()))
-
-(defun ai-code-mcp--documentation-summary (documentation)
-  "Return a trimmed summary line for DOCUMENTATION."
-  (if (stringp documentation)
-      (string-trim (car (split-string documentation "\n" t)))
-    ""))
-
-(defun ai-code-mcp--resolve-buffer (buffer-name)
-  "Return BUFFER-NAME when it names a live buffer, or the current buffer."
-  (if buffer-name
-      (or (get-buffer buffer-name)
-          (error "Buffer not found: %s" buffer-name))
-    (current-buffer)))
-
-(defun ai-code-mcp--backtrace-frame-summary (frame)
-  "Return a readable summary string for backtrace FRAME."
-  (let ((function (nth 1 frame))
-        (arguments (nth 2 frame)))
-    (if arguments
-        (format "%S %S" function arguments)
-      (format "%S" function))))
-
-(defun ai-code-mcp--capture-backtrace-summaries ()
-  "Return the current backtrace as a list of summary strings."
-  (mapcar #'ai-code-mcp--backtrace-frame-summary
-          (backtrace-frames)))
-
-(defun ai-code-mcp--error-message (data)
-  "Return a friendly error message string for DATA."
-  (condition-case nil
-      (error-message-string data)
-    (error
-     (format "%S" data))))
-
-(defun ai-code-mcp--record-command-error (data context signal)
-  "Record the command error DATA, CONTEXT, and SIGNAL for MCP tools."
-  (let ((frames (ai-code-mcp--capture-backtrace-summaries)))
-    (setq ai-code-mcp--last-error-record
-          `((error_symbol . ,(symbol-name (car data)))
-            (error_message . ,(ai-code-mcp--error-message data))
-            (context . ,(format "%s" context))
-            (signal . ,signal)
-            (timestamp . ,(format-time-string "%Y-%m-%dT%H:%M:%S%z"))
-            (frame_count . ,(length frames))
-            (frames . ,frames)))))
-
-(defun ai-code-mcp--ensure-error-capture ()
-  "Install error capture advice once for MCP debugging tools."
-  (unless ai-code-mcp--error-capture-installed
-    (advice-add 'command-error-default-function
-                :before
-                #'ai-code-mcp--record-command-error)
-    (setq ai-code-mcp--error-capture-installed t)))
-
-(defun ai-code-mcp--find-existing-variable-symbol (variable-name)
-  "Return the interned symbol for VARIABLE-NAME, or nil when missing."
-  (and (stringp variable-name)
-       (intern-soft variable-name)))
-
-(defun ai-code-mcp-get-variable-binding-info (variable-name &optional buffer-name)
-  "Return JSON binding details for VARIABLE-NAME in BUFFER-NAME."
-  (let ((symbol (ai-code-mcp--find-existing-variable-symbol variable-name)))
-    (if (not symbol)
-        (json-encode
-         `((exists . :json-false)
-           (variable_name . ,variable-name)
-           (buffer_name . ,buffer-name)
-           (bound . :json-false)
-           (default_bound . :json-false)
-           (buffer_local . :json-false)
-           (current_value_repr . nil)
-           (default_value_repr . nil)
-           (documentation_summary . nil)))
-      (with-current-buffer (ai-code-mcp--resolve-buffer buffer-name)
-        (let ((bound (boundp symbol))
-              (default-bound (default-boundp symbol))
-              (buffer-local (local-variable-p symbol (current-buffer))))
-          (json-encode
-           `((exists . t)
-             (variable_name . ,variable-name)
-             (buffer_name . ,(buffer-name (current-buffer)))
-             (bound . ,(ai-code-mcp--json-bool bound))
-             (default_bound . ,(ai-code-mcp--json-bool default-bound))
-             (buffer_local . ,(ai-code-mcp--json-bool buffer-local))
-             (current_value_repr . ,(and bound
-                                         (format "%S" (symbol-value symbol))))
-             (default_value_repr . ,(and default-bound
-                                         (format "%S" (default-value symbol))))
-             (documentation_summary
-              . ,(ai-code-mcp--documentation-summary
-                  (documentation-property symbol
-                                          'variable-documentation
-                                          t))))))))))
-
-(defun ai-code-mcp-get-variable-value (variable-name)
-  "Return the printed representation of VARIABLE-NAME.
-Return a friendly error string when VARIABLE-NAME does not name an
-existing bound variable."
-  (let ((symbol (ai-code-mcp--find-existing-variable-symbol variable-name)))
-    (cond
-     ((not symbol)
-      (format "Variable not found: %s" variable-name))
-     ((not (boundp symbol))
-      (format "Variable is unbound: %s" variable-name))
-     (t
-      (format "%S" (symbol-value symbol))))))
-
-(defun ai-code-mcp--find-existing-function-symbol (function-name)
-  "Return the interned symbol for FUNCTION-NAME, or nil when missing."
-  (and (stringp function-name)
-       (intern-soft function-name)))
-
-(defun ai-code-mcp--function-advised-p (symbol)
-  "Return non-nil when SYMBOL has active advice."
-  (let (advised)
-    (advice-mapc (lambda (&rest _args)
-                   (setq advised t))
-                 symbol)
-    advised))
-
-(defun ai-code-mcp--function-root-definition (symbol)
-  "Return SYMBOL's root definition with advice wrappers removed."
-  (let ((definition (advice--symbol-function symbol)))
-    (if (advice--p definition)
-        (advice--cd*r definition)
-      definition)))
-
-(defun ai-code-mcp--function-kind (symbol)
-  "Return a string describing SYMBOL's callable kind."
-  (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
-         (resolved-definition (if (symbolp root-definition)
-                                  (indirect-function root-definition)
-                                (indirect-function symbol))))
-    (cond
-     ((macrop symbol) "macro")
-     ((autoloadp root-definition) "autoload")
-     ((subrp resolved-definition) "subr")
-     ((or (functionp resolved-definition)
-          (and (consp resolved-definition)
-               (memq (car resolved-definition) '(lambda closure))))
-      "lambda")
-     (t "unknown"))))
-
-(defun ai-code-mcp-get-function-info (function-name)
-  "Return JSON metadata describing FUNCTION-NAME."
-  (let ((symbol (ai-code-mcp--find-existing-function-symbol function-name)))
-    (if (not (and symbol (fboundp symbol)))
-        (json-encode
-         `((exists . :json-false)
-           (function_name . ,function-name)
-           (kind . nil)
-           (interactive . :json-false)
-           (advised . :json-false)
-           (aliased_to . nil)
-           (source_file . nil)
-           (documentation_summary . nil)))
-      (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
-             (aliased-to (and (symbolp root-definition)
-                              (symbol-name root-definition))))
-        (json-encode
-         `((exists . t)
-           (function_name . ,function-name)
-           (kind . ,(ai-code-mcp--function-kind symbol))
-           (interactive . ,(ai-code-mcp--json-bool (commandp symbol)))
-           (advised . ,(ai-code-mcp--json-bool
-                        (ai-code-mcp--function-advised-p symbol)))
-           (aliased_to . ,aliased-to)
-           (source_file . ,(symbol-file symbol 'defun))
-           (documentation_summary
-            . ,(ai-code-mcp--documentation-summary
-                (documentation symbol t)))))))))
-
-(defun ai-code-mcp--last-error-json-payload (record)
-  "Return a JSON-ready payload for a recorded error RECORD."
-  `((recorded . t)
-    (error_symbol . ,(alist-get 'error_symbol record))
-    (error_message . ,(alist-get 'error_message record))
-    (context . ,(alist-get 'context record))
-    (signal . ,(ai-code-mcp--json-bool (alist-get 'signal record)))
-    (timestamp . ,(alist-get 'timestamp record))
-    (frame_count . ,(alist-get 'frame_count record))
-    (frames . ,(vconcat (alist-get 'frames record)))))
-
-(defun ai-code-mcp--empty-last-error-json-payload ()
-  "Return a JSON-ready payload when no error has been recorded."
-  `((recorded . :json-false)
-    (error_symbol . nil)
-    (error_message . nil)
-    (context . nil)
-    (signal . :json-false)
-    (timestamp . nil)
-    (frame_count . 0)
-    (frames . nil)))
-
-(defun ai-code-mcp-get-last-error-backtrace ()
-  "Return a JSON snapshot of the most recently recorded Emacs error."
-  (json-encode
-   (if ai-code-mcp--last-error-record
-       (ai-code-mcp--last-error-json-payload ai-code-mcp--last-error-record)
-     (ai-code-mcp--empty-last-error-json-payload))))
-
-(defun ai-code-mcp--feature-providers (feature-symbol)
-  "Return `load-history' files that provided FEATURE-SYMBOL."
-  (let (providers)
-    (dolist (entry load-history (delete-dups (nreverse providers)))
-      (when (and (car entry)
-                 (member `(provide . ,feature-symbol) (cdr entry)))
-        (push (car entry) providers)))))
-
-(defun ai-code-mcp--feature-library-matches (feature-name)
-  "Return `load-path' files that look like FEATURE-NAME libraries."
-  (let (matches)
-    (dolist (directory load-path (delete-dups (nreverse matches)))
-      (when (stringp directory)
-        (dolist (suffix '(".el" ".elc" ".eln"))
-          (let ((candidate (expand-file-name (concat feature-name suffix)
-                                             directory)))
-            (when (file-exists-p candidate)
-              (push candidate matches))))))))
-
-(defun ai-code-mcp-get-feature-load-state (feature-name)
-  "Return JSON load-state details for FEATURE-NAME."
-  (let* ((feature-symbol (and (stringp feature-name)
-                              (intern-soft feature-name)))
-         (loaded (and feature-symbol (featurep feature-symbol)))
-         (library-path (locate-library feature-name))
-         (providers (and feature-symbol
-                         (ai-code-mcp--feature-providers feature-symbol))))
-    (json-encode
-     `((feature_name . ,feature-name)
-       (loaded . ,(ai-code-mcp--json-bool loaded))
-       (library_path . ,library-path)
-       (provided_by_files . ,(vconcat providers))
-       (load_history_entries . ,(vconcat providers))
-       (load_path_matches
-        . ,(vconcat (ai-code-mcp--feature-library-matches feature-name)))))))
-
-(defun ai-code-mcp-get-recent-messages (&optional limit)
-  "Return a JSON payload for recent messages using LIMIT."
-  (let* ((limit (or limit 50))
-         (messages (ai-code-mcp--message-lines)))
-    (unless (and (integerp limit) (> limit 0))
-      (error "Argument limit must be a positive integer"))
-    (setq messages (last messages (min limit (length messages))))
-    (json-encode
-     `((ok . t)
-       (limit . ,limit)
-       (messages . ,(vconcat messages))))))
-
+(require 'ai-code-mcp-debug-tools nil t)
 (require 'ai-code-mcp-editor-tools nil t)
 
 (provide 'ai-code-mcp-server)

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -13,6 +13,7 @@
 
 (require 'cl-lib)
 (require 'json)
+(require 'ai-code-mcp-common)
 (require 'imenu)
 (require 'project)
 (require 'seq)
@@ -72,9 +73,6 @@ Use `auto' to prefer Flycheck and then Flymake when available."
                  (const :tag "Flycheck" flycheck)
                  (const :tag "Flymake" flymake))
   :group 'ai-code-mcp-server)
-
-(defvar ai-code-mcp-server-tool-setup-functions nil
-  "Functions that register optional MCP tool groups.")
 
 (defvar ai-code-mcp--sessions (make-hash-table :test 'equal)
   "Hash table mapping MCP session ids to session metadata.")

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -14,6 +14,7 @@
 (require 'cl-lib)
 (require 'json)
 (require 'imenu)
+(require 'nadvice)
 (require 'project)
 (require 'seq)
 (require 'subr-x)
@@ -82,6 +83,12 @@ Use `auto' to prefer Flycheck and then Flymake when available."
 (defvar ai-code-mcp--current-session-id nil
   "Dynamically bound MCP session id for the current tool invocation.")
 
+(defvar ai-code-mcp--last-error-record nil
+  "Most recent Emacs error snapshot recorded for MCP diagnostics tools.")
+
+(defvar ai-code-mcp--error-capture-installed nil
+  "Non-nil when MCP error capture advice has been installed.")
+
 (defconst ai-code-mcp--protocol-version "2024-11-05"
   "Protocol version reported by the MCP core.")
 
@@ -119,12 +126,45 @@ Use `auto' to prefer Flycheck and then Flymake when available."
      :name "get_project_buffers"
      :description "List open buffers that belong to the current project."
      :args nil)
+    (:function ai-code-mcp-get-variable-binding-info
+     :name "get_variable_binding_info"
+     :description "Get current and default binding details for an Emacs variable."
+     :args ((:name "variable_name"
+             :type string
+             :description "Emacs variable name to inspect.")
+            (:name "buffer_name"
+             :type string
+             :description "Optional buffer name used for buffer-local inspection."
+             :optional t)))
     (:function ai-code-mcp-get-variable-value
      :name "get_variable_value"
      :description "Get the printed representation of an Emacs variable value by name."
      :args ((:name "variable_name"
              :type string
              :description "Emacs variable name to inspect.")))
+    (:function ai-code-mcp-get-function-info
+     :name "get_function_info"
+     :description "Get metadata about an Emacs function by name."
+     :args ((:name "function_name"
+             :type string
+             :description "Emacs function name to inspect.")))
+    (:function ai-code-mcp-get-last-error-backtrace
+     :name "get_last_error_backtrace"
+     :description "Get the most recently recorded Emacs error backtrace."
+     :args nil)
+    (:function ai-code-mcp-get-feature-load-state
+     :name "get_feature_load_state"
+     :description "Get load state details for an Emacs feature."
+     :args ((:name "feature_name"
+             :type string
+             :description "Emacs feature name to inspect.")))
+    (:function ai-code-mcp-get-recent-messages
+     :name "get_recent_messages"
+     :description "Get recent entries from the Emacs *Messages* buffer."
+     :args ((:name "limit"
+             :type integer
+             :description "Maximum number of messages to return."
+             :optional t)))
     (:function ai-code-mcp-notify-user
      :name "notify_user"
      :description "Show a notification to the Emacs user."
@@ -184,7 +224,12 @@ The default tool list includes:
 - `get_diagnostics'
 - `get_project_files'
 - `get_project_buffers'
+- `get_variable_binding_info'
 - `get_variable_value'
+- `get_function_info'
+- `get_last_error_backtrace'
+- `get_feature_load_state'
+- `get_recent_messages'
 - `notify_user'
 - `imenu_list_symbols'
 - `xref_find_references'
@@ -269,6 +314,7 @@ Required keys are `:function', `:name', and `:description'."
   (interactive)
   (dolist (tool ai-code-mcp--builtin-tool-specs)
     (apply #'ai-code-mcp-make-tool tool))
+  (ai-code-mcp--ensure-error-capture)
   (dolist (setup-fn ai-code-mcp-server-tool-setup-functions)
     (funcall setup-fn)))
 
@@ -815,10 +861,111 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
   (beep)
   (format "Notified user: %s" message-text))
 
+(defun ai-code-mcp--json-bool (value)
+  "Return VALUE as a JSON boolean token."
+  (if value t :json-false))
+
+(defun ai-code-mcp--message-lines ()
+  "Return the current `*Messages*' contents as a list of lines."
+  (if-let ((buffer (get-buffer "*Messages*")))
+      (with-current-buffer buffer
+        (split-string (buffer-substring-no-properties (point-min) (point-max))
+                      "\n"
+                      t))
+    '()))
+
+(defun ai-code-mcp--documentation-summary (documentation)
+  "Return a trimmed summary line for DOCUMENTATION."
+  (if (stringp documentation)
+      (string-trim (car (split-string documentation "\n" t)))
+    ""))
+
+(defun ai-code-mcp--resolve-buffer (buffer-name)
+  "Return BUFFER-NAME when it names a live buffer, or the current buffer."
+  (if buffer-name
+      (or (get-buffer buffer-name)
+          (error "Buffer not found: %s" buffer-name))
+    (current-buffer)))
+
+(defun ai-code-mcp--backtrace-frame-summary (frame)
+  "Return a readable summary string for backtrace FRAME."
+  (let ((function (nth 1 frame))
+        (arguments (nth 2 frame)))
+    (if arguments
+        (format "%S %S" function arguments)
+      (format "%S" function))))
+
+(defun ai-code-mcp--capture-backtrace-summaries ()
+  "Return the current backtrace as a list of summary strings."
+  (mapcar #'ai-code-mcp--backtrace-frame-summary
+          (backtrace-frames)))
+
+(defun ai-code-mcp--error-message (data)
+  "Return a friendly error message string for DATA."
+  (condition-case nil
+      (error-message-string data)
+    (error
+     (format "%S" data))))
+
+(defun ai-code-mcp--record-command-error (data context signal)
+  "Record the command error DATA, CONTEXT, and SIGNAL for MCP tools."
+  (let ((frames (ai-code-mcp--capture-backtrace-summaries)))
+    (setq ai-code-mcp--last-error-record
+          `((error_symbol . ,(symbol-name (car data)))
+            (error_message . ,(ai-code-mcp--error-message data))
+            (context . ,(format "%s" context))
+            (signal . ,signal)
+            (timestamp . ,(format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+            (frame_count . ,(length frames))
+            (frames . ,frames)))))
+
+(defun ai-code-mcp--ensure-error-capture ()
+  "Install error capture advice once for MCP debugging tools."
+  (unless ai-code-mcp--error-capture-installed
+    (advice-add 'command-error-default-function
+                :before
+                #'ai-code-mcp--record-command-error)
+    (setq ai-code-mcp--error-capture-installed t)))
+
 (defun ai-code-mcp--find-existing-variable-symbol (variable-name)
   "Return the interned symbol for VARIABLE-NAME, or nil when missing."
   (and (stringp variable-name)
        (intern-soft variable-name)))
+
+(defun ai-code-mcp-get-variable-binding-info (variable-name &optional buffer-name)
+  "Return JSON binding details for VARIABLE-NAME in BUFFER-NAME."
+  (let ((symbol (ai-code-mcp--find-existing-variable-symbol variable-name)))
+    (if (not symbol)
+        (json-encode
+         `((exists . :json-false)
+           (variable_name . ,variable-name)
+           (buffer_name . ,buffer-name)
+           (bound . :json-false)
+           (default_bound . :json-false)
+           (buffer_local . :json-false)
+           (current_value_repr . nil)
+           (default_value_repr . nil)
+           (documentation_summary . nil)))
+      (with-current-buffer (ai-code-mcp--resolve-buffer buffer-name)
+        (let ((bound (boundp symbol))
+              (default-bound (default-boundp symbol))
+              (buffer-local (local-variable-p symbol (current-buffer))))
+          (json-encode
+           `((exists . t)
+             (variable_name . ,variable-name)
+             (buffer_name . ,(buffer-name (current-buffer)))
+             (bound . ,(ai-code-mcp--json-bool bound))
+             (default_bound . ,(ai-code-mcp--json-bool default-bound))
+             (buffer_local . ,(ai-code-mcp--json-bool buffer-local))
+             (current_value_repr . ,(and bound
+                                         (format "%S" (symbol-value symbol))))
+             (default_value_repr . ,(and default-bound
+                                         (format "%S" (default-value symbol))))
+             (documentation_summary
+              . ,(ai-code-mcp--documentation-summary
+                  (documentation-property symbol
+                                          'variable-documentation
+                                          t))))))))))
 
 (defun ai-code-mcp-get-variable-value (variable-name)
   "Return the printed representation of VARIABLE-NAME.
@@ -832,6 +979,148 @@ existing bound variable."
       (format "Variable is unbound: %s" variable-name))
      (t
       (format "%S" (symbol-value symbol))))))
+
+(defun ai-code-mcp--find-existing-function-symbol (function-name)
+  "Return the interned symbol for FUNCTION-NAME, or nil when missing."
+  (and (stringp function-name)
+       (intern-soft function-name)))
+
+(defun ai-code-mcp--function-advised-p (symbol)
+  "Return non-nil when SYMBOL has active advice."
+  (let (advised)
+    (advice-mapc (lambda (&rest _args)
+                   (setq advised t))
+                 symbol)
+    advised))
+
+(defun ai-code-mcp--function-root-definition (symbol)
+  "Return SYMBOL's root definition with advice wrappers removed."
+  (let ((definition (advice--symbol-function symbol)))
+    (if (advice--p definition)
+        (advice--cd*r definition)
+      definition)))
+
+(defun ai-code-mcp--function-kind (symbol)
+  "Return a string describing SYMBOL's callable kind."
+  (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
+         (resolved-definition (if (symbolp root-definition)
+                                  (indirect-function root-definition)
+                                (indirect-function symbol))))
+    (cond
+     ((macrop symbol) "macro")
+     ((autoloadp root-definition) "autoload")
+     ((subrp resolved-definition) "subr")
+     ((or (functionp resolved-definition)
+          (and (consp resolved-definition)
+               (memq (car resolved-definition) '(lambda closure))))
+      "lambda")
+     (t "unknown"))))
+
+(defun ai-code-mcp-get-function-info (function-name)
+  "Return JSON metadata describing FUNCTION-NAME."
+  (let ((symbol (ai-code-mcp--find-existing-function-symbol function-name)))
+    (if (not (and symbol (fboundp symbol)))
+        (json-encode
+         `((exists . :json-false)
+           (function_name . ,function-name)
+           (kind . nil)
+           (interactive . :json-false)
+           (advised . :json-false)
+           (aliased_to . nil)
+           (source_file . nil)
+           (documentation_summary . nil)))
+      (let* ((root-definition (ai-code-mcp--function-root-definition symbol))
+             (aliased-to (and (symbolp root-definition)
+                              (symbol-name root-definition))))
+        (json-encode
+         `((exists . t)
+           (function_name . ,function-name)
+           (kind . ,(ai-code-mcp--function-kind symbol))
+           (interactive . ,(ai-code-mcp--json-bool (commandp symbol)))
+           (advised . ,(ai-code-mcp--json-bool
+                        (ai-code-mcp--function-advised-p symbol)))
+           (aliased_to . ,aliased-to)
+           (source_file . ,(symbol-file symbol 'defun))
+           (documentation_summary
+            . ,(ai-code-mcp--documentation-summary
+                (documentation symbol t)))))))))
+
+(defun ai-code-mcp--last-error-json-payload (record)
+  "Return a JSON-ready payload for a recorded error RECORD."
+  `((recorded . t)
+    (error_symbol . ,(alist-get 'error_symbol record))
+    (error_message . ,(alist-get 'error_message record))
+    (context . ,(alist-get 'context record))
+    (signal . ,(ai-code-mcp--json-bool (alist-get 'signal record)))
+    (timestamp . ,(alist-get 'timestamp record))
+    (frame_count . ,(alist-get 'frame_count record))
+    (frames . ,(vconcat (alist-get 'frames record)))))
+
+(defun ai-code-mcp--empty-last-error-json-payload ()
+  "Return a JSON-ready payload when no error has been recorded."
+  `((recorded . :json-false)
+    (error_symbol . nil)
+    (error_message . nil)
+    (context . nil)
+    (signal . :json-false)
+    (timestamp . nil)
+    (frame_count . 0)
+    (frames . nil)))
+
+(defun ai-code-mcp-get-last-error-backtrace ()
+  "Return a JSON snapshot of the most recently recorded Emacs error."
+  (json-encode
+   (if ai-code-mcp--last-error-record
+       (ai-code-mcp--last-error-json-payload ai-code-mcp--last-error-record)
+     (ai-code-mcp--empty-last-error-json-payload))))
+
+(defun ai-code-mcp--feature-providers (feature-symbol)
+  "Return `load-history' files that provided FEATURE-SYMBOL."
+  (let (providers)
+    (dolist (entry load-history (delete-dups (nreverse providers)))
+      (when (and (car entry)
+                 (member `(provide . ,feature-symbol) (cdr entry)))
+        (push (car entry) providers)))))
+
+(defun ai-code-mcp--feature-library-matches (feature-name)
+  "Return `load-path' files that look like FEATURE-NAME libraries."
+  (let (matches)
+    (dolist (directory load-path (delete-dups (nreverse matches)))
+      (when (stringp directory)
+        (dolist (suffix '(".el" ".elc" ".eln"))
+          (let ((candidate (expand-file-name (concat feature-name suffix)
+                                             directory)))
+            (when (file-exists-p candidate)
+              (push candidate matches))))))))
+
+(defun ai-code-mcp-get-feature-load-state (feature-name)
+  "Return JSON load-state details for FEATURE-NAME."
+  (let* ((feature-symbol (and (stringp feature-name)
+                              (intern-soft feature-name)))
+         (loaded (and feature-symbol (featurep feature-symbol)))
+         (library-path (locate-library feature-name))
+         (providers (and feature-symbol
+                         (ai-code-mcp--feature-providers feature-symbol))))
+    (json-encode
+     `((feature_name . ,feature-name)
+       (loaded . ,(ai-code-mcp--json-bool loaded))
+       (library_path . ,library-path)
+       (provided_by_files . ,(vconcat providers))
+       (load_history_entries . ,(vconcat providers))
+       (load_path_matches
+        . ,(vconcat (ai-code-mcp--feature-library-matches feature-name)))))))
+
+(defun ai-code-mcp-get-recent-messages (&optional limit)
+  "Return a JSON payload for recent messages using LIMIT."
+  (let* ((limit (or limit 50))
+         (messages (ai-code-mcp--message-lines)))
+    (unless (and (integerp limit) (> limit 0))
+      (error "Argument limit must be a positive integer"))
+    (setq messages (last messages (min limit (length messages))))
+    (json-encode
+     `((ok . t)
+       (limit . ,limit)
+       (messages . ,(vconcat messages))))))
 
 (require 'ai-code-mcp-editor-tools nil t)
 

--- a/test/test_ai-code-mcp-debug-tools.el
+++ b/test/test_ai-code-mcp-debug-tools.el
@@ -1,0 +1,325 @@
+;;; test_ai-code-mcp-debug-tools.el --- Tests for ai-code-mcp-debug-tools -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for optional MCP debugging tools.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(unless (featurep 'magit)
+  (defun magit-toplevel (&optional _dir) nil)
+  (defun magit-get-current-branch () nil)
+  (defun magit-git-lines (&rest _args) nil)
+  (provide 'magit))
+
+(require 'ai-code-mcp-server nil t)
+(require 'ai-code-mcp-debug-tools nil t)
+
+(defun ai-code-test-mcp-debug-tools--content-text (result)
+  "Extract text content from RESULT."
+  (alist-get 'text
+             (car (alist-get 'content result))))
+
+(defun ai-code-test-mcp-debug-tools--read-json-payload (result)
+  "Decode the JSON text content from RESULT."
+  (let ((json-object-type 'alist)
+        (json-array-type 'vector)
+        (json-key-type 'symbol))
+    (json-read-from-string
+     (ai-code-test-mcp-debug-tools--content-text result))))
+
+(defconst ai-code-test-mcp-debug-tools--tool-names
+  '("get_feature_load_state"
+    "get_function_info"
+    "get_last_error_backtrace"
+    "get_recent_messages"
+    "get_variable_binding_info"
+    "get_variable_value")
+  "Expected MCP debug tool names.")
+
+(ert-deftest ai-code-test-mcp-debug-tools-register-by-default ()
+  "Optional debug tools should register by default."
+  (let ((ai-code-mcp-server-tools nil))
+    (should ai-code-mcp-debug-tools-enabled)
+    (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
+           (tool-names (sort (mapcar (lambda (tool)
+                                       (alist-get 'name tool))
+                                     (alist-get 'tools tools-result))
+                             #'string<)))
+      (dolist (tool-name ai-code-test-mcp-debug-tools--tool-names)
+        (should (member tool-name tool-names))))))
+
+(ert-deftest ai-code-test-mcp-debug-tools-skip-registration-when-disabled ()
+  "Optional debug tools should not register when disabled."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled nil))
+    (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
+           (tool-names (sort (mapcar (lambda (tool)
+                                       (alist-get 'name tool))
+                                     (alist-get 'tools tools-result))
+                             #'string<)))
+      (dolist (tool-name ai-code-test-mcp-debug-tools--tool-names)
+        (should-not (member tool-name tool-names))))))
+
+(ert-deftest ai-code-test-mcp-get-variable-value-returns-bound-variable ()
+  "Variable value tool should stringify the requested Emacs variable."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-diagnostics-backend 'flymake))
+    (let ((result (ai-code-mcp-dispatch
+                   "tools/call"
+                   '((name . "get_variable_value")
+                     (arguments . ((variable_name . "ai-code-mcp-diagnostics-backend")))))))
+      (should (equal "flymake"
+                     (ai-code-test-mcp-debug-tools--content-text result))))))
+
+(ert-deftest ai-code-test-mcp-get-variable-value-reports-missing-variable-without-interning ()
+  "Unknown variable names should not be interned and should return a friendly error."
+  (let* ((ai-code-mcp-server-tools nil)
+         (ai-code-mcp-debug-tools-enabled t)
+         (variable-name "ai-code-test-mcp-missing-variable")
+         (result nil))
+    (when (intern-soft variable-name)
+      (ert-fail "Test requires a missing symbol name"))
+    (setq result
+          (ai-code-mcp-dispatch
+           "tools/call"
+           `((name . "get_variable_value")
+             (arguments . ((variable_name . ,variable-name))))))
+    (should (equal (format "Variable not found: %s" variable-name)
+                   (ai-code-test-mcp-debug-tools--content-text result)))
+    (should-not (intern-soft variable-name))))
+
+(ert-deftest ai-code-test-mcp-get-variable-value-reports-unbound-variable ()
+  "Unbound variable names should return a friendly error."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (variable-name "ai-code-test-mcp-unbound-variable"))
+    (unwind-protect
+        (let ((symbol (intern variable-name)))
+          (setplist symbol nil)
+          (makunbound symbol)
+          (let ((result (ai-code-mcp-dispatch
+                         "tools/call"
+                         `((name . "get_variable_value")
+                           (arguments . ((variable_name . ,variable-name)))))))
+            (should (equal (format "Variable is unbound: %s" variable-name)
+                           (ai-code-test-mcp-debug-tools--content-text result)))))
+      (unintern variable-name obarray))))
+
+(ert-deftest ai-code-test-mcp-tools-list-describes-variable-value-as-printed-representation ()
+  "Variable value tool metadata should match the returned representation."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t))
+    (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
+           (variable-tool (seq-find
+                           (lambda (tool)
+                             (equal "get_variable_value" (alist-get 'name tool)))
+                           (alist-get 'tools tools-result))))
+      (should variable-tool)
+      (should (equal "Get the printed representation of an Emacs variable value by name."
+                     (alist-get 'description variable-tool))))))
+
+(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-default-and-local-values ()
+  "Variable binding info should report current and default values."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (variable-name "ai-code-test-mcp-buffer-local-variable")
+        (buffer (generate-new-buffer " *ai-code-mcp-binding-info*")))
+    (unwind-protect
+        (progn
+          (set-default (intern variable-name) 2)
+          (with-current-buffer buffer
+            (setq-local ai-code-test-mcp-buffer-local-variable 8))
+          (let* ((payload
+                  (ai-code-test-mcp-debug-tools--read-json-payload
+                   (ai-code-mcp-dispatch
+                    "tools/call"
+                    `((name . "get_variable_binding_info")
+                      (arguments . ((variable_name . ,variable-name)
+                                    (buffer_name . ,(buffer-name buffer))))))))
+                 (documentation-summary
+                  (alist-get 'documentation_summary payload)))
+            (should (equal t (alist-get 'exists payload)))
+            (should (equal t (alist-get 'buffer_local payload)))
+            (should (equal "8" (alist-get 'current_value_repr payload)))
+            (should (equal "2" (alist-get 'default_value_repr payload)))
+            (should (equal (buffer-name buffer)
+                           (alist-get 'buffer_name payload)))
+            (should (stringp documentation-summary))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (intern-soft variable-name)
+        (unintern variable-name obarray)))))
+
+(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-missing-variable ()
+  "Variable binding info should report a missing variable without interning it."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (variable-name "ai-code-test-mcp-missing-binding-variable"))
+    (when (intern-soft variable-name)
+      (ert-fail "Test requires a missing symbol name"))
+    (let ((payload
+           (ai-code-test-mcp-debug-tools--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_variable_binding_info")
+               (arguments . ((variable_name . ,variable-name))))))))
+      (should (equal :json-false (alist-get 'exists payload)))
+      (should-not (alist-get 'current_value_repr payload))
+      (should-not (intern-soft variable-name)))))
+
+(ert-deftest ai-code-test-mcp-get-function-info-reports-alias-and-advice-state ()
+  "Function info should report alias and advice metadata."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (base-name "ai-code-test-mcp-base-function")
+        (alias-name "ai-code-test-mcp-aliased-function")
+        (advice-name "ai-code-test-mcp-around-advice"))
+    (unwind-protect
+        (progn
+          (fset (intern base-name) (lambda () :ok))
+          (defalias (intern alias-name) (intern base-name))
+          (fset (intern advice-name)
+                (lambda (fn &rest args)
+                  (apply fn args)))
+          (advice-add (intern alias-name) :around (intern advice-name))
+          (let ((payload
+                 (ai-code-test-mcp-debug-tools--read-json-payload
+                  (ai-code-mcp-dispatch
+                   "tools/call"
+                   `((name . "get_function_info")
+                     (arguments . ((function_name . ,alias-name))))))))
+            (should (equal t (alist-get 'exists payload)))
+            (should (equal "lambda" (alist-get 'kind payload)))
+            (should (equal t (alist-get 'advised payload)))
+            (should (equal base-name (alist-get 'aliased_to payload)))))
+      (when (fboundp (intern-soft alias-name))
+        (ignore-errors
+          (advice-remove (intern alias-name) (intern advice-name)))
+        (fmakunbound (intern alias-name)))
+      (when (fboundp (intern-soft base-name))
+        (fmakunbound (intern base-name)))
+      (when (fboundp (intern-soft advice-name))
+        (fmakunbound (intern advice-name)))
+      (when (intern-soft alias-name)
+        (unintern alias-name obarray))
+      (when (intern-soft base-name)
+        (unintern base-name obarray))
+      (when (intern-soft advice-name)
+        (unintern advice-name obarray)))))
+
+(ert-deftest ai-code-test-mcp-get-function-info-reports-missing-functions ()
+  "Function info should report missing function symbols cleanly."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (function-name "ai-code-test-mcp-missing-function"))
+    (when (intern-soft function-name)
+      (ert-fail "Test requires a missing function symbol"))
+    (let ((payload
+           (ai-code-test-mcp-debug-tools--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_function_info")
+               (arguments . ((function_name . ,function-name))))))))
+      (should (equal :json-false (alist-get 'exists payload)))
+      (should-not (intern-soft function-name)))))
+
+(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-loaded-feature-details ()
+  "Feature load state should report loaded features and their providers."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t))
+    (let* ((payload
+            (ai-code-test-mcp-debug-tools--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_feature_load_state")
+                (arguments . ((feature_name . "json")))))))
+           (provided-by-files (append (alist-get 'provided_by_files payload) nil))
+           (load-path-matches (append (alist-get 'load_path_matches payload) nil)))
+      (should (equal t (alist-get 'loaded payload)))
+      (should (stringp (alist-get 'library_path payload)))
+      (should provided-by-files)
+      (should load-path-matches))))
+
+(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-missing-features ()
+  "Feature load state should report missing features without errors."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (feature-name "ai-code-test-mcp-missing-feature"))
+    (when (intern-soft feature-name)
+      (ert-fail "Test requires a missing feature symbol"))
+    (let ((payload
+           (ai-code-test-mcp-debug-tools--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_feature_load_state")
+               (arguments . ((feature_name . ,feature-name))))))))
+      (should (equal :json-false (alist-get 'loaded payload)))
+      (should-not (alist-get 'library_path payload)))))
+
+(ert-deftest ai-code-test-mcp-get-recent-messages-returns-latest-messages ()
+  "Recent messages should return the latest entries from `*Messages*'."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t))
+    (message "ai-code-mcp-server-test-message")
+    (let* ((payload
+            (ai-code-test-mcp-debug-tools--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_recent_messages")
+                (arguments . ((limit . 1)))))))
+           (messages (alist-get 'messages payload)))
+      (should (equal t (alist-get 'ok payload)))
+      (should (= 1 (length messages)))
+      (should (string-match-p "ai-code-mcp-server-test-message"
+                              (aref messages 0))))))
+
+(ert-deftest ai-code-test-mcp-get-last-error-backtrace-reports-empty-state ()
+  "Last error backtrace should report when no error has been captured."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp--last-error-record nil))
+    (let ((payload
+           (ai-code-test-mcp-debug-tools--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             '((name . "get_last_error_backtrace")
+               (arguments . ()))))))
+      (should (equal :json-false (alist-get 'recorded payload)))
+      (should-not (alist-get 'error_message payload))
+      (should-not (alist-get 'frames payload)))))
+
+(ert-deftest ai-code-test-mcp-get-last-error-backtrace-returns-recorded-error ()
+  "Last error backtrace should return the recorded error snapshot."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp--last-error-record nil))
+    (cl-letf (((symbol-function 'backtrace-frames)
+               (lambda (&optional _base)
+                 '((t ai-code-test-mcp-frame-a nil nil)
+                   (t ai-code-test-mcp-frame-b ("x") nil)))))
+      (ai-code-mcp--record-command-error '(error "Boom") 'command t))
+    (let* ((payload
+            (ai-code-test-mcp-debug-tools--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_last_error_backtrace")
+                (arguments . ())))))
+           (frames (append (alist-get 'frames payload) nil)))
+      (should (equal t (alist-get 'recorded payload)))
+      (should (equal "error" (alist-get 'error_symbol payload)))
+      (should (equal "Boom" (alist-get 'error_message payload)))
+      (should (equal "command" (alist-get 'context payload)))
+      (should (= 2 (alist-get 'frame_count payload)))
+      (should (string-match-p "ai-code-test-mcp-frame-a"
+                              (car frames))))))
+
+(provide 'test_ai-code-mcp-debug-tools)
+
+;;; test_ai-code-mcp-debug-tools.el ends here

--- a/test/test_ai-code-mcp-debug-tools.el
+++ b/test/test_ai-code-mcp-debug-tools.el
@@ -48,6 +48,8 @@
     (insert-file-contents "ai-code-mcp-debug-tools.el")
     (goto-char (point-min))
     (should (search-forward "(require 'ai-code-mcp-common" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(require 'seq)" nil t))
     (should-not (search-forward "(defun ai-code-mcp--json-bool" nil t))
     (goto-char (point-min))
     (should-not (search-forward "(defun ai-code-mcp--message-lines" nil t))
@@ -271,6 +273,20 @@
       (should (equal :json-false (alist-get 'exists payload)))
       (should-not (intern-soft function-name)))))
 
+(ert-deftest ai-code-test-mcp-function-kind-does-not-resolve-autoloads ()
+  "Autoload classification should not force indirect resolution."
+  (let ((symbol (make-symbol "ai-code-test-mcp-autoload-function")))
+    (unwind-protect
+        (progn
+          (fset symbol '(autoload "ai-code-test-autoload-lib" nil nil nil))
+          (cl-letf (((symbol-function 'indirect-function)
+                     (lambda (&rest _args)
+                       (ert-fail "autoload classification should not resolve"))))
+            (should (equal "autoload"
+                           (ai-code-mcp--function-kind symbol)))))
+      (when (fboundp symbol)
+        (fmakunbound symbol)))))
+
 (ert-deftest ai-code-test-mcp-get-feature-load-state-reports-loaded-feature-details ()
   "Feature load state should report loaded features and their providers."
   (let ((ai-code-mcp-server-tools nil)
@@ -286,7 +302,8 @@
       (should (equal t (alist-get 'loaded payload)))
       (should (stringp (alist-get 'library_path payload)))
       (should provided-by-files)
-      (should load-path-matches))))
+      (should load-path-matches)
+      (should-not (alist-get 'load_history_entries payload)))))
 
 (ert-deftest ai-code-test-mcp-get-feature-load-state-reports-missing-features ()
   "Feature load state should report missing features without errors."
@@ -303,6 +320,22 @@
                (arguments . ((feature_name . ,feature-name))))))))
       (should (equal :json-false (alist-get 'loaded payload)))
       (should-not (alist-get 'library_path payload)))))
+
+(ert-deftest ai-code-test-mcp-get-feature-load-state-rejects-invalid-feature-name ()
+  "Feature load state should reject non-string feature names clearly."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled t))
+    (let ((payload
+           (ai-code-test-mcp-debug-tools--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             '((name . "get_feature_load_state")
+               (arguments . ((feature_name . 7))))))))
+      (should (equal :json-false (alist-get 'loaded payload)))
+      (should (equal "feature_name must be a non-empty string"
+                     (alist-get 'error_message payload)))
+      (should-not (alist-get 'library_path payload))
+      (should-not (alist-get 'load_path_matches payload)))))
 
 (ert-deftest ai-code-test-mcp-get-recent-messages-returns-latest-messages ()
   "Recent messages should return the latest entries from `*Messages*'."

--- a/test/test_ai-code-mcp-debug-tools.el
+++ b/test/test_ai-code-mcp-debug-tools.el
@@ -42,6 +42,47 @@
     "get_variable_value")
   "Expected MCP debug tool names.")
 
+(ert-deftest ai-code-test-mcp-debug-tools-source-uses-common-module ()
+  "Debug and editor MCP modules should depend on a shared common module."
+  (with-temp-buffer
+    (insert-file-contents "ai-code-mcp-debug-tools.el")
+    (goto-char (point-min))
+    (should (search-forward "(require 'ai-code-mcp-common" nil t))
+    (should-not (search-forward "(defun ai-code-mcp--json-bool" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defun ai-code-mcp--message-lines" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defvar ai-code-mcp-server-tool-setup-functions nil)" nil t)))
+  (with-temp-buffer
+    (insert-file-contents "ai-code-mcp-editor-tools.el")
+    (goto-char (point-min))
+    (should (search-forward "(require 'ai-code-mcp-common" nil t))
+    (should-not (search-forward "(defun ai-code-mcp-editor-tools--json-bool" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defun ai-code-mcp-editor-tools--message-lines" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defvar ai-code-mcp-server-tool-setup-functions nil)" nil t))))
+
+(ert-deftest ai-code-test-mcp-common-module-defines-shared-helpers ()
+  "The shared MCP common module should define the extracted helpers."
+  (with-temp-buffer
+    (insert-file-contents "ai-code-mcp-common.el")
+    (goto-char (point-min))
+    (should (search-forward "(defvar ai-code-mcp-server-tool-setup-functions" nil t))
+    (goto-char (point-min))
+    (should (search-forward "(defun ai-code-mcp--json-bool" nil t))
+    (goto-char (point-min))
+    (should (search-forward "(defun ai-code-mcp--message-lines" nil t))))
+
+(ert-deftest ai-code-test-mcp-server-source-uses-common-module-for-setup-registry ()
+  "The MCP server source should use the shared setup registry declaration."
+  (with-temp-buffer
+    (insert-file-contents "ai-code-mcp-server.el")
+    (goto-char (point-min))
+    (should (search-forward "(require 'ai-code-mcp-common" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defvar ai-code-mcp-server-tool-setup-functions" nil t))))
+
 (ert-deftest ai-code-test-mcp-debug-tools-register-by-default ()
   "Optional debug tools should register by default."
   (let ((ai-code-mcp-server-tools nil))

--- a/test/test_ai-code-mcp-editor-tools.el
+++ b/test/test_ai-code-mcp-editor-tools.el
@@ -38,6 +38,7 @@
 (ert-deftest ai-code-test-mcp-editor-tools-register-when-enabled ()
   "Optional editor tools should be registered when explicitly enabled."
   (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled nil)
         (ai-code-mcp-editor-tools-enabled t))
     (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
            (tool-names (sort (mapcar (lambda (tool)
@@ -50,7 +51,6 @@
                         "get_diagnostics"
                         "get_project_buffers"
                         "get_project_files"
-                        "get_variable_value"
                         "imenu_list_symbols"
                         "messages_tail"
                         "notify_user"

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -26,14 +26,27 @@
   (alist-get 'text
              (car (alist-get 'content result))))
 
+(defun ai-code-test-mcp--read-json-payload (result)
+  "Decode the JSON text content from RESULT."
+  (let ((json-object-type 'alist)
+        (json-array-type 'vector)
+        (json-key-type 'symbol))
+    (json-read-from-string
+     (ai-code-test-mcp--content-text result))))
+
 (cl-defstruct ai-code-test-mcp-mock-diagnostic
   beg end type text backend)
 
 (defconst ai-code-test-mcp--builtin-tool-names
   '("buffer_query"
     "get_diagnostics"
+    "get_feature_load_state"
+    "get_function_info"
+    "get_last_error_backtrace"
     "get_project_buffers"
     "get_project_files"
+    "get_recent_messages"
+    "get_variable_binding_info"
     "get_variable_value"
     "imenu_list_symbols"
     "notify_user"
@@ -135,8 +148,13 @@
                             #'string<)))
        (should (equal '("buffer_query"
                         "get_diagnostics"
+                        "get_feature_load_state"
+                        "get_function_info"
+                        "get_last_error_backtrace"
                         "get_project_buffers"
                         "get_project_files"
+                        "get_recent_messages"
+                        "get_variable_binding_info"
                         "get_variable_value"
                         "imenu_list_symbols"
                         "notify_user"
@@ -233,6 +251,192 @@
       (should variable-tool)
       (should (equal "Get the printed representation of an Emacs variable value by name."
                      (alist-get 'description variable-tool))))))
+
+(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-default-and-local-values ()
+  "Variable binding info should report current and default values."
+  (let ((ai-code-mcp-server-tools nil)
+        (variable-name "ai-code-test-mcp-buffer-local-variable")
+        (buffer (generate-new-buffer " *ai-code-mcp-binding-info*")))
+    (unwind-protect
+        (progn
+          (set-default (intern variable-name) 2)
+          (with-current-buffer buffer
+            (setq-local ai-code-test-mcp-buffer-local-variable 8))
+          (let* ((payload
+                  (ai-code-test-mcp--read-json-payload
+                   (ai-code-mcp-dispatch
+                    "tools/call"
+                    `((name . "get_variable_binding_info")
+                      (arguments . ((variable_name . ,variable-name)
+                                    (buffer_name . ,(buffer-name buffer))))))))
+                 (documentation-summary
+                  (alist-get 'documentation_summary payload)))
+            (should (equal t (alist-get 'exists payload)))
+            (should (equal t (alist-get 'buffer_local payload)))
+            (should (equal "8" (alist-get 'current_value_repr payload)))
+            (should (equal "2" (alist-get 'default_value_repr payload)))
+            (should (equal (buffer-name buffer)
+                           (alist-get 'buffer_name payload)))
+            (should (stringp documentation-summary))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (when (intern-soft variable-name)
+        (unintern variable-name obarray)))))
+
+(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-missing-variable ()
+  "Variable binding info should report a missing variable without interning it."
+  (let ((ai-code-mcp-server-tools nil)
+        (variable-name "ai-code-test-mcp-missing-binding-variable"))
+    (when (intern-soft variable-name)
+      (ert-fail "Test requires a missing symbol name"))
+    (let ((payload
+           (ai-code-test-mcp--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_variable_binding_info")
+               (arguments . ((variable_name . ,variable-name))))))))
+      (should (equal :json-false (alist-get 'exists payload)))
+      (should-not (alist-get 'current_value_repr payload))
+      (should-not (intern-soft variable-name)))))
+
+(ert-deftest ai-code-test-mcp-get-function-info-reports-alias-and-advice-state ()
+  "Function info should report alias and advice metadata."
+  (let ((ai-code-mcp-server-tools nil)
+        (base-name "ai-code-test-mcp-base-function")
+        (alias-name "ai-code-test-mcp-aliased-function")
+        (advice-name "ai-code-test-mcp-around-advice"))
+    (unwind-protect
+        (progn
+          (fset (intern base-name) (lambda () :ok))
+          (defalias (intern alias-name) (intern base-name))
+          (fset (intern advice-name)
+                (lambda (fn &rest args)
+                  (apply fn args)))
+          (advice-add (intern alias-name) :around (intern advice-name))
+          (let ((payload
+                 (ai-code-test-mcp--read-json-payload
+                  (ai-code-mcp-dispatch
+                   "tools/call"
+                   `((name . "get_function_info")
+                     (arguments . ((function_name . ,alias-name))))))))
+            (should (equal t (alist-get 'exists payload)))
+            (should (equal "lambda" (alist-get 'kind payload)))
+            (should (equal t (alist-get 'advised payload)))
+            (should (equal base-name (alist-get 'aliased_to payload)))))
+      (when (fboundp (intern-soft alias-name))
+        (ignore-errors
+          (advice-remove (intern alias-name) (intern advice-name)))
+        (fmakunbound (intern alias-name)))
+      (when (fboundp (intern-soft base-name))
+        (fmakunbound (intern base-name)))
+      (when (fboundp (intern-soft advice-name))
+        (fmakunbound (intern advice-name)))
+      (when (intern-soft alias-name)
+        (unintern alias-name obarray))
+      (when (intern-soft base-name)
+        (unintern base-name obarray))
+      (when (intern-soft advice-name)
+        (unintern advice-name obarray)))))
+
+(ert-deftest ai-code-test-mcp-get-function-info-reports-missing-functions ()
+  "Function info should report missing function symbols cleanly."
+  (let ((ai-code-mcp-server-tools nil)
+        (function-name "ai-code-test-mcp-missing-function"))
+    (when (intern-soft function-name)
+      (ert-fail "Test requires a missing function symbol"))
+    (let ((payload
+           (ai-code-test-mcp--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_function_info")
+               (arguments . ((function_name . ,function-name))))))))
+      (should (equal :json-false (alist-get 'exists payload)))
+      (should-not (intern-soft function-name)))))
+
+(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-loaded-feature-details ()
+  "Feature load state should report loaded features and their providers."
+  (let ((ai-code-mcp-server-tools nil))
+    (let* ((payload
+            (ai-code-test-mcp--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_feature_load_state")
+                (arguments . ((feature_name . "json")))))))
+           (provided-by-files (append (alist-get 'provided_by_files payload) nil))
+           (load-path-matches (append (alist-get 'load_path_matches payload) nil)))
+      (should (equal t (alist-get 'loaded payload)))
+      (should (stringp (alist-get 'library_path payload)))
+      (should provided-by-files)
+      (should load-path-matches))))
+
+(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-missing-features ()
+  "Feature load state should report missing features without errors."
+  (let ((ai-code-mcp-server-tools nil)
+        (feature-name "ai-code-test-mcp-missing-feature"))
+    (when (intern-soft feature-name)
+      (ert-fail "Test requires a missing feature symbol"))
+    (let ((payload
+           (ai-code-test-mcp--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             `((name . "get_feature_load_state")
+               (arguments . ((feature_name . ,feature-name))))))))
+      (should (equal :json-false (alist-get 'loaded payload)))
+      (should-not (alist-get 'library_path payload)))))
+
+(ert-deftest ai-code-test-mcp-get-recent-messages-returns-latest-messages ()
+  "Recent messages should return the latest entries from `*Messages*'."
+  (let ((ai-code-mcp-server-tools nil))
+    (message "ai-code-mcp-server-test-message")
+    (let* ((payload
+            (ai-code-test-mcp--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_recent_messages")
+                (arguments . ((limit . 1)))))))
+           (messages (alist-get 'messages payload)))
+      (should (equal t (alist-get 'ok payload)))
+      (should (= 1 (length messages)))
+      (should (string-match-p "ai-code-mcp-server-test-message"
+                              (aref messages 0))))))
+
+(ert-deftest ai-code-test-mcp-get-last-error-backtrace-reports-empty-state ()
+  "Last error backtrace should report when no error has been captured."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp--last-error-record nil))
+    (let ((payload
+           (ai-code-test-mcp--read-json-payload
+            (ai-code-mcp-dispatch
+             "tools/call"
+             '((name . "get_last_error_backtrace")
+               (arguments . ()))))))
+      (should (equal :json-false (alist-get 'recorded payload)))
+      (should-not (alist-get 'error_message payload))
+      (should-not (alist-get 'frames payload)))))
+
+(ert-deftest ai-code-test-mcp-get-last-error-backtrace-returns-recorded-error ()
+  "Last error backtrace should return the recorded error snapshot."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp--last-error-record nil))
+    (cl-letf (((symbol-function 'backtrace-frames)
+               (lambda (&optional _base)
+                 '((t ai-code-test-mcp-frame-a nil nil)
+                   (t ai-code-test-mcp-frame-b ("x") nil)))))
+      (ai-code-mcp--record-command-error '(error "Boom") 'command t))
+    (let* ((payload
+            (ai-code-test-mcp--read-json-payload
+             (ai-code-mcp-dispatch
+              "tools/call"
+              '((name . "get_last_error_backtrace")
+                (arguments . ())))))
+           (frames (append (alist-get 'frames payload) nil)))
+      (should (equal t (alist-get 'recorded payload)))
+      (should (equal "error" (alist-get 'error_symbol payload)))
+      (should (equal "Boom" (alist-get 'error_message payload)))
+      (should (equal "command" (alist-get 'context payload)))
+      (should (= 2 (alist-get 'frame_count payload)))
+      (should (string-match-p "ai-code-test-mcp-frame-a"
+                              (car frames))))))
 
 (ert-deftest ai-code-test-mcp-tools-list-encodes-empty-input-schema-properties ()
   "No-argument tools should encode empty schema properties as an object."

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -26,28 +26,14 @@
   (alist-get 'text
              (car (alist-get 'content result))))
 
-(defun ai-code-test-mcp--read-json-payload (result)
-  "Decode the JSON text content from RESULT."
-  (let ((json-object-type 'alist)
-        (json-array-type 'vector)
-        (json-key-type 'symbol))
-    (json-read-from-string
-     (ai-code-test-mcp--content-text result))))
-
 (cl-defstruct ai-code-test-mcp-mock-diagnostic
   beg end type text backend)
 
 (defconst ai-code-test-mcp--builtin-tool-names
   '("buffer_query"
     "get_diagnostics"
-    "get_feature_load_state"
-    "get_function_info"
-    "get_last_error_backtrace"
     "get_project_buffers"
     "get_project_files"
-    "get_recent_messages"
-    "get_variable_binding_info"
-    "get_variable_value"
     "imenu_list_symbols"
     "notify_user"
     "project_info"
@@ -139,7 +125,8 @@
 
 (ert-deftest ai-code-test-mcp-builtins-setup-registers-common-tools-once ()
   "Built-in setup should register the common Emacs tools without duplicates."
-  (let ((ai-code-mcp-server-tools nil))
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled nil))
     (ai-code-mcp-builtins-setup)
     (ai-code-mcp-builtins-setup)
     (let ((tool-names (sort (mapcar (lambda (tool)
@@ -148,14 +135,8 @@
                             #'string<)))
        (should (equal '("buffer_query"
                         "get_diagnostics"
-                        "get_feature_load_state"
-                        "get_function_info"
-                        "get_last_error_backtrace"
                         "get_project_buffers"
                         "get_project_files"
-                        "get_recent_messages"
-                        "get_variable_binding_info"
-                        "get_variable_value"
                         "imenu_list_symbols"
                         "notify_user"
                         "project_info"
@@ -166,7 +147,8 @@
 
 (ert-deftest ai-code-test-mcp-tools-list-registers-builtins-by-default ()
   "Tools list should expose built-in tools without manual setup."
-  (let ((ai-code-mcp-server-tools nil))
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp-debug-tools-enabled nil))
     (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
            (tool-names (sort (mapcar (lambda (tool)
                                        (alist-get 'name tool))
@@ -196,247 +178,6 @@
         (should beep-called)
         (should (equal "Notified user: Build finished"
                        (ai-code-test-mcp--content-text result)))))))
-
-(ert-deftest ai-code-test-mcp-get-variable-value-returns-bound-variable ()
-  "Variable value tool should stringify the requested Emacs variable."
-  (let ((ai-code-mcp-server-tools nil)
-        (ai-code-mcp-diagnostics-backend 'flymake))
-    (let ((result (ai-code-mcp-dispatch
-                   "tools/call"
-                   '((name . "get_variable_value")
-                     (arguments . ((variable_name . "ai-code-mcp-diagnostics-backend")))))))
-      (should (equal "flymake"
-                     (ai-code-test-mcp--content-text result))))))
-
-(ert-deftest ai-code-test-mcp-get-variable-value-reports-missing-variable-without-interning ()
-  "Unknown variable names should not be interned and should return a friendly error."
-  (let* ((ai-code-mcp-server-tools nil)
-         (variable-name "ai-code-test-mcp-missing-variable")
-         (result nil))
-    (when (intern-soft variable-name)
-      (ert-fail "Test requires a missing symbol name"))
-    (setq result
-          (ai-code-mcp-dispatch
-           "tools/call"
-           `((name . "get_variable_value")
-             (arguments . ((variable_name . ,variable-name))))))
-    (should (equal (format "Variable not found: %s" variable-name)
-                   (ai-code-test-mcp--content-text result)))
-    (should-not (intern-soft variable-name))))
-
-(ert-deftest ai-code-test-mcp-get-variable-value-reports-unbound-variable ()
-  "Unbound variable names should return a friendly error."
-  (let ((ai-code-mcp-server-tools nil)
-        (variable-name "ai-code-test-mcp-unbound-variable"))
-    (unwind-protect
-        (let ((symbol (intern variable-name)))
-          (setplist symbol nil)
-          (makunbound symbol)
-          (let ((result (ai-code-mcp-dispatch
-                         "tools/call"
-                         `((name . "get_variable_value")
-                           (arguments . ((variable_name . ,variable-name)))))))
-            (should (equal (format "Variable is unbound: %s" variable-name)
-                           (ai-code-test-mcp--content-text result)))))
-      (unintern variable-name obarray))))
-
-(ert-deftest ai-code-test-mcp-tools-list-describes-variable-value-as-printed-representation ()
-  "Variable value tool metadata should match the returned representation."
-  (let ((ai-code-mcp-server-tools nil))
-    (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
-           (variable-tool (seq-find
-                           (lambda (tool)
-                             (equal "get_variable_value" (alist-get 'name tool)))
-                           (alist-get 'tools tools-result))))
-      (should variable-tool)
-      (should (equal "Get the printed representation of an Emacs variable value by name."
-                     (alist-get 'description variable-tool))))))
-
-(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-default-and-local-values ()
-  "Variable binding info should report current and default values."
-  (let ((ai-code-mcp-server-tools nil)
-        (variable-name "ai-code-test-mcp-buffer-local-variable")
-        (buffer (generate-new-buffer " *ai-code-mcp-binding-info*")))
-    (unwind-protect
-        (progn
-          (set-default (intern variable-name) 2)
-          (with-current-buffer buffer
-            (setq-local ai-code-test-mcp-buffer-local-variable 8))
-          (let* ((payload
-                  (ai-code-test-mcp--read-json-payload
-                   (ai-code-mcp-dispatch
-                    "tools/call"
-                    `((name . "get_variable_binding_info")
-                      (arguments . ((variable_name . ,variable-name)
-                                    (buffer_name . ,(buffer-name buffer))))))))
-                 (documentation-summary
-                  (alist-get 'documentation_summary payload)))
-            (should (equal t (alist-get 'exists payload)))
-            (should (equal t (alist-get 'buffer_local payload)))
-            (should (equal "8" (alist-get 'current_value_repr payload)))
-            (should (equal "2" (alist-get 'default_value_repr payload)))
-            (should (equal (buffer-name buffer)
-                           (alist-get 'buffer_name payload)))
-            (should (stringp documentation-summary))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer))
-      (when (intern-soft variable-name)
-        (unintern variable-name obarray)))))
-
-(ert-deftest ai-code-test-mcp-get-variable-binding-info-reports-missing-variable ()
-  "Variable binding info should report a missing variable without interning it."
-  (let ((ai-code-mcp-server-tools nil)
-        (variable-name "ai-code-test-mcp-missing-binding-variable"))
-    (when (intern-soft variable-name)
-      (ert-fail "Test requires a missing symbol name"))
-    (let ((payload
-           (ai-code-test-mcp--read-json-payload
-            (ai-code-mcp-dispatch
-             "tools/call"
-             `((name . "get_variable_binding_info")
-               (arguments . ((variable_name . ,variable-name))))))))
-      (should (equal :json-false (alist-get 'exists payload)))
-      (should-not (alist-get 'current_value_repr payload))
-      (should-not (intern-soft variable-name)))))
-
-(ert-deftest ai-code-test-mcp-get-function-info-reports-alias-and-advice-state ()
-  "Function info should report alias and advice metadata."
-  (let ((ai-code-mcp-server-tools nil)
-        (base-name "ai-code-test-mcp-base-function")
-        (alias-name "ai-code-test-mcp-aliased-function")
-        (advice-name "ai-code-test-mcp-around-advice"))
-    (unwind-protect
-        (progn
-          (fset (intern base-name) (lambda () :ok))
-          (defalias (intern alias-name) (intern base-name))
-          (fset (intern advice-name)
-                (lambda (fn &rest args)
-                  (apply fn args)))
-          (advice-add (intern alias-name) :around (intern advice-name))
-          (let ((payload
-                 (ai-code-test-mcp--read-json-payload
-                  (ai-code-mcp-dispatch
-                   "tools/call"
-                   `((name . "get_function_info")
-                     (arguments . ((function_name . ,alias-name))))))))
-            (should (equal t (alist-get 'exists payload)))
-            (should (equal "lambda" (alist-get 'kind payload)))
-            (should (equal t (alist-get 'advised payload)))
-            (should (equal base-name (alist-get 'aliased_to payload)))))
-      (when (fboundp (intern-soft alias-name))
-        (ignore-errors
-          (advice-remove (intern alias-name) (intern advice-name)))
-        (fmakunbound (intern alias-name)))
-      (when (fboundp (intern-soft base-name))
-        (fmakunbound (intern base-name)))
-      (when (fboundp (intern-soft advice-name))
-        (fmakunbound (intern advice-name)))
-      (when (intern-soft alias-name)
-        (unintern alias-name obarray))
-      (when (intern-soft base-name)
-        (unintern base-name obarray))
-      (when (intern-soft advice-name)
-        (unintern advice-name obarray)))))
-
-(ert-deftest ai-code-test-mcp-get-function-info-reports-missing-functions ()
-  "Function info should report missing function symbols cleanly."
-  (let ((ai-code-mcp-server-tools nil)
-        (function-name "ai-code-test-mcp-missing-function"))
-    (when (intern-soft function-name)
-      (ert-fail "Test requires a missing function symbol"))
-    (let ((payload
-           (ai-code-test-mcp--read-json-payload
-            (ai-code-mcp-dispatch
-             "tools/call"
-             `((name . "get_function_info")
-               (arguments . ((function_name . ,function-name))))))))
-      (should (equal :json-false (alist-get 'exists payload)))
-      (should-not (intern-soft function-name)))))
-
-(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-loaded-feature-details ()
-  "Feature load state should report loaded features and their providers."
-  (let ((ai-code-mcp-server-tools nil))
-    (let* ((payload
-            (ai-code-test-mcp--read-json-payload
-             (ai-code-mcp-dispatch
-              "tools/call"
-              '((name . "get_feature_load_state")
-                (arguments . ((feature_name . "json")))))))
-           (provided-by-files (append (alist-get 'provided_by_files payload) nil))
-           (load-path-matches (append (alist-get 'load_path_matches payload) nil)))
-      (should (equal t (alist-get 'loaded payload)))
-      (should (stringp (alist-get 'library_path payload)))
-      (should provided-by-files)
-      (should load-path-matches))))
-
-(ert-deftest ai-code-test-mcp-get-feature-load-state-reports-missing-features ()
-  "Feature load state should report missing features without errors."
-  (let ((ai-code-mcp-server-tools nil)
-        (feature-name "ai-code-test-mcp-missing-feature"))
-    (when (intern-soft feature-name)
-      (ert-fail "Test requires a missing feature symbol"))
-    (let ((payload
-           (ai-code-test-mcp--read-json-payload
-            (ai-code-mcp-dispatch
-             "tools/call"
-             `((name . "get_feature_load_state")
-               (arguments . ((feature_name . ,feature-name))))))))
-      (should (equal :json-false (alist-get 'loaded payload)))
-      (should-not (alist-get 'library_path payload)))))
-
-(ert-deftest ai-code-test-mcp-get-recent-messages-returns-latest-messages ()
-  "Recent messages should return the latest entries from `*Messages*'."
-  (let ((ai-code-mcp-server-tools nil))
-    (message "ai-code-mcp-server-test-message")
-    (let* ((payload
-            (ai-code-test-mcp--read-json-payload
-             (ai-code-mcp-dispatch
-              "tools/call"
-              '((name . "get_recent_messages")
-                (arguments . ((limit . 1)))))))
-           (messages (alist-get 'messages payload)))
-      (should (equal t (alist-get 'ok payload)))
-      (should (= 1 (length messages)))
-      (should (string-match-p "ai-code-mcp-server-test-message"
-                              (aref messages 0))))))
-
-(ert-deftest ai-code-test-mcp-get-last-error-backtrace-reports-empty-state ()
-  "Last error backtrace should report when no error has been captured."
-  (let ((ai-code-mcp-server-tools nil)
-        (ai-code-mcp--last-error-record nil))
-    (let ((payload
-           (ai-code-test-mcp--read-json-payload
-            (ai-code-mcp-dispatch
-             "tools/call"
-             '((name . "get_last_error_backtrace")
-               (arguments . ()))))))
-      (should (equal :json-false (alist-get 'recorded payload)))
-      (should-not (alist-get 'error_message payload))
-      (should-not (alist-get 'frames payload)))))
-
-(ert-deftest ai-code-test-mcp-get-last-error-backtrace-returns-recorded-error ()
-  "Last error backtrace should return the recorded error snapshot."
-  (let ((ai-code-mcp-server-tools nil)
-        (ai-code-mcp--last-error-record nil))
-    (cl-letf (((symbol-function 'backtrace-frames)
-               (lambda (&optional _base)
-                 '((t ai-code-test-mcp-frame-a nil nil)
-                   (t ai-code-test-mcp-frame-b ("x") nil)))))
-      (ai-code-mcp--record-command-error '(error "Boom") 'command t))
-    (let* ((payload
-            (ai-code-test-mcp--read-json-payload
-             (ai-code-mcp-dispatch
-              "tools/call"
-              '((name . "get_last_error_backtrace")
-                (arguments . ())))))
-           (frames (append (alist-get 'frames payload) nil)))
-      (should (equal t (alist-get 'recorded payload)))
-      (should (equal "error" (alist-get 'error_symbol payload)))
-      (should (equal "Boom" (alist-get 'error_message payload)))
-      (should (equal "command" (alist-get 'context payload)))
-      (should (= 2 (alist-get 'frame_count payload)))
-      (should (string-match-p "ai-code-test-mcp-frame-a"
-                              (car frames))))))
 
 (ert-deftest ai-code-test-mcp-tools-list-encodes-empty-input-schema-properties ()
   "No-argument tools should encode empty schema properties as an object."


### PR DESCRIPTION
## Summary

This PR adds a focused set of Emacs debugging and inspection MCP tools so AI backends can inspect runtime state directly when troubleshooting Emacs Lisp code or package issues.

The main approach is to keep the MCP core transport-agnostic while moving the new debugging functionality into an optional module that is enabled by default. This keeps the server core smaller, makes the debugging surface easier to evolve, and avoids mixing editor-facing tools with debugging-specific probes.

## What Changed

- Add a new optional `ai-code-mcp-debug-tools.el` module for debugging-oriented MCP tools.
- Add `get_variable_value`, `get_variable_binding_info`, `get_function_info`, `get_feature_load_state`, `get_recent_messages`, and `get_last_error_backtrace` as MCP debugging tools.
- Add `ai-code-mcp-debug-tools-enabled`, defaulting to `t`, so the debugging tools can be disabled without affecting the MCP core.
- Keep `ai-code-mcp-server.el` focused on core MCP transport, registration, diagnostics, project navigation, and code-intelligence primitives.
- Move shared MCP helpers into `ai-code-mcp-common.el` to eliminate duplicated helper logic across optional MCP modules.
- Update `ai-code-mcp-editor-tools.el` to consume the shared MCP common helpers instead of duplicating them locally.
- Split tests so core MCP behavior stays in `test/test_ai-code-mcp-server.el` while debug-tool behavior lives in `test/test_ai-code-mcp-debug-tools.el`.
- Add structure tests to ensure the shared/common module is used and the extracted helper duplication does not regress.

## User Impact

- AI backends now have a cleaner MCP surface for debugging Emacs Lisp and package issues.
- Debugging tools are available by default, but can be turned off with `ai-code-mcp-debug-tools-enabled`.
- The MCP module layout is clearer: core server, shared helpers, debug tools, and editor-session tools are now separated by responsibility.

## Testing

- `emacs -Q --batch --eval '(setq load-prefer-newer t)' -L . -L test/stubs -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit`
  - Result: 619 tests run, 606 passed, 0 failed, 13 skipped.
- `emacs -Q --batch -L . -L test/stubs -f batch-byte-compile ai-code-mcp-server.el ai-code-mcp-common.el ai-code-mcp-debug-tools.el ai-code-mcp-editor-tools.el test/test_ai-code-mcp-server.el test/test_ai-code-mcp-debug-tools.el test/test_ai-code-mcp-editor-tools.el`
- `emacs -Q --batch --eval "(progn (require 'checkdoc) (checkdoc-file \"ai-code-mcp-server.el\") (checkdoc-file \"ai-code-mcp-common.el\") (checkdoc-file \"ai-code-mcp-debug-tools.el\") (checkdoc-file \"ai-code-mcp-editor-tools.el\") (checkdoc-file \"test/test_ai-code-mcp-server.el\") (checkdoc-file \"test/test_ai-code-mcp-debug-tools.el\") (checkdoc-file \"test/test_ai-code-mcp-editor-tools.el\"))"`

## Notes for Reviewers

- There are no PR review comments yet on this PR.
- The follow-up refactoring in this branch intentionally keeps `resolve-buffer` behavior split between debug tools and editor tools because the two call sites need different semantics.