### PR TITLE
Chore: Route prompts to visible AI session buffers

### DIFF
--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -22,7 +22,7 @@
 (defvar ai-code-discussion-auto-follow-up-enabled)
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
-(defvar ai-code-backends-infra--session-terminal-backend
+(defvar ai-code-backends-infra--session-terminal-backend nil
   "Terminal backend recorded on terminal-managed AI session buffers.")
 
 (declare-function yas-load-directory "yasnippet" (dir))

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -23,7 +23,7 @@
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 (defvar ai-code-backends-infra--session-terminal-backend nil
-  "Terminal backend symbol for terminal-managed AI session buffers, or nil.")
+  "Terminal backend symbol from `ai-code-backends-infra.el', or nil.")
 
 (declare-function yas-load-directory "yasnippet" (dir))
 (declare-function yas-minor-mode "yasnippet")

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -22,6 +22,7 @@
 (defvar ai-code-discussion-auto-follow-up-enabled)
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
+(defvar ai-code-backends-infra--session-terminal-backend)
 
 (declare-function yas-load-directory "yasnippet" (dir))
 (declare-function yas-minor-mode "yasnippet")
@@ -182,27 +183,31 @@ that should be recorded in the prompt history file."
   (ai-code--format-and-insert-prompt stored-prompt-text))
 
 (defun ai-code--find-visible-session-buffer ()
-  "Return an AI session buffer visible in the current frame, or nil."
+  "Return a visible terminal-managed AI session buffer in the current frame."
   (cl-some
    (lambda (win)
-     (let ((buf (window-buffer win)))
-       (when (and (buffer-live-p buf)
-                  (ai-code-backends-infra--session-buffer-p buf))
-         buf)))
+      (let ((buf (window-buffer win)))
+        (when (and (buffer-live-p buf)
+                   (ai-code-backends-infra--session-buffer-p buf)
+                   (buffer-local-value
+                    'ai-code-backends-infra--session-terminal-backend buf))
+          buf)))
    (window-list nil 'no-minibuffer)))
 
 (defun ai-code--find-project-session-buffers ()
-  "Return AI session buffers associated with the current project."
+  "Return terminal-managed AI session buffers associated with the current project."
   (when-let ((git-root (ai-code--git-root)))
     (cl-remove-if-not
      (lambda (buf)
-       (and (ai-code-backends-infra--session-buffer-p buf)
-            (ai-code-backends-infra--session-buffer-matches-directory-p buf git-root)))
+        (and (ai-code-backends-infra--session-buffer-p buf)
+             (buffer-local-value
+              'ai-code-backends-infra--session-terminal-backend buf)
+             (ai-code-backends-infra--session-buffer-matches-directory-p buf git-root)))
      (buffer-list))))
 
 (defun ai-code--prompt-choose-target-session ()
   "Choose AI session buffer to send prompt to.
-Return session buffer when a non-default target is chosen, nil for default."
+Return session buffer for direct routing, or nil to use default backend dispatch."
   (when-let ((visible-session (ai-code--find-visible-session-buffer)))
     (let* ((project-sessions (ai-code--find-project-session-buffers))
            (visible-is-project-session (memq visible-session project-sessions))
@@ -244,8 +249,6 @@ backend dispatch."
 
 (defun ai-code--write-prompt-to-file-and-send (prompt-text)
   "Write PROMPT-TEXT to the AI prompt file."
-  ;; DONE: right now it can only sent prompt to buffer associated ai coding session, which belong to the same git repo. If there is already a AI coding session buffer opened in side panel in same window, it should allow the prompt send to it. If there is already a ai coding session opened for the triggered buffer, but current side panel shows a different session, it should ask user to choose which session it want to send to.
-  ;; DONE: if the current side panel ai coding session is in the same git repo of the triggered buffer file, it should go through the same code path as before, no need to ask user to select session
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
                                          ai-code-auto-test-suffix)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -186,12 +186,12 @@ that should be recorded in the prompt history file."
   "Return a visible terminal-managed AI session buffer in the current frame."
   (cl-some
    (lambda (win)
-      (let ((buf (window-buffer win)))
-        (when (and (buffer-live-p buf)
-                   (ai-code-backends-infra--session-buffer-p buf)
-                   (buffer-local-value
-                    'ai-code-backends-infra--session-terminal-backend buf))
-          buf)))
+     (let ((buf (window-buffer win)))
+       (when (and (buffer-live-p buf)
+                  (ai-code-backends-infra--session-buffer-p buf)
+                  (buffer-local-value
+                   'ai-code-backends-infra--session-terminal-backend buf))
+         buf)))
    (window-list nil 'no-minibuffer)))
 
 (defun ai-code--find-project-session-buffers ()
@@ -199,10 +199,10 @@ that should be recorded in the prompt history file."
   (when-let ((git-root (ai-code--git-root)))
     (cl-remove-if-not
      (lambda (buf)
-        (and (ai-code-backends-infra--session-buffer-p buf)
-             (buffer-local-value
-              'ai-code-backends-infra--session-terminal-backend buf)
-             (ai-code-backends-infra--session-buffer-matches-directory-p buf git-root)))
+       (and (ai-code-backends-infra--session-buffer-p buf)
+            (buffer-local-value
+             'ai-code-backends-infra--session-terminal-backend buf)
+            (ai-code-backends-infra--session-buffer-matches-directory-p buf git-root)))
      (buffer-list))))
 
 (defun ai-code--prompt-choose-target-session ()

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -35,6 +35,11 @@
 (declare-function ai-code--choose-symbol-from-file "ai-code-input" (file))
 (declare-function ai-code-read-string "ai-code-input" (prompt &optional initial-input candidate-list))
 (declare-function ai-code-current-backend-label "ai-code-backends" ())
+(declare-function ai-code-backends-infra--session-buffer-p "ai-code-backends-infra" (buffer))
+(declare-function ai-code-backends-infra--session-buffer-matches-directory-p "ai-code-backends-infra" (buffer directory))
+(declare-function ai-code-backends-infra--terminal-send-string "ai-code-backends-infra" (string))
+(declare-function ai-code-backends-infra--terminal-send-return "ai-code-backends-infra" ())
+(declare-function ai-code-backends-infra--display-buffer-in-side-window "ai-code-backends-infra" (buffer))
 
 (defcustom ai-code-prompt-preprocess-filepaths t
   "When non-nil, preprocess the prompt to replace file paths.
@@ -176,13 +181,68 @@ that should be recorded in the prompt history file."
   (ai-code--insert-backend-label-drawer)
   (ai-code--format-and-insert-prompt stored-prompt-text))
 
+(defun ai-code--find-visible-session-buffer ()
+  "Return an AI session buffer visible in the current frame, or nil."
+  (cl-some
+   (lambda (win)
+     (let ((buf (window-buffer win)))
+       (when (and (buffer-live-p buf)
+                  (ai-code-backends-infra--session-buffer-p buf))
+         buf)))
+   (window-list nil 'no-minibuffer)))
+
+(defun ai-code--find-project-session-buffers ()
+  "Return AI session buffers associated with the current project."
+  (when-let ((git-root (ai-code--git-root)))
+    (cl-remove-if-not
+     (lambda (buf)
+       (and (ai-code-backends-infra--session-buffer-p buf)
+            (ai-code-backends-infra--session-buffer-matches-directory-p buf git-root)))
+     (buffer-list))))
+
+(defun ai-code--prompt-choose-target-session ()
+  "Choose AI session buffer to send prompt to.
+Return session buffer when a non-default target is chosen, nil for default."
+  (when-let ((visible-session (ai-code--find-visible-session-buffer)))
+    (let* ((project-sessions (ai-code--find-project-session-buffers))
+           (competing-sessions
+            (cl-remove visible-session project-sessions)))
+      (cond
+       ((null competing-sessions)
+        visible-session)
+       (t
+        (let* ((choice-alist (mapcar (lambda (buf)
+                                       (cons (buffer-name buf) buf))
+                                     (cons visible-session competing-sessions)))
+               (selection (completing-read
+                           "Multiple AI sessions available.  Send to: "
+                           (mapcar #'car choice-alist)
+                           nil t nil nil (buffer-name visible-session))))
+          (cdr (assoc selection choice-alist))))))))
+
+(defun ai-code--send-prompt-to-session-buffer (prompt buffer)
+  "Send PROMPT directly to session BUFFER and display it."
+  (with-current-buffer buffer
+    (ai-code-backends-infra--terminal-send-string prompt)
+    (sit-for 0.5)
+    (ai-code-backends-infra--terminal-send-return))
+  (if-let ((window (get-buffer-window buffer)))
+      (select-window window)
+    (ai-code-backends-infra--display-buffer-in-side-window buffer)))
+
 (defun ai-code--send-prompt (full-prompt)
-  "Send FULL-PROMPT to AI."
-  (ai-code-cli-send-command full-prompt)
-  (ai-code-cli-switch-to-buffer))
+  "Send FULL-PROMPT to AI.
+When a visible AI session buffer is detected in the current frame,
+send the prompt directly to it instead of going through the default
+backend dispatch."
+  (if-let ((target (ai-code--prompt-choose-target-session)))
+      (ai-code--send-prompt-to-session-buffer full-prompt target)
+    (ai-code-cli-send-command full-prompt)
+    (ai-code-cli-switch-to-buffer)))
 
 (defun ai-code--write-prompt-to-file-and-send (prompt-text)
   "Write PROMPT-TEXT to the AI prompt file."
+  ;; DONE: right now it can only sent prompt to buffer associated ai coding session, which belong to the same git repo. If there is already a AI coding session buffer opened in side panel in same window, it should allow the prompt send to it. If there is already a ai coding session opened for the triggered buffer, but current side panel shows a different session, it should ask user to choose which session it want to send to.
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
                                          ai-code-auto-test-suffix)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -23,7 +23,7 @@
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 (defvar ai-code-backends-infra--session-terminal-backend nil
-  "Terminal backend recorded on terminal-managed AI session buffers.")
+  "Terminal backend symbol for terminal-managed AI session buffers, or nil.")
 
 (declare-function yas-load-directory "yasnippet" (dir))
 (declare-function yas-minor-mode "yasnippet")

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -205,9 +205,11 @@ that should be recorded in the prompt history file."
 Return session buffer when a non-default target is chosen, nil for default."
   (when-let ((visible-session (ai-code--find-visible-session-buffer)))
     (let* ((project-sessions (ai-code--find-project-session-buffers))
+           (visible-is-project-session (memq visible-session project-sessions))
            (competing-sessions
             (cl-remove visible-session project-sessions)))
       (cond
+       (visible-is-project-session nil)
        ((null competing-sessions)
         visible-session)
        (t
@@ -243,6 +245,7 @@ backend dispatch."
 (defun ai-code--write-prompt-to-file-and-send (prompt-text)
   "Write PROMPT-TEXT to the AI prompt file."
   ;; DONE: right now it can only sent prompt to buffer associated ai coding session, which belong to the same git repo. If there is already a AI coding session buffer opened in side panel in same window, it should allow the prompt send to it. If there is already a ai coding session opened for the triggered buffer, but current side panel shows a different session, it should ask user to choose which session it want to send to.
+  ;; DONE: if the current side panel ai coding session is in the same git repo of the triggered buffer file, it should go through the same code path as before, no need to ask user to select session
   (let* ((suffix-parts (delq nil (list ai-code-prompt-suffix
                                        (when ai-code-auto-test-type
                                          ai-code-auto-test-suffix)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -23,7 +23,10 @@
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 (defvar ai-code-backends-infra--session-terminal-backend nil
-  "Terminal backend symbol from `ai-code-backends-infra.el', or nil.")
+  "Buffer-local terminal backend symbol for an AI session buffer, or nil.
+This is set by `ai-code-backends-infra.el' for terminal-managed sessions
+such as `vterm' and `eat'.  A nil value means the buffer is not managed by
+the terminal backend infrastructure.")
 
 (declare-function yas-load-directory "yasnippet" (dir))
 (declare-function yas-minor-mode "yasnippet")

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -22,7 +22,8 @@
 (defvar ai-code-discussion-auto-follow-up-enabled)
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
-(defvar ai-code-backends-infra--session-terminal-backend)
+(defvar ai-code-backends-infra--session-terminal-backend
+  "Terminal backend recorded on terminal-managed AI session buffers.")
 
 (declare-function yas-load-directory "yasnippet" (dir))
 (declare-function yas-minor-mode "yasnippet")

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1518,7 +1518,7 @@ and ensures everything is cleaned up afterward."
           (with-current-buffer session-buf
             (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
             (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (buf _dir) (eq buf session-buf))))
+                      (lambda (_buf _dir) (eq _buf session-buf))))
               (should (memq session-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer session-buf)))))
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1515,11 +1515,11 @@ and ensures everything is cleaned up afterward."
   (ai-code-with-test-repo
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
-         (with-current-buffer session-buf
-           (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
-           (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (buf _dir) (eq buf session-buf))))
-             (should (memq session-buf (ai-code--find-project-session-buffers)))))
+          (with-current-buffer session-buf
+            (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                      (lambda (candidate-buf _dir) (eq candidate-buf session-buf))))
+              (should (memq session-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer session-buf)))))
 
 (ert-deftest ai-code-test-find-project-session-buffers-excludes-other-projects ()
@@ -1527,11 +1527,11 @@ and ensures everything is cleaned up afterward."
   (ai-code-with-test-repo
    (let ((other-buf (get-buffer-create "*claude[other-project]*")))
      (unwind-protect
-         (with-current-buffer other-buf
-           (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
-           (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (_buf _dir) nil)))
-             (should-not (memq other-buf (ai-code--find-project-session-buffers)))))
+          (with-current-buffer other-buf
+            (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                      (lambda (_candidate-buf _dir) nil)))
+              (should-not (memq other-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer other-buf)))))
 
 (ert-deftest ai-code-test-find-project-session-buffers-excludes-non-terminal-sessions ()
@@ -1540,7 +1540,7 @@ and ensures everything is cleaned up afterward."
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
          (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (_buf _dir) t)))
+                    (lambda (_candidate-buf _dir) t)))
            (should-not (memq session-buf (ai-code--find-project-session-buffers))))
        (kill-buffer session-buf)))))
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1474,5 +1474,142 @@ and ensures everything is cleaned up afterward."
         (should (string-match-p (regexp-quote ":AGENT: gemini") content))
         (should (string-match-p (regexp-quote ":END:") content))))))
 
+;;; Tests for visible session routing in ai-code--send-prompt
+
+(ert-deftest ai-code-test-find-visible-session-buffer-returns-session ()
+  "Find a session buffer in visible windows."
+  (let ((session-buf (get-buffer-create "*claude[test-project]*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'window-list)
+                   (lambda (&optional _frame _no-minibuf)
+                     '(win1 win2)))
+                  ((symbol-function 'window-buffer)
+                   (lambda (win)
+                     (if (eq win 'win1) (get-buffer "*scratch*") session-buf))))
+          (should (eq (ai-code--find-visible-session-buffer) session-buf)))
+      (kill-buffer session-buf))))
+
+(ert-deftest ai-code-test-find-visible-session-buffer-nil-when-no-sessions ()
+  "Return nil when no session buffers are visible."
+  (cl-letf (((symbol-function 'window-list)
+             (lambda (&optional _frame _no-minibuf) '(win1)))
+            ((symbol-function 'window-buffer)
+             (lambda (_win) (get-buffer "*scratch*"))))
+    (should-not (ai-code--find-visible-session-buffer))))
+
+(ert-deftest ai-code-test-find-project-session-buffers-finds-matching ()
+  "Find session buffers matching the current project directory."
+  (ai-code-with-test-repo
+   (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
+     (unwind-protect
+         (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                    (lambda (buf dir) (eq buf session-buf))))
+           (should (memq session-buf (ai-code--find-project-session-buffers))))
+       (kill-buffer session-buf)))))
+
+(ert-deftest ai-code-test-find-project-session-buffers-excludes-other-projects ()
+  "Exclude session buffers for other projects."
+  (ai-code-with-test-repo
+   (let ((other-buf (get-buffer-create "*claude[other-project]*")))
+     (unwind-protect
+         (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                    (lambda (_buf _dir) nil)))
+           (should-not (memq other-buf (ai-code--find-project-session-buffers))))
+       (kill-buffer other-buf)))))
+
+(ert-deftest ai-code-test-prompt-choose-target-session-nil-when-no-visible ()
+  "Return nil when no visible session buffers."
+  (cl-letf (((symbol-function 'ai-code--find-visible-session-buffer)
+             (lambda () nil)))
+    (should-not (ai-code--prompt-choose-target-session))))
+
+(ert-deftest ai-code-test-prompt-choose-target-session-returns-visible-when-only-option ()
+  "Return visible session buffer when no other project sessions differ."
+  (let ((session-buf (get-buffer-create "*claude[test]*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--find-visible-session-buffer)
+                   (lambda () session-buf))
+                  ((symbol-function 'ai-code--find-project-session-buffers)
+                   (lambda () (list session-buf))))
+          (should (eq (ai-code--prompt-choose-target-session) session-buf)))
+      (kill-buffer session-buf))))
+
+(ert-deftest ai-code-test-prompt-choose-target-session-returns-visible-when-no-project-session ()
+  "Return visible session buffer when current project has no sessions."
+  (let ((visible-buf (get-buffer-create "*gemini[other-project]*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--find-visible-session-buffer)
+                   (lambda () visible-buf))
+                  ((symbol-function 'ai-code--find-project-session-buffers)
+                   (lambda () nil)))
+          (should (eq (ai-code--prompt-choose-target-session) visible-buf)))
+      (kill-buffer visible-buf))))
+
+(ert-deftest ai-code-test-prompt-choose-target-session-asks-when-sessions-differ ()
+  "Ask user to choose when visible and project sessions differ."
+  (let ((visible-buf (get-buffer-create "*gemini[other-project]*"))
+        (project-buf (get-buffer-create "*claude[my-project]*"))
+        (offered-choices nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--find-visible-session-buffer)
+                   (lambda () visible-buf))
+                  ((symbol-function 'ai-code--find-project-session-buffers)
+                   (lambda () (list project-buf)))
+                  ((symbol-function 'completing-read)
+                   (lambda (_prompt collection &rest _args)
+                     (setq offered-choices collection)
+                     (buffer-name project-buf))))
+          (let ((result (ai-code--prompt-choose-target-session)))
+            (should (eq result project-buf))
+            (should (member (buffer-name visible-buf) offered-choices))
+            (should (member (buffer-name project-buf) offered-choices))))
+      (kill-buffer visible-buf)
+      (kill-buffer project-buf))))
+
+(ert-deftest ai-code-test-send-prompt-uses-visible-session-directly ()
+  "Send prompt directly to visible session when target is resolved."
+  (let ((session-buf (get-buffer-create "*claude[test]*"))
+        (sent-string nil)
+        (return-sent nil)
+        (displayed-buffer nil)
+        (cli-send-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--prompt-choose-target-session)
+                   (lambda () session-buf))
+                  ((symbol-function 'ai-code-backends-infra--terminal-send-string)
+                   (lambda (str) (setq sent-string str)))
+                  ((symbol-function 'ai-code-backends-infra--terminal-send-return)
+                   (lambda () (setq return-sent t)))
+                  ((symbol-function 'get-buffer-window)
+                   (lambda (_buf &rest _) nil))
+                  ((symbol-function 'ai-code-backends-infra--display-buffer-in-side-window)
+                   (lambda (buf) (setq displayed-buffer buf)))
+                  ((symbol-function 'ai-code-cli-send-command)
+                   (lambda (_cmd) (setq cli-send-called t)))
+                  ((symbol-function 'ai-code-cli-switch-to-buffer)
+                   (lambda () nil))
+                  ((symbol-function 'sit-for)
+                   (lambda (_secs) nil)))
+          (ai-code--send-prompt "test prompt")
+          (should (string= sent-string "test prompt"))
+          (should return-sent)
+          (should (eq displayed-buffer session-buf))
+          (should-not cli-send-called))
+      (kill-buffer session-buf))))
+
+(ert-deftest ai-code-test-send-prompt-falls-through-when-no-visible-session ()
+  "Use default path when no visible session is chosen."
+  (let ((cli-send-called nil)
+        (switch-called nil))
+    (cl-letf (((symbol-function 'ai-code--prompt-choose-target-session)
+               (lambda () nil))
+              ((symbol-function 'ai-code-cli-send-command)
+               (lambda (cmd) (setq cli-send-called cmd)))
+              ((symbol-function 'ai-code-cli-switch-to-buffer)
+               (lambda () (setq switch-called t))))
+      (ai-code--send-prompt "test prompt")
+      (should (string= cli-send-called "test prompt"))
+      (should switch-called))))
+
 (provide 'test-ai-code-prompt-mode)
 ;;; test_ai-code-prompt-mode.el ends here

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1540,7 +1540,7 @@ and ensures everything is cleaned up afterward."
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
          (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (buf _dir) (eq buf session-buf))))
+                    (lambda (_buf _dir) t)))
            (should-not (memq session-buf (ai-code--find-project-session-buffers))))
        (kill-buffer session-buf)))))
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1518,7 +1518,8 @@ and ensures everything is cleaned up afterward."
           (with-current-buffer session-buf
             (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
             (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (candidate-buf _dir) (eq candidate-buf session-buf))))
+                      (lambda (candidate-buf &rest _)
+                        (eq candidate-buf session-buf))))
               (should (memq session-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer session-buf)))))
 
@@ -1530,7 +1531,7 @@ and ensures everything is cleaned up afterward."
           (with-current-buffer other-buf
             (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
             (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (_candidate-buf _dir) nil)))
+                      (lambda (&rest _) nil)))
               (should-not (memq other-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer other-buf)))))
 
@@ -1540,7 +1541,7 @@ and ensures everything is cleaned up afterward."
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
          (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (_candidate-buf _dir) t)))
+                    (lambda (&rest _) t)))
            (should-not (memq session-buf (ai-code--find-project-session-buffers))))
        (kill-buffer session-buf)))))
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1480,13 +1480,15 @@ and ensures everything is cleaned up afterward."
   "Find a session buffer in visible windows."
   (let ((session-buf (get-buffer-create "*claude[test-project]*")))
     (unwind-protect
-        (cl-letf (((symbol-function 'window-list)
-                   (lambda (&optional _frame _no-minibuf)
-                     '(win1 win2)))
-                  ((symbol-function 'window-buffer)
-                   (lambda (win)
-                     (if (eq win 'win1) (get-buffer "*scratch*") session-buf))))
-          (should (eq (ai-code--find-visible-session-buffer) session-buf)))
+        (with-current-buffer session-buf
+          (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+          (cl-letf (((symbol-function 'window-list)
+                     (lambda (&optional _frame _no-minibuf)
+                       '(win1 win2)))
+                    ((symbol-function 'window-buffer)
+                     (lambda (win)
+                       (if (eq win 'win1) (get-buffer "*scratch*") session-buf))))
+            (should (eq (ai-code--find-visible-session-buffer) session-buf))))
       (kill-buffer session-buf))))
 
 (ert-deftest ai-code-test-find-visible-session-buffer-nil-when-no-sessions ()
@@ -1497,25 +1499,50 @@ and ensures everything is cleaned up afterward."
              (lambda (_win) (get-buffer "*scratch*"))))
     (should-not (ai-code--find-visible-session-buffer))))
 
+(ert-deftest ai-code-test-find-visible-session-buffer-ignores-non-terminal-sessions ()
+  "Ignore visible session-like buffers that are not terminal managed."
+  (let ((session-buf (get-buffer-create "*claude[test-project]*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'window-list)
+                   (lambda (&optional _frame _no-minibuf) '(win1)))
+                  ((symbol-function 'window-buffer)
+                   (lambda (_win) session-buf)))
+          (should-not (ai-code--find-visible-session-buffer)))
+      (kill-buffer session-buf))))
+
 (ert-deftest ai-code-test-find-project-session-buffers-finds-matching ()
   "Find session buffers matching the current project directory."
   (ai-code-with-test-repo
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
-         (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (buf dir) (eq buf session-buf))))
-           (should (memq session-buf (ai-code--find-project-session-buffers))))
-       (kill-buffer session-buf)))))
+         (with-current-buffer session-buf
+           (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+           (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                      (lambda (buf _dir) (eq buf session-buf))))
+             (should (memq session-buf (ai-code--find-project-session-buffers)))))
+        (kill-buffer session-buf)))))
 
 (ert-deftest ai-code-test-find-project-session-buffers-excludes-other-projects ()
   "Exclude session buffers for other projects."
   (ai-code-with-test-repo
    (let ((other-buf (get-buffer-create "*claude[other-project]*")))
      (unwind-protect
+         (with-current-buffer other-buf
+           (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+           (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
+                      (lambda (_buf _dir) nil)))
+             (should-not (memq other-buf (ai-code--find-project-session-buffers)))))
+        (kill-buffer other-buf)))))
+
+(ert-deftest ai-code-test-find-project-session-buffers-excludes-non-terminal-sessions ()
+  "Exclude project sessions that are not terminal managed."
+  (ai-code-with-test-repo
+   (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
+     (unwind-protect
          (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (_buf _dir) nil)))
-           (should-not (memq other-buf (ai-code--find-project-session-buffers))))
-       (kill-buffer other-buf)))))
+                    (lambda (buf _dir) (eq buf session-buf))))
+           (should-not (memq session-buf (ai-code--find-project-session-buffers))))
+       (kill-buffer session-buf)))))
 
 (ert-deftest ai-code-test-prompt-choose-target-session-nil-when-no-visible ()
   "Return nil when no visible session buffers."

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1518,8 +1518,7 @@ and ensures everything is cleaned up afterward."
           (with-current-buffer session-buf
             (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
             (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (candidate-buf &rest _)
-                        (eq candidate-buf session-buf))))
+                      (lambda (buf _dir) (eq buf session-buf))))
               (should (memq session-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer session-buf)))))
 
@@ -1531,7 +1530,7 @@ and ensures everything is cleaned up afterward."
           (with-current-buffer other-buf
             (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
             (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                      (lambda (&rest _) nil)))
+                      (lambda (_buf _dir) nil)))
               (should-not (memq other-buf (ai-code--find-project-session-buffers)))))
         (kill-buffer other-buf)))))
 
@@ -1541,7 +1540,7 @@ and ensures everything is cleaned up afterward."
    (let ((session-buf (get-buffer-create "*claude[test-repo]*")))
      (unwind-protect
          (cl-letf (((symbol-function 'ai-code-backends-infra--session-buffer-matches-directory-p)
-                    (lambda (&rest _) t)))
+                    (lambda (_buf _dir) t)))
            (should-not (memq session-buf (ai-code--find-project-session-buffers))))
        (kill-buffer session-buf)))))
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1524,14 +1524,14 @@ and ensures everything is cleaned up afterward."
     (should-not (ai-code--prompt-choose-target-session))))
 
 (ert-deftest ai-code-test-prompt-choose-target-session-returns-visible-when-only-option ()
-  "Return visible session buffer when no other project sessions differ."
+  "Return nil when visible session belongs to the same project (default dispatch)."
   (let ((session-buf (get-buffer-create "*claude[test]*")))
     (unwind-protect
         (cl-letf (((symbol-function 'ai-code--find-visible-session-buffer)
                    (lambda () session-buf))
                   ((symbol-function 'ai-code--find-project-session-buffers)
                    (lambda () (list session-buf))))
-          (should (eq (ai-code--prompt-choose-target-session) session-buf)))
+          (should-not (ai-code--prompt-choose-target-session)))
       (kill-buffer session-buf))))
 
 (ert-deftest ai-code-test-prompt-choose-target-session-returns-visible-when-no-project-session ()


### PR DESCRIPTION
This is about to make it possible to do things like take org-roam note on other repo