### PR TITLE
Chore: Add action intent prompt to TODO implementation flow

### DIFF
--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -364,8 +364,19 @@ ARG is the prefix argument for clipboard context."
                                                region-start-line)))))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
+         ;; Validate scenario before prompting user
+         (_ (unless (or region-text is-comment)
+              (user-error "Current line is not a TODO comment and cannot proceed with `ai-code-implement-todo'.  Please select a TODO comment (not DONE), a region of comments, or activate on a blank line")))
+         (action-intent (completing-read "Select action: "
+                                         '("Code change" "Ask question")
+                                         nil t))
+         (ask-question-p (string= action-intent "Ask question"))
          (prompt-label
           (cond
+           (ask-question-p
+            (if (and clipboard-context (string-match-p "\\S-" clipboard-context))
+                "Question about TODO comment (clipboard context): "
+              "Question about TODO comment: "))
            ((and clipboard-context
                  (string-match-p "\\S-" clipboard-context))
             (cond
@@ -379,6 +390,14 @@ ARG is the prefix argument for clipboard context."
            (t "TODO implementation instruction: ")))
          (initial-input
           (cond
+           ((and ask-question-p region-text)
+            (unless (ai-code--is-comment-block region-text)
+              (user-error "Selected region must be a comment block"))
+            (format "Regarding this TODO comment block in the selected region:\n%s\n%s%s%s"
+                    region-location-line region-text function-context files-context-string))
+           ((and ask-question-p is-comment)
+            (format "Regarding this TODO comment on line %d: '%s'%s%s"
+                    current-line-number current-line function-context files-context-string))
            (region-text
             (unless (ai-code--is-comment-block region-text)
               (user-error "Selected region must be a comment block"))
@@ -389,18 +408,7 @@ ARG is the prefix argument for clipboard context."
            (is-comment
             (format "Please implement code for this requirement comment on line %d: '%s' first. After implementing, keep the comment in place and ensure it begins with a DONE prefix (change TODO to DONE or prepend DONE if needed). If this is a pure new code block, place it after the comment; otherwise keep the existing structure and make corresponding change for the context.%s%s"
                     current-line-number current-line function-context files-context-string))
-           ;; (function-name
-           ;;  (format "Please implement code after all TODO comments in function '%s'. The TODOs are TODO comments. Keep each comment in place and ensure each begins with a DONE prefix (change TODO to DONE or prepend DONE if needed) before adding implementation code after it. Keep the existing code structure and only add code after these marked items.%s"
-           ;;          function-name files-context-string))
-           ;; (t
-           ;;  (format "Please implement code after all TODO comments in file '%s'. The TODOs are TODO comments. Keep each comment in place and ensure each begins with a DONE prefix (change TODO to DONE or prepend DONE if needed) before adding implementation code after it. Keep the existing code structure and only add code after these marked items.%s"
-           ;;          (file-name-nondirectory buffer-file-name) files-context-string))
-           ;; DONE: otherwise, let user know the current line is not a comment and cannot proceed
-           (t
-            (user-error "Current line is not a TODO comment and cannot proceed with `ai-code-implement-todo'.  Please select a TODO comment (not DONE), a region of comments, or activate on a blank line"))))
-         (action-intent (completing-read "Select action: "
-                                         '("Code change" "Ask question")
-                                         nil t))
+           (t "")))
          (prompt (ai-code-read-string prompt-label initial-input))
          (final-prompt
           (concat prompt

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -43,6 +43,10 @@
   "Note: Please make the code change described above for the selected files/directories."
   "Prompt note for code changes scoped to selected files or directories.")
 
+(defconst ai-code-change--ask-question-note
+  "Note: Please only answer the question about the code above, do not make any code changes."
+  "Prompt note for question-only requests without code changes.")
+
 (defun ai-code--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.
 Returns non-nil if LINE starts with one or more comment characters,
@@ -329,6 +333,7 @@ Returns non-nil if handled and the caller should exit."
 (defun ai-code--implement-todo--build-and-send-prompt (arg)
   "Build the TODO implementation prompt and insert it.
 ARG is the prefix argument for clipboard context."
+  ;; DONE: ask user with completing-read before build up prompt, candidate should be 1. Code change; 2. Ask question. Given selection, add suffix to them respectively to indicate AI to make code change, or do not make any code change
   (let* ((clipboard-context (when arg (ai-code--get-clipboard-text)))
          (current-line (string-trim (thing-at-point 'line t)))
          (current-line-number (line-number-at-pos (point)))
@@ -393,13 +398,18 @@ ARG is the prefix argument for clipboard context."
            ;; DONE: otherwise, let user know the current line is not a comment and cannot proceed
            (t
             (user-error "Current line is not a TODO comment and cannot proceed with `ai-code-implement-todo'.  Please select a TODO comment (not DONE), a region of comments, or activate on a blank line"))))
+         (action-intent (completing-read "Select action: "
+                                         '("Code change" "Ask question")
+                                         nil t))
          (prompt (ai-code-read-string prompt-label initial-input))
          (final-prompt
           (concat prompt
                   (when (and clipboard-context
                              (string-match-p "\\S-" clipboard-context))
                     (concat "\n\nClipboard context:\n" clipboard-context))
-                  repo-context-string)))
+                  repo-context-string
+                  (when (string= action-intent "Ask question")
+                    (concat "\n" ai-code-change--ask-question-note)))))
     (ai-code--insert-prompt final-prompt)))
 
 ;;; Flycheck integration

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -401,6 +401,111 @@ is between the function definition and its body."
         (should (stringp captured-prompt))
         (should (string-match-p "do not make any code change" captured-prompt))))))
 
+(ert-deftest ai-code-test-implement-todo-ask-question-no-implement-wording ()
+  "Test that 'Ask question' prompt body does not contain implementation wording."
+  (with-temp-buffer
+    (setq buffer-file-name "test.el")
+    (setq-local comment-start ";")
+    (setq-local comment-end "")
+    (insert ";; TODO: implement feature\n")
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt candidates &rest _args)
+                   (if (and (listp candidates)
+                            (member "Ask question" candidates))
+                       "Ask question"
+                     (if (listp candidates) (car candidates) ""))))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'ai-code--get-function-name-for-comment) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (p) (setq captured-prompt p))))
+
+        (ai-code--implement-todo--build-and-send-prompt nil)
+
+        (should (stringp captured-prompt))
+        ;; Should NOT contain implementation-oriented wording
+        (should-not (string-match-p "Please implement code" captured-prompt))
+        ;; Should contain question-oriented wording
+        (should (string-match-p "TODO comment" captured-prompt))))))
+
+(ert-deftest ai-code-test-implement-todo-code-change-keeps-implement-wording ()
+  "Test that 'Code change' prompt body still contains implementation wording."
+  (with-temp-buffer
+    (setq buffer-file-name "test.el")
+    (setq-local comment-start ";")
+    (setq-local comment-end "")
+    (insert ";; TODO: implement feature\n")
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt candidates &rest _args)
+                   (if (and (listp candidates)
+                            (member "Code change" candidates))
+                       "Code change"
+                     (if (listp candidates) (car candidates) ""))))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'ai-code--get-function-name-for-comment) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (p) (setq captured-prompt p))))
+
+        (ai-code--implement-todo--build-and-send-prompt nil)
+
+        (should (stringp captured-prompt))
+        ;; Should contain implementation-oriented wording
+        (should (string-match-p "Please implement code" captured-prompt))
+        ;; Should NOT contain no-code-change suffix
+        (should-not (string-match-p "do not make any code change" captured-prompt))))))
+
+(ert-deftest ai-code-test-implement-todo-ask-question-prompt-label ()
+  "Test that 'Ask question' uses a question-oriented prompt label."
+  (with-temp-buffer
+    (setq buffer-file-name "test.el")
+    (setq-local comment-start ";")
+    (setq-local comment-end "")
+    (insert ";; TODO: implement feature\n")
+    (goto-char (point-min))
+
+    (let (captured-label)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt candidates &rest _args)
+                   (if (and (listp candidates)
+                            (member "Ask question" candidates))
+                       "Ask question"
+                     (if (listp candidates) (car candidates) ""))))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (label input)
+                   (setq captured-label label)
+                   input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'ai-code--get-function-name-for-comment) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt) (lambda (_p) nil)))
+
+        (ai-code--implement-todo--build-and-send-prompt nil)
+
+        (should (stringp captured-label))
+        ;; Should contain question-oriented label, not implementation
+        (should (string-match-p "[Qq]uestion" captured-label))
+        (should-not (string-match-p "implementation" captured-label))))))
+
 (provide 'test_ai-code-change)
 
 ;;; test_ai-code-change.el ends here

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -338,6 +338,69 @@ is between the function definition and its body."
         (goto-char (point-min))
         (should (looking-at-p "    ;; TODO: indented task"))))))
 
+(ert-deftest ai-code-test-implement-todo-action-choice-is-presented ()
+  "Test that build-and-send-prompt presents action choice via completing-read."
+  (with-temp-buffer
+    (setq buffer-file-name "test.el")
+    (setq-local comment-start ";")
+    (setq-local comment-end "")
+    (insert ";; TODO: implement feature\n")
+    (goto-char (point-min))
+
+    (let ((action-asked nil))
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt candidates &rest _args)
+                   (when (and (listp candidates)
+                              (member "Code change" candidates)
+                              (member "Ask question" candidates))
+                     (setq action-asked t))
+                   "Code change"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'ai-code--get-function-name-for-comment) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt) (lambda (_p) nil)))
+
+        (ai-code--implement-todo--build-and-send-prompt nil)
+
+        (should action-asked)))))
+
+(ert-deftest ai-code-test-implement-todo-action-choice-ask-question ()
+  "Test that choosing 'Ask question' adds no-code-change suffix to prompt."
+  (with-temp-buffer
+    (setq buffer-file-name "test.el")
+    (setq-local comment-start ";")
+    (setq-local comment-end "")
+    (insert ";; TODO: implement feature\n")
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt candidates &rest _args)
+                   (if (and (listp candidates)
+                            (member "Ask question" candidates))
+                       "Ask question"
+                     (if (listp candidates) (car candidates) ""))))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'ai-code--get-function-name-for-comment) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (p) (setq captured-prompt p))))
+
+        (ai-code--implement-todo--build-and-send-prompt nil)
+
+        (should (stringp captured-prompt))
+        (should (string-match-p "do not make any code change" captured-prompt))))))
+
 (provide 'test_ai-code-change)
 
 ;;; test_ai-code-change.el ends here


### PR DESCRIPTION
With this change, ai-code-implement-todo can just discuss with AI, after user confirmed with the solution, then he can tell AI to go ahead.