### PR TITLE
Chore: tweak auto follow up suggestion feature

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,9 @@
 * Release history
 
 ** Main branch change
+- Chore: tweak auto follow up suggestion feature
+  - Turn it on by default. This is just about to let user to choose use it or not (in 2).
+  - Let user use y/n to use it in each non code change question.
 - Chore: Improve ai-code-implement-todo inside org-mode file
 - Fix: Make org TODO headline section work well with ai-code-implement-todo + helm
 - Chore: ai-code-code-change and ai-code-ask-question can trigger ai-code-implement-todo when the cursor is on a TODO comment or TODO org headline

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,8 @@
 * Release history
 
 ** Main branch change
+
+** 1.78
 - Chore: tweak auto follow up suggestion feature
   - Turn it on by default. This is just about to let user to choose use it or not (in 2).
   - Let user use y/n to use it in each non code change question.

--- a/README.org
+++ b/README.org
@@ -98,10 +98,9 @@ Enable installation of packages from MELPA by adding an entry to package-archive
     ;; (ai-code-prompt-filepath-completion-mode -1)
     ;; Optional: Ask AI to run test after code changes, for a tighter build-test loop
     (setq ai-code-auto-test-type 'ask-me)
-    ;; Optional: Offer numbered next steps for discussion prompts at send time
-    ;; Customize `ai-code-discussion-auto-follow-up-enabled` to non-nil
-    ;; or set it directly like this:
-    ;; (setq ai-code-discussion-auto-follow-up-enabled t)
+    ;; Optional: Disable numbered next steps for discussion prompts at send time
+    ;; (enabled by default)
+    ;; (setq ai-code-discussion-auto-follow-up-enabled nil)
     ;; Optional: In AI session buffers, SPC in Evil normal state triggers the prompt-enter UI
     (with-eval-after-load 'evil (ai-code-backends-infra-evil-setup))
     ;; Optional: Turn on auto-revert buffer, so that the AI code change automatically appears in the buffer
@@ -163,7 +162,7 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 - *Implementing a TODO*: Write a comment in your code, like `;; TODO: Implement caching for this function`. Place your cursor on that line and press `C-c a`, then `i` (`ai-code-implement-todo`). The AI will generate the implementation based on the comment.
   - Relevant packages for TODO: [[https://github.com/tarsius/hl-todo][hl-todo]], [[https://github.com/alphapapa/magit-todos][magit-todos]]
 - *Asking a Question*: Place your cursor within a function, press `C-c a`, then `q` (`ai-code-ask-question`), type your question, and press Enter. The question, along with context, will be sent to the AI.
-- *Discussion follow-up suggestions*: Customize `ai-code-discussion-auto-follow-up-enabled` to non-nil, or set `(setq ai-code-discussion-auto-follow-up-enabled t)`. Then ask a question with `C-c a q` or use `C-c a <SPC>` for a design discussion. When enabled, AI Code asks at send time whether to append 2-3 numbered next-step suggestions, and the transient toggle on `C-c a F` lets you turn the feature on or off from the menu.
+- *Discussion follow-up suggestions*: `ai-code-discussion-auto-follow-up-enabled` is enabled by default. Set `(setq ai-code-discussion-auto-follow-up-enabled nil)` to turn it off. Then ask a question with `C-c a q` or use `C-c a <SPC>` for a design discussion. When enabled, AI Code asks at send time whether to append 2-3 numbered next-step suggestions, and the transient toggle on `C-c a F` lets you turn the feature on or off from the menu.
 - *Refactoring a Function*: With the cursor in a function, press `C-c a`, then `r` (`ai-code-refactor-book-method`). Select a refactoring technique from the list, provide any required input (e.g., a new method name), and the prompt will be generated.
 - *Automatically run tests after change*: When ai-code-auto-test-type is non-nil, AI will automatically run tests after code changes and follow up on results.
 - *One-prompt TDD with refactoring*: Press `C-c a`, then `t` (`ai-code-tdd-cycle`) and choose `5. Red + Green + Blue (One prompt)` to generate tests, implement code, run tests, and then refactor the changed code in one flow.

--- a/ai-code.el
+++ b/ai-code.el
@@ -59,8 +59,8 @@
 ;;   ;; (ai-code-prompt-filepath-completion-mode -1)
 ;;   ;; Optional: Configure AI test prompting mode (e.g., ask about running tests/TDD) for a tighter build-test loop
 ;;   (setq ai-code-auto-test-type 'ask-me)
-;;   ;; Optional: Offer numbered next steps for discussion prompts at send time
-;;   ;; (setq ai-code-discussion-auto-follow-up-enabled t)
+;;   ;; Optional: Disable numbered next steps for discussion prompts at send time
+;;   ;; (setq ai-code-discussion-auto-follow-up-enabled nil)
 ;;   ;; Optional: In the AI session buffer (Evil normal state), SPC triggers the prompt entry UI
 ;;   (with-eval-after-load 'evil (ai-code-backends-infra-evil-setup))
 ;;   (global-auto-revert-mode 1)
@@ -176,7 +176,7 @@ See the later `defcustom' for user-facing documentation and default.")
 (defvar ai-code-discussion-auto-follow-up-suffix nil
   "Send-time prompt suffix that requests numbered next-step suggestions.")
 
-(defvar ai-code-discussion-auto-follow-up-enabled nil
+(defvar ai-code-discussion-auto-follow-up-enabled t
   "Forward declaration for `ai-code-discussion-auto-follow-up-enabled'.
 See the later `defcustom' for user-facing documentation and default.")
 
@@ -409,11 +409,12 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   :set #'ai-code--test-after-code-change--set
   :group 'ai-code)
 
-(defcustom ai-code-discussion-auto-follow-up-enabled nil
+(defcustom ai-code-discussion-auto-follow-up-enabled t
   "When non-nil, prompts may request numbered next-step suggestions.
-Customize this to non-nil to turn on the send-time choice globally.
-Pair it with `ai-code-use-gptel-classify-prompt` when you want
-code-change prompts to skip these discussion follow-up suggestions."
+This is enabled by default; customize it to nil to turn the send-time
+choice off globally. Pair it with `ai-code-use-gptel-classify-prompt`
+when you want code-change prompts to skip these discussion follow-up
+suggestions."
   :type 'boolean
   :set (lambda (symbol value)
          (set-default symbol value)

--- a/ai-code.el
+++ b/ai-code.el
@@ -192,11 +192,6 @@ See the later `defcustom' for user-facing documentation and default.")
     ("Off" . nil))
   "Persistent choices for `ai-code-auto-test-type`.")
 
-(defconst ai-code--auto-follow-up-type-ask-choices
-  '(("Suggest next steps" . t)
-    ("No next-step suggestions" . nil))
-  "Resolve next-step suggestion choices for `ask-me` mode.")
-
 (defconst ai-code--auto-test-type-legacy-persistent-modes
   '(test-after-change tdd tdd-with-refactoring)
   "Legacy persistent values still honored for backward compatibility.")
@@ -214,13 +209,7 @@ See the later `defcustom' for user-facing documentation and default.")
 
 (defun ai-code--read-auto-follow-up-choice ()
   "Read whether to request numbered next-step suggestions for this send action."
-  (let* ((choice (completing-read "Discussion follow-up suggestions: "
-                                  (mapcar #'car ai-code--auto-follow-up-type-ask-choices)
-                                  nil t nil nil
-                                  (caar ai-code--auto-follow-up-type-ask-choices)))
-         (choice-cell (assoc choice ai-code--auto-follow-up-type-ask-choices)))
-    (and choice-cell
-         (cdr choice-cell))))
+  (y-or-n-p "Discussion follow-up suggestions (y/n)? "))
 
 ;;;###autoload
 (defcustom ai-code-use-gptel-classify-prompt nil

--- a/ai-code.el
+++ b/ai-code.el
@@ -209,7 +209,7 @@ See the later `defcustom' for user-facing documentation and default.")
 
 (defun ai-code--read-auto-follow-up-choice ()
   "Read whether to request numbered next-step suggestions for this send action."
-  (y-or-n-p "Discussion follow-up suggestions (y/n)? "))
+  (y-or-n-p "Discussion follow-up suggestions? "))
 
 ;;;###autoload
 (defcustom ai-code-use-gptel-classify-prompt nil

--- a/ai-code.el
+++ b/ai-code.el
@@ -1,7 +1,7 @@
 ;;; ai-code.el --- Unified interface for AI coding backends such as Codex CLI, Copilot CLI, Claude Code, Gemini CLI, Opencode, Kilo, Grok CLI, etc -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 1.77
+;; Version: 1.78
 ;; Package-Requires: ((emacs "29.1") (transient "0.9.0") (magit "2.1.0"))
 ;; URL: https://github.com/tninja/ai-code-interface.el
 

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -214,7 +214,9 @@
                (lambda (&rest _args)
                  (ert-fail "Should not use completing-read for follow-up y/n choice."))))
       (should (eq t (ai-code--read-auto-follow-up-choice)))
-      (should (equal asked-prompt "Discussion follow-up suggestions (y/n)? ")))))
+      (should (string-match-p
+               "\\`Discussion follow-up suggestions\\(?: (y/n)\\)?\\? \\'"
+               asked-prompt)))))
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-off ()
   "Test that off mode never resolves a discussion follow-up suffix."

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -203,6 +203,19 @@
                (lambda (&rest _args) "TDD Red + Green + Blue (refactor after Green)")))
       (should (eq 'tdd-with-refactoring (ai-code--read-auto-test-type-choice))))))
 
+(ert-deftest ai-code-test-read-auto-follow-up-choice-uses-y-or-n-p ()
+  "Test that follow-up choice reads a y/n decision."
+  (let ((asked-prompt nil))
+    (cl-letf (((symbol-function 'y-or-n-p)
+               (lambda (prompt)
+                 (setq asked-prompt prompt)
+                 t))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _args)
+                 (ert-fail "Should not use completing-read for follow-up y/n choice."))))
+      (should (eq t (ai-code--read-auto-follow-up-choice)))
+      (should (equal asked-prompt "Discussion follow-up suggestions (y/n)? ")))))
+
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-off ()
   "Test that off mode never resolves a discussion follow-up suffix."
   (let ((ai-code-discussion-auto-follow-up-enabled nil)
@@ -217,15 +230,26 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t)))
+               (lambda (&rest _args) t)))
       (should (string-match-p
                "3-4 numbered candidate next[[:space:]\n]+steps"
                (ai-code--resolve-auto-follow-up-suffix-for-send
                 "Explain this function")))
       (should (string-match-p
                "At least 2 candidates must[[:space:]\n]+be AI-actionable items"
-               (ai-code--resolve-auto-follow-up-suffix-for-send
-                "Explain this function"))))))
+                (ai-code--resolve-auto-follow-up-suffix-for-send
+                 "Explain this function"))))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-calls-choice-reader-without-args ()
+  "Test that follow-up choice reader is called without extra arguments."
+  (let ((ai-code-discussion-auto-follow-up-enabled t)
+        (ai-code-next-step-suggestion-suffix "FOLLOW-UP")
+        (ai-code-use-gptel-classify-prompt nil))
+    (cl-letf (((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () t)))
+      (should (equal "FOLLOW-UP"
+                     (ai-code--resolve-auto-follow-up-suffix-for-send
+                      "Explain this function"))))))
 
 (ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-ask-me-code-change-skips ()
   "Test that ask-me mode does not offer next-step suggestions for code-change prompts."
@@ -236,7 +260,7 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda ()
+               (lambda (&rest _args)
                  (setq asked t)
                  t)))
       (should-not
@@ -253,7 +277,7 @@
                (lambda (_prompt-text)
                  (ert-fail "Should not call GPTel for code-change prompt markers.")))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda ()
+               (lambda (&rest _args)
                  (setq asked t)
                  t)))
       (should-not
@@ -268,7 +292,7 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t)))
+               (lambda (&rest _args) t)))
       (let ((this-command 'ai-code-ask-question))
         (should (string-match-p
                  "The user may also[[:space:]\n]+ignore these options"
@@ -291,7 +315,7 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t))
+               (lambda (&rest _args) t))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code-cli-send-command)
@@ -322,7 +346,7 @@
         (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                    (lambda (_prompt-text) 'non-code-change))
                   ((symbol-function 'ai-code--read-auto-follow-up-choice)
-                   (lambda () t))
+                   (lambda (&rest _args) t))
                   ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                    (lambda () prompt-file))
                   ((symbol-function 'ai-code-cli-send-command)
@@ -352,7 +376,7 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t))
+               (lambda (&rest _args) t))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code-cli-send-command)

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -495,6 +495,10 @@
     'boolean
     (get 'ai-code-discussion-auto-follow-up-enabled 'custom-type))))
 
+(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-default-is-on ()
+  "Test that discussion auto follow-up defaults to enabled."
+  (should (eq t (default-value 'ai-code-discussion-auto-follow-up-enabled))))
+
 (ert-deftest ai-code-test-resolve-auto-test-suffix-for-send-ask-me-tdd-with-refactoring ()
   "Test that ask-me resolves to the repo-local TDD harness reference."
   (let* ((temp-root (make-temp-file "ai-code-harness-root-" t))
@@ -528,6 +532,7 @@
   "Test that ask-me no-test choice appends explicit no-test instruction."
   (let ((sent-command nil)
         (ai-code-auto-test-type 'ask-me)
+        (ai-code-discussion-auto-follow-up-enabled nil)
         (ai-code-use-prompt-suffix t)
         (ai-code-prompt-suffix "BASE SUFFIX")
         (ai-code-auto-test-suffix "SHOULD NOT APPEAR"))


### PR DESCRIPTION
The auto follow up suggestion (introduced in https://github.com/tninja/ai-code-interface.el/pull/283) turns out to be very useful in my daily work. This PR did:

1. Turn it on by default. This is just about to let user to choose use it or not (in 2).
2. Let user use y/n to use it in each non code change question.