### PR TITLE
Feat: Support Org TODO headlines in implement-todo

### DIFF
--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -13,6 +13,7 @@
 (require 'cl-lib)
 (require 'magit)
 (require 'flycheck nil t)
+(require 'org)
 
 (require 'ai-code-input)
 (require 'ai-code-prompt-mode)
@@ -24,6 +25,8 @@
 (declare-function ai-code--get-git-relative-paths "ai-code-discussion")
 (declare-function ai-code--get-region-location-info "ai-code-discussion")
 (declare-function ai-code--format-repo-context-info "ai-code-file")
+(declare-function dired-get-marked-files "dired"
+                  (&optional localp arg filter distinguish-one-marked error-if-none-p))
 (declare-function flycheck-error-pos "flycheck")
 (declare-function flycheck-error-line "flycheck")
 (declare-function flycheck-error-column "flycheck")
@@ -262,6 +265,7 @@ line, with proper indentation.  If cursor is inside a function, implement
 comments for that function.
 Otherwise implement comments for the entire current file.
 Argument ARG is the prefix argument."
+  ;; DONE: I want to implement the idea inside https://github.com/tninja/ai-code-interface.el/issues/316, it could to either code change or ask question, given user's input with completing-read selection. The difference of this org-mode section TODO, with the existing comment todo is, it won't replace the TODO section with implementation. It just use the section headline and content inside this section as part of prompt, and send to AI.
   (interactive "P")
   (if (not buffer-file-name)
       (user-error "Error: buffer-file-name must be available")
@@ -330,6 +334,50 @@ Returns non-nil if handled and the caller should exit."
         (indent-according-to-mode)))
     t))
 
+(defun ai-code--implement-todo--get-org-todo-section-info ()
+  "Return current Org TODO section info as a plist, or nil.
+The plist contains `:heading-line', `:content', and `:line-number'."
+  (when (derived-mode-p 'org-mode)
+    (save-excursion
+      (when (and (org-at-heading-p)
+                 (ignore-errors (org-back-to-heading t)))
+        (let* ((line-number (line-number-at-pos (point)))
+               (heading-line (buffer-substring-no-properties
+                              (line-beginning-position)
+                              (line-end-position)))
+               (todo-state (org-get-todo-state))
+               (todo-prefix-p
+                (ai-code--implement-todo--org-todo-headline-p heading-line)))
+          (when (and (or todo-state todo-prefix-p)
+                     (not (org-entry-is-done-p)))
+            (let* ((content-start (save-excursion
+                                    (forward-line 1)
+                                    (point)))
+                   (content-end (save-excursion
+                                  (org-end-of-subtree t t)
+                                  (point)))
+                   (content (string-trim-right
+                             (buffer-substring-no-properties
+                              content-start
+                              content-end))))
+              (list :heading-line heading-line
+                    :content content
+                    :line-number line-number))))))))
+
+(defun ai-code--implement-todo--format-org-section-block (org-todo-section-info)
+  "Return formatted Org section text from ORG-TODO-SECTION-INFO."
+  (when org-todo-section-info
+    (let ((heading-line (plist-get org-todo-section-info :heading-line))
+          (content (plist-get org-todo-section-info :content)))
+      (concat heading-line
+              (unless (string-blank-p content)
+                (concat "\n" content))))))
+
+(defun ai-code--implement-todo--org-todo-headline-p (heading-line)
+  "Return non-nil when HEADING-LINE begins with a TODO-style Org headline."
+  (string-match-p "^[[:space:]]*\\*+[[:space:]]+TODO:?\\(?:[[:space:]]\\|$\\)"
+                  heading-line))
+
 (defun ai-code--implement-todo--build-and-send-prompt (arg)
   "Build the TODO implementation prompt and insert it.
 ARG is the prefix argument for clipboard context."
@@ -341,6 +389,11 @@ ARG is the prefix argument for clipboard context."
          (function-name (if is-comment
                             (ai-code--get-function-name-for-comment)
                           (which-function)))
+         (org-todo-section-info (ai-code--implement-todo--get-org-todo-section-info))
+         (org-line-number (plist-get org-todo-section-info :line-number))
+         (org-section-block
+          (ai-code--implement-todo--format-org-section-block
+           org-todo-section-info))
          (function-context (if function-name
                                (format "\nFunction: %s" function-name)
                              ""))
@@ -366,8 +419,8 @@ ARG is the prefix argument for clipboard context."
          (region-comment-block-p (or (not region-text)
                                      (ai-code--is-comment-block region-text)))
          ;; Validate scenario before prompting user
-         (_ (unless (or region-text is-comment)
-              (user-error "Current line is not a TODO comment and cannot proceed with `ai-code-implement-todo'.  Please select a TODO comment (not DONE), a region of comments, or activate on a blank line")))
+         (_ (unless (or org-todo-section-info region-text is-comment)
+              (user-error "Current line is not a TODO comment or Org TODO headline and cannot proceed with `ai-code-implement-todo'.  Please select a TODO comment (not DONE), an Org TODO headline, a region of comments, or activate on a blank line")))
          (_ (unless region-comment-block-p
               (user-error "Selected region must be a comment block")))
          (action-intent (completing-read "Select action: "
@@ -376,10 +429,18 @@ ARG is the prefix argument for clipboard context."
          (ask-question-p (string= action-intent "Ask question"))
          (prompt-label
           (cond
+           ((and ask-question-p org-todo-section-info)
+            (if (and clipboard-context (string-match-p "\\S-" clipboard-context))
+                "Question about Org TODO headline (clipboard context): "
+              "Question about Org TODO headline: "))
            (ask-question-p
             (if (and clipboard-context (string-match-p "\\S-" clipboard-context))
                 "Question about TODO comment (clipboard context): "
               "Question about TODO comment: "))
+           ((and org-todo-section-info
+                 clipboard-context
+                 (string-match-p "\\S-" clipboard-context))
+            "TODO implementation instruction for Org TODO headline (clipboard context): ")
            ((and clipboard-context
                  (string-match-p "\\S-" clipboard-context))
             (cond
@@ -387,18 +448,26 @@ ARG is the prefix argument for clipboard context."
              (is-comment "TODO implementation instruction (clipboard context): ")
              (function-name (format "TODO implementation instruction for function %s (clipboard context): " function-name))
              (t "TODO implementation instruction (clipboard context): ")))
+           (org-todo-section-info "TODO implementation instruction for Org TODO headline: ")
            (region-text "TODO implementation instruction: ")
            (is-comment "TODO implementation instruction: ")
            (function-name (format "TODO implementation instruction for function %s: " function-name))
            (t "TODO implementation instruction: ")))
          (initial-input
           (cond
+           ((and ask-question-p org-todo-section-info)
+            (format "Regarding this Org TODO headline on line %d:\n%s%s%s"
+                    org-line-number org-section-block function-context files-context-string))
            ((and ask-question-p region-text)
             (format "Regarding this TODO comment block in the selected region:\n%s\n%s%s%s"
                     region-location-line region-text function-context files-context-string))
            ((and ask-question-p is-comment)
             (format "Regarding this TODO comment on line %d: '%s'%s%s"
                     current-line-number current-line function-context files-context-string))
+           (org-todo-section-info
+            (format "Please implement code for this Org TODO headline first. After implementing, keep the Org TODO headline in place and use the headline and content as prompt context.\nLine %d:\n%s%s%s"
+                    org-line-number org-section-block function-context
+                    files-context-string))
            (region-text
             (format
              "Please implement code for this requirement comment block in the selected region first. After implementing, keep the comment in place and ensure it begins with a DONE prefix (change TODO to DONE or prepend DONE if no prefix). If this is a pure new code block, place it after the comment; otherwise keep the existing structure and make corresponding change for the context.\n%s\n%s%s%s"

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -339,7 +339,7 @@ is between the function definition and its body."
         (should (looking-at-p "    ;; TODO: indented task"))))))
 
 (ert-deftest ai-code-test-implement-todo-action-choice-is-presented ()
-  "Test that build-and-send-prompt presents action choice via completing-read."
+  "Test that build-and-send-prompt presents action choice via `completing-read'."
   (with-temp-buffer
     (setq buffer-file-name "test.el")
     (setq-local comment-start ";")
@@ -505,6 +505,81 @@ is between the function definition and its body."
         ;; Should contain question-oriented label, not implementation
         (should (string-match-p "[Qq]uestion" captured-label))
         (should-not (string-match-p "implementation" captured-label))))))
+
+(ert-deftest ai-code-test-ai-code-implement-todo-org-section-includes-heading-and-content ()
+  "Test Org TODO section is used as prompt context without requiring comment syntax."
+  (with-temp-buffer
+    (require 'org)
+    (setq buffer-file-name "todo.org")
+    (insert "* TODO Build backend switcher\n")
+    (insert "Use Codex for implementation.\n")
+    (insert "Keep the UI untouched.\n")
+    (org-mode)
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _) "Code change"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+
+        (ai-code-implement-todo nil)
+
+        (should (stringp captured-prompt))
+        (should (string-match-p "Please implement code" captured-prompt))
+        (should (string-match-p "\\* TODO Build backend switcher" captured-prompt))
+        (should (string-match-p "Use Codex for implementation\\." captured-prompt))
+        (should (string-match-p "Keep the UI untouched\\." captured-prompt))))))
+
+(ert-deftest ai-code-test-ai-code-implement-todo-org-body-line-is-not-headline ()
+  "Test Org body lines do not count as the TODO entry for implementation."
+  (with-temp-buffer
+    (require 'org)
+    (setq buffer-file-name "todo.org")
+    (insert "** TODO my task description\n")
+    (insert "Supporting details live here.\n")
+    (org-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+
+    (cl-letf (((symbol-function 'region-active-p) (lambda () nil)))
+      (should-error (ai-code-implement-todo nil) :type 'user-error))))
+
+(ert-deftest ai-code-test-ai-code-implement-todo-org-headline-with-colon-prefix ()
+  "Test Org headline with `TODO:' prefix is accepted."
+  (with-temp-buffer
+    (require 'org)
+    (setq buffer-file-name "todo.org")
+    (insert "** TODO: what is the most important verse in Bible\n")
+    (org-mode)
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _) "Ask question"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+
+        (ai-code-implement-todo nil)
+
+        (should (stringp captured-prompt))
+        (should (string-match-p "Regarding this Org TODO headline" captured-prompt))
+        (should (string-match-p "\\*\\* TODO: what is the most important verse in Bible"
+                                captured-prompt))))))
 
 (provide 'test_ai-code-change)
 


### PR DESCRIPTION
This updates `ai-code-implement-todo` so it can treat Org TODO headlines as TODO prompts, including headlines written as `TODO:`. Before this, invoking `C-c a i` on an Org headline like `** TODO: ...` could fail with the "not a TODO comment or Org TODO headline" error.

The change adds Org-specific headline detection for both `TODO` and `TODO:` forms, keeps the Org path restricted to the current headline instead of body lines, and includes the headline plus subtree content in the generated prompt. The existing comment-based TODO flow stays unchanged.

I also added ERT coverage for standard Org TODO headlines, `TODO:` headlines, and the non-headline body-line case so the entry behavior stays explicit. Verification was not run as part of this PR creation step, per request.