### PR TITLE
Feat: Add Kilo backend support (Opencode fork)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The project uses melpazoid for CI checks. The workflow is defined in `.github/wo
 ## High-Level Architecture
 
 ### Core Design Philosophy
-This is a unified interface package for AI-assisted software development that abstracts over multiple AI coding CLI backends (Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot CLI, Opencode, Grok CLI, Cursor CLI, CodeBuddy Code CLI, Kiro CLI). The package provides a consistent user experience across different AI tools while maintaining context-aware code actions and agile development workflows.
+This is a unified interface package for AI-assisted software development that abstracts over multiple AI coding CLI backends (Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot CLI, Opencode, Kilo, Grok CLI, Cursor CLI, CodeBuddy Code CLI, Kiro CLI). The package provides a consistent user experience across different AI tools while maintaining context-aware code actions and agile development workflows.
 
 ### Backend System Architecture
 
@@ -93,7 +93,7 @@ The codebase is organized into focused modules:
 - **`ai-code-prompt-mode.el`**: Prompt file management (`.ai.code.prompt.org`), @-completion, yasnippet integration
 - **`ai-code-input.el`**: User input handling, context gathering, completion utilities
 - **`ai-code-notifications.el`**: Desktop notifications for AI session completion
-- **Backend implementations**: `ai-code-codex-cli.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, `ai-code-opencode.el`, `ai-code-grok-cli.el`, `ai-code-cursor-cli.el`, `ai-code-kiro-cli.el`, `ai-code-claude-code.el`
+- **Backend implementations**: `ai-code-codex-cli.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, `ai-code-opencode.el`, `ai-code-kilo.el`, `ai-code-grok-cli.el`, `ai-code-cursor-cli.el`, `ai-code-kiro-cli.el`, `ai-code-claude-code.el`
 
 ### Transient Menu System
 
@@ -205,6 +205,7 @@ Each backend requires the corresponding CLI to be installed and available on PAT
 - OpenAI Codex: `codex`
 - GitHub Copilot CLI: `copilot`
 - Opencode: `opencode`
+- Kilo: `kilo`
 - Grok CLI: `grok`
 - Cursor CLI: `cursor`
 - Kiro CLI: `kiro`

--- a/README.org
+++ b/README.org
@@ -15,6 +15,7 @@ An Emacs interface for AI-assisted software development. *The purpose is to prov
   - [[https://github.com/google-gemini/gemini-cli][Gemini CLI]]
   - [[https://github.com/anthropics/claude-code][Claude Code]]
   - [[https://opencode.ai/][Opencode]]
+  - [[https://kilo.dev/][Kilo]]
   - [[https://grokcli.io/][Grok CLI]]
   - [[https://docs.cursor.com/en/cli][Cursor CLI]]
   - [[https://kiro.dev/cli/][Kiro CLI]]
@@ -83,7 +84,7 @@ Enable installation of packages from MELPA by adding an entry to package-archive
   (use-package ai-code
     ;; :straight (:host github :repo "tninja/ai-code-interface.el") ;; if you want to use straight to install, no need to have MELPA setting above
     :config
-    ;; use codex as backend, other options are 'claude-code, 'gemini, 'github-copilot-cli, 'opencode, 'grok, 'cursor, 'kiro, 'codebuddy, 'aider, 'eca, 'agent-shell, 'claude-code-ide, 'claude-code-el
+    ;; use codex as backend, other options are 'claude-code, 'gemini, 'github-copilot-cli, 'opencode, 'kilo, 'grok, 'cursor, 'kiro, 'codebuddy, 'aider, 'eca, 'agent-shell, 'claude-code-ide, 'claude-code-el
     (ai-code-set-backend 'codex)
     ;; Optional: default menu stays unchanged; use a narrower 2-column layout on smaller frames
     ;; (setq ai-code-menu-layout 'two-columns)
@@ -418,6 +419,7 @@ When working with multiple AI sessions, it can be useful to receive desktop noti
      - Binds =Shift+Enter=/=Ctrl+Enter= inside Claude sessions to send Claude's
        multiline input sequence.
    - [[https://opencode.ai/][Opencode]] (`[[./ai-code-opencode.el][ai-code-opencode.el]]`)
+   - [[https://kilo.dev/][Kilo]] (`[[./ai-code-kilo.el][ai-code-kilo.el]]`)
    - [[https://grokcli.io/][Grok CLI]] (`[[./ai-code-grok-cli.el][ai-code-grok-cli.el]]`)
    - [[https://docs.cursor.com/en/cli][Cursor CLI]] (`[[./ai-code-cursor-cli.el][ai-code-cursor-cli.el]]`)
    - [[https://kiro.dev/cli/][Kiro CLI]] (`[[./ai-code-kiro-cli.el][ai-code-kiro-cli.el]]`)

--- a/ai-code-autoloads.el
+++ b/ai-code-autoloads.el
@@ -32,11 +32,16 @@ with a newline separator.")
 When non-nil, append `ai-code-prompt-suffix` where supported.")
 (custom-autoload 'ai-code-use-prompt-suffix "ai-code" t)
 (defvar ai-code-use-gptel-classify-prompt nil "\
-Whether to use GPTel to classify prompts in `ask-me` auto test mode.
-When non-nil and `ai-code-auto-test-type` is not nil, classify whether
-the current prompt is about code changes.  If not, skip test type selection
-and do not append auto test suffix.")
+Whether to use GPTel to classify prompts before send-time suffix routing.
+When non-nil and `ai-code-auto-test-type` or
+`ai-code-discussion-auto-follow-up-enabled` is non-nil, classify whether
+the current prompt is about code changes.  This lets code-change prompts
+skip discussion follow-up suggestions, and discussion prompts skip auto
+test suffixes.")
 (custom-autoload 'ai-code-use-gptel-classify-prompt "ai-code" t)
+(defvar ai-code-next-step-suggestion-suffix (concat "At the end of your response, provide 3-4 numbered candidate next\n" "steps. Keep each option to one sentence. At least 2 candidates must\n" "be AI-actionable items as follow up: either a code change or tool usage. Mark the\n" "single best option with \"(Recommended)\". If the user replies with\n" "only a number such as 1, 2, 3, or 4, treat that as selecting the\n" "corresponding next step from your previous answer. The user may also\n" "ignore these options and send a different follow-up request instead.") "\
+Prompt suffix for numbered next-step suggestions in discussion prompts.")
+(custom-autoload 'ai-code-next-step-suggestion-suffix "ai-code" t)
 (defvar ai-code-cli "claude" "\
 The command-line AI tool to use for `ai-code-apply-prompt-on-current-file`.")
 (custom-autoload 'ai-code-cli "ai-code" t)
@@ -188,7 +193,7 @@ When called interactively, prompts for the command.
 When called from Lisp code, sends CMD directly without prompting.
 
 (fn CMD)" t)
-(defvar ai-code-backends '((claude-code :label "Claude Code" :require ai-code-claude-code :start ai-code-claude-code :switch ai-code-claude-code-switch-to-buffer :send ai-code-claude-code-send-command :resume ai-code-claude-code-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills ai-code-claude-code-install-skills :cli "claude") (gemini :label "Gemini CLI" :require ai-code-gemini-cli :start ai-code-gemini-cli :switch ai-code-gemini-cli-switch-to-buffer :send ai-code-gemini-cli-send-command :resume ai-code-gemini-cli-resume :config "~/.gemini/settings.json" :agent-file "GEMINI.md" :upgrade "npm install -g @google/gemini-cli" :install-skills nil :cli "gemini") (github-copilot-cli :label "GitHub Copilot CLI" :require ai-code-github-copilot-cli :start ai-code-github-copilot-cli :switch ai-code-github-copilot-cli-switch-to-buffer :send ai-code-github-copilot-cli-send-command :resume ai-code-github-copilot-cli-resume :config "~/.copilot/mcp-config.json" :agent-file nil :upgrade "npm install -g @github/copilot" :install-skills nil :cli "copilot") (codex :label "OpenAI Codex CLI" :require ai-code-codex-cli :start ai-code-codex-cli :switch ai-code-codex-cli-switch-to-buffer :send ai-code-codex-cli-send-command :resume ai-code-codex-cli-resume :config "~/.codex/config.toml" :agent-file "AGENTS.md" :upgrade "npm install -g @openai/codex@latest" :install-skills nil :cli "codex") (opencode :label "Opencode" :require ai-code-opencode :start ai-code-opencode :switch ai-code-opencode-switch-to-buffer :send ai-code-opencode-send-command :resume ai-code-opencode-resume :config "~/.config/opencode/opencode.jsonc" :agent-file nil :upgrade "npm i -g opencode-ai@latest" :install-skills nil :cli "opencode") (grok :label "Grok CLI" :require ai-code-grok-cli :start ai-code-grok-cli :switch ai-code-grok-cli-switch-to-buffer :send ai-code-grok-cli-send-command :resume ai-code-grok-cli-resume :config "~/.config/grok/config.json" :agent-file nil :upgrade "bun add -g @vibe-kit/grok-cli" :install-skills nil :cli "grok") (cursor :label "Cursor CLI" :require ai-code-cursor-cli :start ai-code-cursor-cli :switch ai-code-cursor-cli-switch-to-buffer :send ai-code-cursor-cli-send-command :resume ai-code-cursor-cli-resume :config "~/.cursor" :agent-file nil :upgrade "cursor-agent update" :install-skills nil :cli "cursor-agent") (kiro :label "Kiro CLI" :require ai-code-kiro-cli :start ai-code-kiro-cli :switch ai-code-kiro-cli-switch-to-buffer :send ai-code-kiro-cli-send-command :resume ai-code-kiro-cli-resume :config "~/.kiro/settings/cli.json" :agent-file nil :upgrade "kiro-cli update" :install-skills nil :cli "kiro-cli") (codebuddy :label "CodeBuddy Code" :require ai-code-codebuddy-cli :start ai-code-codebuddy-cli :switch ai-code-codebuddy-cli-switch-to-buffer :send ai-code-codebuddy-cli-send-command :resume ai-code-codebuddy-cli-resume :config "~/.codebuddy" :agent-file nil :upgrade "codebuddy update" :install-skills nil :cli "codebuddy") (aider :label "Aider CLI" :require ai-code-aider-cli :start ai-code-aider-cli :switch ai-code-aider-cli-switch-to-buffer :send ai-code-aider-cli-send-command :resume nil :config "~/.aider.conf.yml" :agent-file nil :upgrade nil :install-skills nil :cli "aider") (eca :label "ECA (Editor Code Assistant)" :require ai-code-eca :start ai-code-eca-start :switch ai-code-eca-switch :send ai-code-eca-send :resume ai-code-eca-resume :config "~/.config/eca/config.json" :agent-file "AGENTS.md" :upgrade ai-code-eca-upgrade :install-skills ai-code-eca-install-skills :cli nil) (agent-shell :label "agent-shell" :require ai-code-agent-shell :start ai-code-agent-shell :switch ai-code-agent-shell-switch-to-buffer :send ai-code-agent-shell-send-command :resume ai-code-agent-shell-resume :config nil :agent-file nil :upgrade nil :install-skills nil :cli "agent-shell") (gptel-agent :label "GPTel Agent" :require ai-code-gptel-agent :start ai-code-gptel-agent :switch ai-code-gptel-agent-switch-to-buffer :send ai-code-gptel-agent-send-command :resume nil :config nil :agent-file nil :upgrade nil :install-skills nil :cli nil) (claude-code-ide :label "claude-code-ide.el" :require claude-code-ide :start claude-code-ide--start-if-no-session :switch claude-code-ide-switch-to-buffer :send claude-code-ide-send-prompt :resume claude-code-ide-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills nil :cli "claude") (claude-code-el :label "claude-code.el" :require claude-code :start claude-code :switch claude-code-switch-to-buffer :send ai-code-claude-code-el-send-command :resume claude-code-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills nil :cli "claude")) "\
+(defvar ai-code-backends '((claude-code :label "Claude Code" :require ai-code-claude-code :start ai-code-claude-code :switch ai-code-claude-code-switch-to-buffer :send ai-code-claude-code-send-command :resume ai-code-claude-code-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills nil :cli "claude") (gemini :label "Gemini CLI" :require ai-code-gemini-cli :start ai-code-gemini-cli :switch ai-code-gemini-cli-switch-to-buffer :send ai-code-gemini-cli-send-command :resume ai-code-gemini-cli-resume :config "~/.gemini/settings.json" :agent-file "GEMINI.md" :upgrade "npm install -g @google/gemini-cli" :install-skills nil :cli "gemini") (github-copilot-cli :label "GitHub Copilot CLI" :require ai-code-github-copilot-cli :start ai-code-github-copilot-cli :switch ai-code-github-copilot-cli-switch-to-buffer :send ai-code-github-copilot-cli-send-command :resume ai-code-github-copilot-cli-resume :config "~/.copilot/mcp-config.json" :agent-file nil :upgrade "npm install -g @github/copilot" :install-skills nil :cli "copilot") (codex :label "OpenAI Codex CLI" :require ai-code-codex-cli :start ai-code-codex-cli :switch ai-code-codex-cli-switch-to-buffer :send ai-code-codex-cli-send-command :resume ai-code-codex-cli-resume :config "~/.codex/config.toml" :agent-file "AGENTS.md" :upgrade "npm install -g @openai/codex@latest" :install-skills nil :cli "codex") (opencode :label "Opencode" :require ai-code-opencode :start ai-code-opencode :switch ai-code-opencode-switch-to-buffer :send ai-code-opencode-send-command :resume ai-code-opencode-resume :config "~/.config/opencode/opencode.jsonc" :agent-file nil :upgrade "npm i -g opencode-ai@latest" :install-skills nil :cli "opencode") (kilo :label "Kilo" :require ai-code-kilo :start ai-code-kilo :switch ai-code-kilo-switch-to-buffer :send ai-code-kilo-send-command :resume ai-code-kilo-resume :config "~/.config/kilo/kilo.json" :agent-file nil :upgrade "npm install -g kilo@latest" :install-skills nil :cli "kilo") (grok :label "Grok CLI" :require ai-code-grok-cli :start ai-code-grok-cli :switch ai-code-grok-cli-switch-to-buffer :send ai-code-grok-cli-send-command :resume ai-code-grok-cli-resume :config "~/.config/grok/config.json" :agent-file nil :upgrade "bun add -g @vibe-kit/grok-cli" :install-skills nil :cli "grok") (cursor :label "Cursor CLI" :require ai-code-cursor-cli :start ai-code-cursor-cli :switch ai-code-cursor-cli-switch-to-buffer :send ai-code-cursor-cli-send-command :resume ai-code-cursor-cli-resume :config "~/.cursor" :agent-file nil :upgrade "cursor-agent update" :install-skills nil :cli "cursor-agent") (kiro :label "Kiro CLI" :require ai-code-kiro-cli :start ai-code-kiro-cli :switch ai-code-kiro-cli-switch-to-buffer :send ai-code-kiro-cli-send-command :resume ai-code-kiro-cli-resume :config "~/.kiro/settings/cli.json" :agent-file nil :upgrade "kiro-cli update" :install-skills nil :cli "kiro-cli") (codebuddy :label "CodeBuddy Code" :require ai-code-codebuddy-cli :start ai-code-codebuddy-cli :switch ai-code-codebuddy-cli-switch-to-buffer :send ai-code-codebuddy-cli-send-command :resume ai-code-codebuddy-cli-resume :config "~/.codebuddy" :agent-file nil :upgrade "codebuddy update" :install-skills nil :cli "codebuddy") (aider :label "Aider CLI" :require ai-code-aider-cli :start ai-code-aider-cli :switch ai-code-aider-cli-switch-to-buffer :send ai-code-aider-cli-send-command :resume nil :config "~/.aider.conf.yml" :agent-file nil :upgrade nil :install-skills nil :cli "aider") (eca :label "ECA (Editor Code Assistant)" :require ai-code-eca :start ai-code-eca-start :switch ai-code-eca-switch :send ai-code-eca-send :resume ai-code-eca-resume :config "~/.config/eca/config.json" :agent-file "AGENTS.md" :upgrade ai-code-eca-upgrade :install-skills ai-code-eca-install-skills :cli nil) (agent-shell :label "agent-shell" :require ai-code-agent-shell :start ai-code-agent-shell :switch ai-code-agent-shell-switch-to-buffer :send ai-code-agent-shell-send-command :resume ai-code-agent-shell-resume :config nil :agent-file nil :upgrade nil :install-skills nil :cli "agent-shell") (gptel-agent :label "GPTel Agent" :require ai-code-gptel-agent :start ai-code-gptel-agent :switch ai-code-gptel-agent-switch-to-buffer :send ai-code-gptel-agent-send-command :resume nil :config nil :agent-file nil :upgrade nil :install-skills nil :cli nil) (claude-code-ide :label "claude-code-ide.el" :require claude-code-ide :start claude-code-ide--start-if-no-session :switch claude-code-ide-switch-to-buffer :send claude-code-ide-send-prompt :resume claude-code-ide-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills nil :cli "claude") (claude-code-el :label "claude-code.el" :require claude-code :start claude-code :switch claude-code-switch-to-buffer :send ai-code-claude-code-el-send-command :resume claude-code-resume :config "~/.claude.json" :agent-file "CLAUDE.md" :upgrade "npm install -g @anthropic-ai/claude-code@latest" :install-skills nil :cli "claude")) "\
 Available AI backends and how to integrate with them.
 Each entry is (KEY :label STRING :require FEATURE :start FN :switch FN
 :send FN :resume FN-or-nil :upgrade STRING-or-nil :cli STRING
@@ -217,12 +222,13 @@ ARG is the prefix argument to pass to the upgrade function.
 
 (fn &optional ARG)" t)
 (autoload 'ai-code-install-backend-skills "ai-code-backends" "\
-Install skills for the currently selected backend.
-If the backend defines an :install-skills property, use it:
+Install or uninstall skills for the currently selected backend.
+Prompt for whether to install or uninstall first.
+When installing, if the backend defines an :install-skills property, use it:
   - string: run as a shell command via `compile'.
   - symbol: call the function.
-Otherwise fall back to prompting the AI session to install from a
-skills repository URL." t)
+Otherwise, or when uninstalling, fall back to prompting the AI session
+to manage skills from a skills repository URL." t)
 (register-definition-prefixes "ai-code-backends" '("ai-code-"))
 
 
@@ -242,8 +248,10 @@ typically in your Emacs configuration with:
 (autoload 'ai-code-behaviors-agent-shell-setup "ai-code-behaviors" "\
 Set up ai-code-behaviors integration with agent-shell.
 Adds the request decorator to inject behaviors into agent-shell prompts.
-Also advises file completion to skip when @preset is typed.
-Adds preset completion to agent-shell buffers." t)
+Merges preset names with file completion (both show in same popup).
+Adds hashtag completion (triggers on #).
+Adds mode-line indicator to agent-shell buffers.
+Safe to call multiple times - guards prevent duplicate advice/hooks." t)
 (register-definition-prefixes "ai-code-behaviors" '("ai-code-"))
 
 
@@ -435,7 +443,7 @@ This value is used by `ai-code-take-notes' when suggesting where to store notes.
 (defvar ai-code-notes-use-gptel-headline nil "\
 Whether to use GPTel to generate headline for notes.
 If non-nil, call `ai-code-call-gptel-sync` to generate a smart default
-headline based on the selected content. Otherwise, prompt with empty default.")
+headline based on the selected content.  Otherwise, prompt with empty default.")
 (custom-autoload 'ai-code-notes-use-gptel-headline "ai-code-discussion" t)
 (autoload 'ai-code-take-notes "ai-code-discussion" "\
 Take notes from selected region and save to a note file.
@@ -443,7 +451,7 @@ When there is a selected region, prompt to select from currently open
 org buffers or the default note file path (.ai.code.notes.org in the
 .ai.code.files/ directory).  Add the section title as a headline at the
 end of the note file, and put the selected region as content of that section." t)
-(register-definition-prefixes "ai-code-discussion" '("ai-code--"))
+(register-definition-prefixes "ai-code-discussion" '("ai-code-"))
 
 
 ;;; Generated autoloads from ai-code-eca.el
@@ -544,7 +552,9 @@ Otherwise, ask AI to generate a build command." t)
 (autoload 'ai-code-test-project "ai-code-file" "\
 Ask AI to run test on the whole project and provide failure analysis." t)
 (autoload 'ai-code-add-context "ai-code-file" "\
-Capture current buffer context and store it per Git repository.
+Capture current buffer context and store it per selected repository root.
+If current buffer is not inside a Git repository, select from known repository
+roots gathered from existing context entries and visible/session buffers.
 When no region is selected, use the full file path and current function
 (if any).  When a region is active, use the file path with line range
 in the form filepath#Lstart-Lend." t)
@@ -591,9 +601,9 @@ Resume a previous Gemini CLI session.
 ;;; Generated autoloads from ai-code-git.el
 
 (autoload 'ai-code-pull-or-review-diff-file "ai-code-git" "\
-Review a diff file with AI Code or generate one if not viewing a diff.
+Review a diff file with AI Code or choose a PR review workflow.
 If current buffer is a .diff file, ask AI Code to review it.
-Otherwise, generate the diff." t)
+Otherwise, prompt for a review source and analysis mode." t)
 (autoload 'ai-code-magit-blame-analyze "ai-code-git" "\
 Analyze current file or region Git history with AI for deeper insights.
 If region is active, analyze just that region.  Otherwise analyze entire file.
@@ -620,7 +630,7 @@ PREFIX is the prefix argument.
 
 (fn PREFIX)" t)
 (autoload 'ai-code-update-git-ignore "ai-code-git" "\
-Ensure repository .gitignore contains AI Code related entries.
+Ensure repository .gitignore has AI Code-related entries.
 If not inside a Git repository, do nothing." t)
 (autoload 'ai-code--git-repo-recent-modified-files "ai-code-git" "\
 Return up to LIMIT most recently modified files under BASE-DIR.
@@ -628,7 +638,7 @@ If BASE-DIR is in a Git repository, use `git ls-files' to enumerate files.
 
 (fn BASE-DIR LIMIT)")
 (autoload 'ai-code-git-repo-recent-modified-files "ai-code-git" "\
-Open or insert one of the most recently modified files in the repo or current dir.
+Open or insert a recently modified file in the repo or current dir.
 With no PREFIX argument, prompt for a recently modified file and open it
 with `find-file'.
 
@@ -639,14 +649,15 @@ buffer from which this command was invoked, instead of visiting the file.
 (fn PREFIX)" t)
 (autoload 'ai-code-git-worktree-branch "ai-code-git" "\
 Create BRANCH and check it out in a new centralized worktree.
-The worktree path is
+The worktree path for START-POINT is
 `ai-code-git-worktree-root/REPO-NAME/BRANCH'.
 
 (fn BRANCH START-POINT)" t)
 (autoload 'ai-code-git-worktree-action "ai-code-git" "\
 Dispatch worktree action by PREFIX.
 Without PREFIX, call `ai-code-git-worktree-branch'.
-With PREFIX (for example C-u), call `magit-worktree-status'.
+With PREFIX (for example \\[universal-argument]), call
+`magit-worktree-status'.
 
 (fn &optional PREFIX)" t)
 (register-definition-prefixes "ai-code-git" '("ai-code-"))
@@ -736,6 +747,11 @@ Read a string from the user with PROMPT and optional INITIAL-INPUT.
 CANDIDATE-LIST provides additional completion options if provided.
 
 (fn PROMPT &optional INITIAL-INPUT CANDIDATE-LIST)")
+(autoload 'ai-code-speech-to-text-input "ai-code-input" "\
+Record audio with whisper.el, then choose how to use the transcription.
+
+After recording and transcription, you can insert the text at point in the
+original buffer, send it to an AI coding session, or copy it to the clipboard." t)
 (when (featurep 'helm) (setq ai-code--read-string-fn #'ai-code-helm-read-string))
 (autoload 'ai-code-insert-function-at-point "ai-code-input" "\
 Insert a function name selected from current windows' prog-mode buffers." t)
@@ -770,7 +786,7 @@ disabled.
 Toggle @ file completion in comments and AI sessions across all buffers." t)
 (autoload 'ai-code-session-navigate-link-at-point "ai-code-input" "\
 Navigate to the file or URL session link at point." t)
-(register-definition-prefixes "ai-code-input" '("ai-code-"))
+(register-definition-prefixes "ai-code-input" '("ai-code-" "whisper-after-transcription-hook"))
 
 
 ;;; Generated autoloads from ai-code-kiro-cli.el
@@ -891,7 +907,10 @@ based on the task name. Otherwise, use cleaned-up task name directly.")
 Create or open an AI task file.
 Prompts for a task name. If empty, opens the task directory.
 If non-empty, optionally prompts for a URL, generates a filename
-using GPTel, and creates the task file." t)
+using GPTel, and creates the task file.
+With prefix ARG, prompt AI to search org file content under a target directory.
+
+(fn &optional ARG)" t)
 (add-to-list 'auto-mode-alist '("/\\.ai\\.code\\.files/.*\\.org\\'" . ai-code-prompt-mode))
 (register-definition-prefixes "ai-code-prompt-mode" '("ai-code-"))
 
@@ -931,15 +950,80 @@ User-provided prompt suffix for test-after-code-change.")
 Directory used to cache generated auto-test harness files.
 
 When nil, store harness files under `harness/` inside the directory returned
-by `ai-code--ensure-files-directory`. In a Git repository, that is typically
+by `ai-code--ensure-files-directory`.  In a Git repository, that is typically
 `.ai.code.files/harness/` under the current repository so prompts can cite
-them with `@`-prefixed repo-relative paths. Outside a Git repository, this
+them with `@`-prefixed repo-relative paths.  Outside a Git repository, this
 falls back to `harness/` under `default-directory`.
 
 Set this to a directory path to override the default location.")
 (custom-autoload 'ai-code-auto-test-harness-cache-directory "ai-code-harness" t)
 (register-definition-prefixes "ai-code-harness" '("ai-code--"))
 
+
+;;; Generated autoloads from ai-code-backends-infra-eat.el
+
+(register-definition-prefixes "ai-code-backends-infra-eat" '("ai-code-backends-infra-"))
+
+
+;;; Generated autoloads from ai-code-backends-infra-ghostel.el
+
+(register-definition-prefixes "ai-code-backends-infra-ghostel" '("ai-code-backends-infra-" "ghostel-"))
+
+
+;;; Generated autoloads from ai-code-backends-infra-vterm.el
+
+(register-definition-prefixes "ai-code-backends-infra-vterm" '("ai-code-backends-infra-"))
+
+
+;;; Generated autoloads from ai-code-kilo.el
+
+(autoload 'ai-code-kilo "ai-code-kilo" "\
+Start Kilo (uses `ai-code-backends-infra' logic).
+With prefix ARG, prompt for CLI args using
+`ai-code-kilo-program-switches' as the default input.
+
+(fn &optional ARG)" t)
+(autoload 'ai-code-kilo-switch-to-buffer "ai-code-kilo" "\
+Switch to the Kilo buffer.
+When FORCE-PROMPT is non-nil, prompt to select a session.
+
+(fn &optional FORCE-PROMPT)" t)
+(autoload 'ai-code-kilo-send-command "ai-code-kilo" "\
+Send LINE to Kilo.
+When called interactively, prompts for the command.
+
+(fn LINE)" t)
+(autoload 'ai-code-kilo-resume "ai-code-kilo" "\
+Resume a previous Kilo session.
+
+This command starts Kilo with the --continue flag to resume
+a specific past session.  The CLI will present an interactive list of past
+sessions to choose from.
+
+If current buffer belongs to a project, start in the project's root
+directory.  Otherwise start in the directory of the current buffer file,
+or the current value of `default-directory' if no project and no buffer file.
+
+With double prefix ARG (\\[universal-argument] \\[universal-argument]),
+prompt for the project directory.
+
+(fn &optional ARG)" t)
+(register-definition-prefixes "ai-code-kilo" '("ai-code-kilo-"))
+
+
+;;; Generated autoloads from ai-code-mcp-common.el
+
+(register-definition-prefixes "ai-code-mcp-common" '("ai-code-mcp-"))
+
+
+;;; Generated autoloads from ai-code-mcp-debug-tools.el
+
+(register-definition-prefixes "ai-code-mcp-debug-tools" '("ai-code-mcp-"))
+
+
+;;; Generated autoloads from ai-code-mcp-editor-tools.el
+
+(register-definition-prefixes "ai-code-mcp-editor-tools" '("ai-code-mcp-"))
 
 ;;; End of scraped data
 

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -258,6 +258,18 @@ so the CLI itself handles the installation details."
      :upgrade "npm i -g opencode-ai@latest"
      :install-skills nil
      :cli     "opencode")
+    (kilo
+     :label "Kilo"
+     :require ai-code-kilo
+     :start   ai-code-kilo
+     :switch  ai-code-kilo-switch-to-buffer
+     :send    ai-code-kilo-send-command
+     :resume  ai-code-kilo-resume
+     :config  "~/.config/kilo/kilo.json"
+     :agent-file nil
+     :upgrade "npm install -g kilo@latest"
+     :install-skills nil
+     :cli     "kilo")
     (grok
      :label "Grok CLI"
      :require ai-code-grok-cli

--- a/ai-code-behaviors.el
+++ b/ai-code-behaviors.el
@@ -2234,6 +2234,7 @@ Call this when completely disabling ai-code-behaviors."
 
 (defconst ai-code--backend-session-prefixes
   '((opencode . "opencode")
+    (kilo . "kilo")
     (claude-code . "claude")
     (gemini . "gemini")
     (github-copilot-cli . "copilot")

--- a/ai-code-kilo.el
+++ b/ai-code-kilo.el
@@ -1,0 +1,132 @@
+;;; ai-code-kilo.el --- Thin wrapper for Kilo  -*- lexical-binding: t; -*-
+
+;; Author: sirmacik <sirmacik@wioo.waw.pl>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;;
+;; Thin wrapper that reuses `ai-code-backends-infra' to run Kilo.
+;; Provides interactive commands and aliases for the AI Code suite.
+;;
+;; Kilo is a fork of Opencode, an open-source alternative to Claude Code
+;; that provides HTTP server APIs and customization features (LSP, custom
+;; LLM providers, etc.)
+;; See: https://kilo.dev/
+;;
+;;; Code:
+
+(require 'ai-code-backends)
+(require 'ai-code-backends-infra)
+
+
+(defgroup ai-code-kilo nil
+  "Kilo integration via `ai-code-backends-infra.el'."
+  :group 'tools
+  :prefix "ai-code-kilo-")
+
+(defcustom ai-code-kilo-program "kilo"
+  "Path to the Kilo executable."
+  :type 'string
+  :group 'ai-code-kilo)
+
+(defcustom ai-code-kilo-program-switches nil
+  "Command line switches to pass to Kilo on startup."
+  :type '(repeat string)
+  :group 'ai-code-kilo)
+
+(defcustom ai-code-kilo-extra-env-vars
+  '("OTUI_USE_ALTERNATE_SCREEN=main-screen")
+  "Extra environment variables passed to the Kilo terminal session.
+`OTUI_USE_ALTERNATE_SCREEN=main-screen' avoids the alternate screen
+buffer so that terminal scrollback is partially preserved."
+  :type '(repeat string)
+  :group 'ai-code-kilo)
+
+(defconst ai-code-kilo--session-prefix "kilo"
+  "Session prefix used in Kilo buffer names.")
+
+(defvar ai-code-kilo--processes (make-hash-table :test 'equal)
+  "Hash table mapping Kilo session keys to processes.")
+
+;;;###autoload
+(defun ai-code-kilo (&optional arg)
+  "Start Kilo (uses `ai-code-backends-infra' logic).
+With prefix ARG, prompt for CLI args using
+`ai-code-kilo-program-switches' as the default input."
+  (interactive "P")
+  (let* ((working-dir (ai-code-backends-infra--session-working-directory))
+         (resolved (ai-code-backends-infra--resolve-start-command
+                    ai-code-kilo-program
+                    ai-code-kilo-program-switches
+                    arg
+                    "Kilo"))
+         (command (plist-get resolved :command)))
+    (ai-code-backends-infra--toggle-or-create-session
+     working-dir
+     nil
+     ai-code-kilo--processes
+     command
+     nil
+     nil
+     nil
+     ai-code-kilo--session-prefix
+     nil
+     ai-code-kilo-extra-env-vars)))
+
+;;;###autoload
+(defun ai-code-kilo-switch-to-buffer (&optional force-prompt)
+  "Switch to the Kilo buffer.
+When FORCE-PROMPT is non-nil, prompt to select a session."
+  (interactive "P")
+  (let ((working-dir (ai-code-backends-infra--session-working-directory)))
+    (ai-code-backends-infra--switch-to-session-buffer
+     nil
+     "No Kilo session for this project"
+     ai-code-kilo--session-prefix
+     working-dir
+     force-prompt)))
+
+;;;###autoload
+(defun ai-code-kilo-send-command (line)
+  "Send LINE to Kilo.
+When called interactively, prompts for the command."
+  (interactive "sKilo> ")
+  (let ((working-dir (ai-code-backends-infra--session-working-directory)))
+    (ai-code-backends-infra--send-line-to-session
+     nil
+     "No Kilo session for this project"
+     line
+     ai-code-kilo--session-prefix
+     working-dir)))
+
+;;;###autoload
+(defun ai-code-kilo-resume (&optional arg)
+  "Resume a previous Kilo session.
+
+This command starts Kilo with the --continue flag to resume
+a specific past session.  The CLI will present an interactive list of past
+sessions to choose from.
+
+If current buffer belongs to a project, start in the project's root
+directory.  Otherwise start in the directory of the current buffer file,
+or the current value of `default-directory' if no project and no buffer file.
+
+With double prefix ARG (\\[universal-argument] \\[universal-argument]),
+prompt for the project directory."
+  (interactive "P")
+  (let ((ai-code-kilo-program-switches
+         (append ai-code-kilo-program-switches '("--continue"))))
+    (ai-code-kilo arg)
+    (let* ((working-dir (ai-code-backends-infra--session-working-directory))
+           (buffer (ai-code-backends-infra--select-session-buffer
+                    ai-code-kilo--session-prefix
+                    working-dir)))
+      (when buffer
+        (with-current-buffer buffer
+          (sit-for 0.5)
+          (ai-code-backends-infra--terminal-send-string "")
+          (goto-char (point-min)))))))
+
+(provide 'ai-code-kilo)
+
+;;; ai-code-kilo.el ends here

--- a/ai-code.el
+++ b/ai-code.el
@@ -1,4 +1,4 @@
-;;; ai-code.el --- Unified interface for AI coding backends such as Codex CLI, Copilot CLI, Claude Code, Gemini CLI, Opencode, Grok CLI, etc -*- lexical-binding: t; -*-
+;;; ai-code.el --- Unified interface for AI coding backends such as Codex CLI, Copilot CLI, Claude Code, Gemini CLI, Opencode, Kilo, Grok CLI, etc -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 1.74
@@ -21,6 +21,7 @@
 ;;   - Gemini CLI
 ;;   - Claude Code
 ;;   - Opencode
+;;   - Kilo
 ;;   - Grok CLI
 ;;   - Cursor CLI
 ;;   - Kiro CLI
@@ -49,7 +50,7 @@
 ;;
 ;; (use-package ai-code
 ;;   :config
-;;   ;; use codex as backend, other options are 'gemini, 'github-copilot-cli, 'opencode, 'grok, 'claude-code-ide, 'claude-code-el, 'claude-code, 'cursor, 'kiro, 'codebuddy, 'aider, 'agent-shell, 'eca
+;;   ;; use codex as backend, other options are 'gemini, 'github-copilot-cli, 'opencode, 'kilo, 'grok, 'claude-code-ide, 'claude-code-el, 'claude-code, 'cursor, 'kiro, 'codebuddy, 'aider, 'agent-shell, 'eca
 ;;   (ai-code-set-backend 'codex) ;; set your preferred backend
 ;;   ;; Optional: use a narrower transient menu on smaller frames
 ;;   ;; (setq ai-code-menu-layout 'two-columns)
@@ -112,6 +113,7 @@
 (require 'ai-code-aider-cli)
 (require 'ai-code-github-copilot-cli)
 (require 'ai-code-opencode)
+(require 'ai-code-kilo)
 (require 'ai-code-grok-cli)
 (require 'ai-code-codebuddy-cli)
 (require 'ai-code-file)

--- a/test/test_ai-code-behaviors.el
+++ b/test/test_ai-code-behaviors.el
@@ -554,12 +554,14 @@
   "Test that CLI backend session prefixes are defined."
   (should ai-code--backend-session-prefixes)
   (should (assoc 'opencode ai-code--backend-session-prefixes))
+  (should (assoc 'kilo ai-code--backend-session-prefixes))
   (should (assoc 'claude-code ai-code--backend-session-prefixes))
   (should-not (assoc 'eca ai-code--backend-session-prefixes)))
 
 (ert-deftest ai-code-test-get-session-prefix ()
   "Test getting session prefix for different backends."
   (should (equal "opencode" (alist-get 'opencode ai-code--backend-session-prefixes)))
+  (should (equal "kilo" (alist-get 'kilo ai-code--backend-session-prefixes)))
   (should (equal "claude" (alist-get 'claude-code ai-code--backend-session-prefixes)))
   (should-not (alist-get 'eca ai-code--backend-session-prefixes)))
 


### PR DESCRIPTION
## Summary
- Adds Kilo backend support. Kilo is a pure fork of Opencode, so the implementation mirrors `ai-code-opencode.el`.
- New file: `ai-code-kilo.el` — thin wrapper providing start, switch, send, and resume commands.
- Registered in `ai-code-backends.el`, `ai-code-behaviors.el` session prefix map, `ai-code.el` requires, and `README.org`.
- Autoloads regenerated; tests updated and passing.