### PR TITLE
Fix: Enable ghostel full-redraw mode for Claude Code and Copilot CLI sessions

### DIFF
--- a/ai-code-claude-code.el
+++ b/ai-code-claude-code.el
@@ -16,6 +16,8 @@
 (require 'ai-code-backends-infra)
 (require 'ai-code-mcp-agent)
 
+(defvar ghostel-full-redraw)
+
 (defgroup ai-code-claude-code nil
   "Claude Code CLI integration via `ai-code-backends-infra'."
   :group 'tools
@@ -70,26 +72,25 @@ With prefix ARG, prompt for CLI args using
          (launch-command (or (plist-get mcp-launch :command) command))
          (cleanup-fn (plist-get mcp-launch :cleanup-fn))
          (mcp-post-start-fn (plist-get mcp-launch :post-start-fn))
-         ;; Wrap post-start-fn to conditionally disable strip-alternate-screen.
-         ;; strip-alternate-screen (PR #298) strips \e[?1049h/l so scrollback
-         ;; is preserved, but it causes the Claude Code badge to repeat
-         ;; because the Ink/React TUI redraws the full screen every frame.
+         ;; Wrap post-start-fn to configure per-backend rendering.
          ;;
-         ;; - vterm: KEEP strip-alternate-screen enabled (with throttling).
-         ;;   libvterm's alternate screen has no scrollback ring, so letting
-         ;;   \e[?1049h through truncates scrollback to vterm-max-scrollback
-         ;;   (~1000 lines).
-         ;; - eat/ghostel: DISABLE strip-alternate-screen.  eat saves the
-         ;;   entire buffer on alternate-screen entry and restores on exit,
-         ;;   so scrollback is never lost.
+         ;; - vterm: Enable strip-alternate-screen (with throttling).
+         ;;   libvterm's alternate screen has no scrollback ring, so
+         ;;   stripping \e[?1049h/l keeps content in the normal buffer.
+         ;; - eat: Disable strip-alternate-screen.  eat natively saves
+         ;;   the buffer on alternate-screen entry and restores on exit.
+         ;; - ghostel: Disable strip-alternate-screen (libghostty handles
+         ;;   VT sequences correctly).  Enable full-redraw mode because
+         ;;   ghostel's incremental renderer cannot track Claude Code's
+         ;;   aggressive partial screen updates, causing duplicate frames.
          (post-start-fn
           (lambda (buffer process instance-name)
             (with-current-buffer buffer
               (if (eq ai-code-backends-infra-terminal-backend 'vterm)
-                  ;; Explicitly re-enable for vterm to guard against stale
-                  ;; buffer-local nil from a previous session or backend switch.
                   (setq-local ai-code-backends-infra-strip-alternate-screen t)
-                (setq-local ai-code-backends-infra-strip-alternate-screen nil)))
+                (setq-local ai-code-backends-infra-strip-alternate-screen nil))
+              (when (eq ai-code-backends-infra-terminal-backend 'ghostel)
+                (setq-local ghostel-full-redraw t)))
             (when mcp-post-start-fn
               (funcall mcp-post-start-fn buffer process instance-name))))
          (env-vars (append (list "TERM_PROGRAM=emacs"

--- a/ai-code-github-copilot-cli.el
+++ b/ai-code-github-copilot-cli.el
@@ -44,6 +44,8 @@ that `/terminal-setup' installs for Shift+Enter and Ctrl+Enter."
   :type 'string
   :group 'ai-code-github-copilot-cli)
 
+(defvar ghostel-full-redraw)
+
 (defconst ai-code-github-copilot-cli--session-prefix "copilot"
   "Session prefix used in GitHub Copilot CLI buffer names.")
 
@@ -75,7 +77,9 @@ With prefix ARG, prompt for CLI args using
          (post-start-fn
           (lambda (buffer process instance-name)
             (with-current-buffer buffer
-              (setq ai-code-backends-infra--sync-redraw-scrollback t))
+              (setq ai-code-backends-infra--sync-redraw-scrollback t)
+              (when (eq ai-code-backends-infra-terminal-backend 'ghostel)
+                (setq-local ghostel-full-redraw t)))
             (when mcp-post-start-fn
               (funcall mcp-post-start-fn buffer process instance-name)))))
     (ai-code-backends-infra--toggle-or-create-session


### PR DESCRIPTION
Claude Code and Copilot CLI use full-screen TUI rendering that causes repeated output accumulation in ghostel's incremental render mode. Setting ghostel-full-redraw to t in these sessions makes ghostel completely rewrite the buffer from terminal state on each frame, which correctly handles the aggressive screen updates.