### PR TITLE
Fix: Make org TODO headline section work well with ai-code-implement-todo + helm

### DIFF
--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -388,7 +388,7 @@ The plist contains `:heading-line', `:content', and `:line-number'."
   (when org-todo-section-info
     (let ((heading-line (plist-get org-todo-section-info :heading-line))
           (content (plist-get org-todo-section-info :content)))
-      (concat heading-line
+      (concat (replace-regexp-in-string "\\`\\*+ " "" heading-line)
               (unless (string-blank-p content)
                 (concat "\n" content))))))
 

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -534,7 +534,7 @@ is between the function definition and its body."
 
         (should (stringp captured-prompt))
         (should (string-match-p "Please implement code" captured-prompt))
-        (should (string-match-p "\\* TODO Build backend switcher" captured-prompt))
+        (should (string-match-p "TODO Build backend switcher" captured-prompt))
         (should (string-match-p "Use Codex for implementation\\." captured-prompt))
         (should (string-match-p "Keep the UI untouched\\." captured-prompt))))))
 
@@ -578,7 +578,7 @@ is between the function definition and its body."
 
         (should (stringp captured-prompt))
         (should (string-match-p "Regarding this Org TODO headline" captured-prompt))
-        (should (string-match-p "\\*\\* TODO: what is the most important verse in Bible"
+        (should (string-match-p "TODO: what is the most important verse in Bible"
                                 captured-prompt))))))
 
 (ert-deftest ai-code-test-detect-todo-info-org-todo-headline ()


### PR DESCRIPTION
This feature: https://github.com/tninja/ai-code-interface.el/pull/317, doesn't work well with helm.

The leading * character mess up with helm search. This fix remove * so that it work with helm