### PR TITLE
Chore: Treat documentation changes as non-code changes

### DIFF
--- a/ai-code.el
+++ b/ai-code.el
@@ -305,7 +305,8 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
                  (let* ((raw-answer (ai-code-call-gptel-sync
                                      (concat "Classify whether this user prompt requests program code changes in a repository.\n"
                                              "Reply with exactly one token: CODE_CHANGE or NOT_CODE_CHANGE.\n"
-                                             "Treat edit/refactor/implement/fix/add/remove/update/tests as CODE_CHANGE.\n"
+                                             "Return CODE_CHANGE only for changes to program code or test code.\n"
+                                             "Treat documentation changes and any other non-program-code actions as NOT_CODE_CHANGE.\n"
                                              "Treat explain/summarize/discuss/review without editing as NOT_CODE_CHANGE.\n\n"
                                              "Prompt:\n" prompt-text)))
                         (answer (upcase (string-trim (or raw-answer "")))))

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -392,6 +392,31 @@
       (should (equal "Please explain why this fails, then update the implementation."
                      captured-prompt)))))
 
+(ert-deftest ai-code-test-gptel-classifier-prompt-treats-document-edits-as-non-code-change ()
+  "Test that GPTel instructions reserve CODE_CHANGE for program code edits."
+  (let ((captured-prompt nil)
+        (original-require (symbol-function 'require)))
+    (cl-letf (((symbol-function 'require)
+               (lambda (feature &optional filename noerror)
+                 (if (eq feature 'gptel)
+                     t
+                   (funcall original-require feature filename noerror))))
+              ((symbol-function 'ai-code-call-gptel-sync)
+               (lambda (prompt)
+                 (setq captured-prompt prompt)
+                 "NOT_CODE_CHANGE")))
+      (should (eq 'non-code-change
+                  (ai-code--gptel-classify-prompt-code-change
+                   "Please update the README and other docs.")))
+      (should
+       (string-match-p
+        "Return CODE_CHANGE only for changes to program code or test code\\."
+        captured-prompt))
+      (should
+       (string-match-p
+        "Treat documentation changes and any other non-program-code actions as NOT_CODE_CHANGE\\."
+        captured-prompt)))))
+
 (ert-deftest ai-code-test-simple-classifier-reuses-shared-prompt-markers ()
   "Test that classifier markers reuse shared prompt-builder constants."
   (should (boundp 'ai-code-change--selected-region-note))


### PR DESCRIPTION
## Summary
Update the change classifier so documentation-only requests are treated as non-code changes instead of code changes.

The classifier guidance was too broad and could treat generic update-style requests as code work even when the request was only about documentation. That makes the package choose the wrong path for docs-oriented tasks.

This change narrows the prompt so `CODE_CHANGE` is reserved for program code and test code, and it explicitly calls out documentation and other non-program-code work as non-code. I also added a regression test that covers a documentation-only prompt so the classifier keeps this behavior.

## Verification
- Added ERT regression coverage for a documentation-only classification case in `test/test_ai-code.el`