### PR TITLE
Fix: guard process filters against deleted buffers on exit, for ghostel and eat terminal

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Fix: Guard eat/ghostel process filters against deleted buffers on exit and add regression tests
 - Fix: Enable ghostel full-redraw mode for Claude Code and Copilot CLI sessions
 - Refactor: Use Ghostel public API for sending input
 - Chore: Notify on response and beep before D-Bus

--- a/ai-code-backends-infra-eat.el
+++ b/ai-code-backends-infra-eat.el
@@ -134,15 +134,18 @@ variables for the terminal process."
           (set-process-filter
            proc
            (lambda (process output)
-             (let ((filtered-output
-                    (with-current-buffer (process-buffer process)
-                      (ai-code-backends-infra--strip-alternate-screen-sequences output))))
-               (when orig-filter
-                 (funcall orig-filter process filtered-output))
-               (with-current-buffer (process-buffer process)
-                 (when (ai-code-backends-infra--output-meaningful-p filtered-output)
-                   (ai-code-backends-infra--note-meaningful-output))
-                 (ai-code-session-link--linkify-recent-output filtered-output)))))))
+             (when-let ((buf (process-buffer process)))
+               (when (buffer-live-p buf)
+                 (let ((filtered-output
+                        (with-current-buffer buf
+                          (ai-code-backends-infra--strip-alternate-screen-sequences output))))
+                   (when orig-filter
+                     (funcall orig-filter process filtered-output))
+                   (when (buffer-live-p buf)
+                     (with-current-buffer buf
+                       (when (ai-code-backends-infra--output-meaningful-p filtered-output)
+                         (ai-code-backends-infra--note-meaningful-output))
+                       (ai-code-session-link--linkify-recent-output filtered-output)))))))))))
       (cons buffer (get-buffer-process buffer)))))
 
 (provide 'ai-code-backends-infra-eat)

--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -110,12 +110,15 @@ variables for the terminal process."
             (set-process-filter
              proc
              (lambda (process output)
-               (when orig-filter
-                 (funcall orig-filter process output))
-               (with-current-buffer (process-buffer process)
-                 (when (ai-code-backends-infra--output-meaningful-p output)
-                   (ai-code-backends-infra--note-meaningful-output))
-                 (ai-code-session-link--linkify-recent-output output))))))
+               (when-let ((buf (process-buffer process)))
+                 (when (buffer-live-p buf)
+                   (when orig-filter
+                     (funcall orig-filter process output))
+                   (when (buffer-live-p buf)
+                     (with-current-buffer buf
+                       (when (ai-code-backends-infra--output-meaningful-p output)
+                         (ai-code-backends-infra--note-meaningful-output))
+                       (ai-code-session-link--linkify-recent-output output)))))))))
         (cons buffer proc)))))
 
 (provide 'ai-code-backends-infra-ghostel)

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -449,6 +449,64 @@
       (when (file-directory-p working-dir)
         (delete-directory working-dir t)))))
 
+(ert-deftest test-ai-code-backends-infra-create-terminal-session-eat-filter-ignores-dead-buffer ()
+  "Eat filter wrapper should skip bookkeeping when session buffer is dead."
+  (let* ((buffer-name "*test-ai-code-eat-dead-buffer*")
+         (buffer (get-buffer-create buffer-name))
+         (ai-code-backends-infra-terminal-backend 'eat)
+         wrapped-filter
+         orig-filter-called
+         strip-called
+         note-called
+         linkify-called)
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-ensure-backend)
+                     (lambda () nil))
+                    ((symbol-function 'eat-mode)
+                     (lambda () nil))
+                    ((symbol-function 'eat-exec)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'get-buffer-process)
+                     (lambda (_buffer) 'eat-proc))
+                    ((symbol-function 'process-filter)
+                     (lambda (_process)
+                       (lambda (_process _output)
+                         (setq orig-filter-called t))))
+                    ((symbol-function 'set-process-filter)
+                     (lambda (_process filter)
+                       (setq wrapped-filter filter)))
+                    ((symbol-function 'process-buffer)
+                     (lambda (_process) buffer))
+                    ((symbol-function 'ai-code-backends-infra--strip-alternate-screen-sequences)
+                     (lambda (output)
+                       (setq strip-called t)
+                       output))
+                    ((symbol-function 'ai-code-backends-infra--note-meaningful-output)
+                     (lambda (&rest _args)
+                       (setq note-called t)))
+                    ((symbol-function 'ai-code-session-link--linkify-recent-output)
+                     (lambda (&rest _args)
+                       (setq linkify-called t))))
+            (ai-code-backends-infra--create-terminal-session
+             buffer-name
+             default-directory
+             "echo hi"
+             nil))
+          (kill-buffer buffer)
+          (should wrapped-filter)
+          (should-not
+           (condition-case nil
+               (progn (funcall wrapped-filter 'eat-proc "src/foo.el:12\n")
+                      nil)
+             (error t)))
+          (should-not orig-filter-called)
+          (should-not strip-called)
+          (should-not note-called)
+          (should-not linkify-called))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest test-ai-code-backends-infra-terminal-send-string-delegates-to-vterm-module ()
   "Terminal send should delegate vterm specifics to the vterm module."
   (let ((buffer (generate-new-buffer " *ai-code-terminal-send-delegate*"))
@@ -742,6 +800,64 @@
       (advice-remove 'ai-code-session-link--linkify-recent-output linkify-advice)
       (when (process-live-p proc)
         (delete-process proc))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-create-terminal-session-ghostel-filter-ignores-dead-buffer ()
+  "Ghostel filter wrapper should skip bookkeeping when session buffer is dead."
+  (let* ((buffer-name "*test-ai-code-ghostel-dead-buffer*")
+         (buffer (get-buffer-create buffer-name))
+         (orig-filter-called nil)
+         (note-called nil)
+         (linkify-called nil)
+         (wrapped-filter nil)
+         (ai-code-backends-infra-terminal-backend 'ghostel))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-ensure-backend)
+                     (lambda () nil))
+                    ((symbol-function 'ghostel-exec)
+                     (lambda (target-buffer _program &optional _args)
+                       (with-current-buffer target-buffer
+                         (setq-local ghostel--process 'ghostel-proc))
+                       'ghostel-proc))
+                    ((symbol-function 'get-buffer-process)
+                     (lambda (target-buffer)
+                       (with-current-buffer target-buffer
+                         ghostel--process)))
+                    ((symbol-function 'process-filter)
+                     (lambda (_process)
+                       (lambda (_process _output)
+                         (setq orig-filter-called t))))
+                    ((symbol-function 'set-process-filter)
+                     (lambda (_process filter)
+                       (setq wrapped-filter filter)))
+                    ((symbol-function 'processp)
+                     (lambda (proc)
+                       (eq proc 'ghostel-proc)))
+                    ((symbol-function 'process-buffer)
+                     (lambda (_process) buffer))
+                    ((symbol-function 'ai-code-backends-infra--note-meaningful-output)
+                     (lambda (&rest _args)
+                       (setq note-called t)))
+                    ((symbol-function 'ai-code-session-link--linkify-recent-output)
+                     (lambda (&rest _args)
+                       (setq linkify-called t))))
+            (ai-code-backends-infra--create-terminal-session
+             buffer-name
+             default-directory
+             "echo hi"
+             nil))
+          (kill-buffer buffer)
+          (should wrapped-filter)
+          (should-not
+           (condition-case nil
+               (progn (funcall wrapped-filter 'ghostel-proc "src/foo.el:12\n")
+                      nil)
+             (error t)))
+          (should-not orig-filter-called)
+          (should-not note-called)
+          (should-not linkify-called))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -454,11 +454,11 @@
   (let* ((buffer-name "*test-ai-code-eat-dead-buffer*")
          (buffer (get-buffer-create buffer-name))
          (ai-code-backends-infra-terminal-backend 'eat)
-         wrapped-filter
-         orig-filter-called
-         strip-called
-         note-called
-         linkify-called)
+         (wrapped-filter nil)
+         (orig-filter-called nil)
+         (strip-called nil)
+         (note-called nil)
+         (linkify-called nil))
     (unwind-protect
         (progn
           (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-ensure-backend)
@@ -493,8 +493,8 @@
              default-directory
              "echo hi"
              nil))
-          (kill-buffer buffer)
           (should wrapped-filter)
+          (kill-buffer buffer)
           (should-not
            (condition-case nil
                (progn (funcall wrapped-filter 'eat-proc "src/foo.el:12\n")
@@ -848,8 +848,8 @@
              default-directory
              "echo hi"
              nil))
-          (kill-buffer buffer)
           (should wrapped-filter)
+          (kill-buffer buffer)
           (should-not
            (condition-case nil
                (progn (funcall wrapped-filter 'ghostel-proc "src/foo.el:12\n")


### PR DESCRIPTION
When Claude Code exits inside a ghostel or eat terminal buffer, the process filter could fire after the buffer was already killed, causing "error in process filter: Selecting deleted buffer". Add buffer-live-p checks before and after orig-filter in both backends.