### PR TITLE
Feat: diagnostics baseline + observation envelope for MCP get_diagnostics

### DIFF
--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -28,7 +28,7 @@
 ;;;; Auto-Test Harness: Content and Cache
 
 (defconst ai-code--diagnostics-first-harness-instruction
-  "Record a diagnostics baseline with the get_diagnostics MCP tool before editing. After each edit, re-run get_diagnostics for the touched files and do not finish until they have no new diagnostics compared with the baseline."
+  "Before editing, record a diagnostics baseline by calling the diagnostics_baseline MCP tool. After each edit, call the get_diagnostics MCP tool with since=\"baseline\" for the touched files and do not finish until its status is \"clean\" (no new diagnostics versus the baseline)."
   "Shared diagnostics-first harness guidance for code-change prompts.")
 
 (defun ai-code--diagnostics-first-harness-instruction-inline ()

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -80,6 +80,13 @@ Use `auto' to prefer Flycheck and then Flymake when available."
 (defvar ai-code-mcp--current-session-id nil
   "Dynamically bound MCP session id for the current tool invocation.")
 
+(defvar ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal)
+  "Hash table mapping MCP session ids to recorded diagnostics baselines.
+Each value is a hash set whose keys are diagnostic identity strings.  The
+baseline lets `get_diagnostics' report only NEW diagnostics so the agent
+can verify it introduced no regressions, without tracking the baseline in
+the model context itself.")
+
 (defconst ai-code-mcp--protocol-version "2024-11-05"
   "Protocol version reported by the MCP core.")
 
@@ -112,11 +119,19 @@ Use `auto' to prefer Flycheck and then Flymake when available."
              :optional t)))
     (:function ai-code-mcp-get-diagnostics
      :name "get_diagnostics"
-     :description "Get language diagnostics for a file or the active project."
+     :description "Get language diagnostics as an observation envelope (status, summary, files, next_actions, artifacts) for a file or the active project.  Pass since=\"baseline\" to report only diagnostics that are new since diagnostics_baseline was called."
      :args ((:name "uri"
              :type string
              :description "Optional file URI to inspect."
+             :optional t)
+            (:name "since"
+             :type string
+             :description "Optional.  Use \"baseline\" to report only diagnostics new since the last diagnostics_baseline call."
              :optional t)))
+    (:function ai-code-mcp-diagnostics-baseline
+     :name "diagnostics_baseline"
+     :description "Record current project diagnostics as a baseline.  After editing, call get_diagnostics with since=\"baseline\" to verify no new diagnostics were introduced."
+     :args nil)
     (:function ai-code-mcp-get-project-files
      :name "get_project_files"
      :description "List regular files in the current project."
@@ -184,6 +199,7 @@ The default tool list includes:
 - `visible_buffers'
 - `buffer_query'
 - `get_diagnostics'
+- `diagnostics_baseline'
 - `get_project_files'
 - `get_project_buffers'
 - `notify_user'
@@ -232,8 +248,9 @@ Required keys are `:function', `:name', and `:description'."
            ai-code-mcp--sessions))
 
 (defun ai-code-mcp-unregister-session (session-id)
-  "Unregister MCP SESSION-ID."
-  (remhash session-id ai-code-mcp--sessions))
+  "Unregister MCP SESSION-ID and free its recorded diagnostics baseline."
+  (remhash session-id ai-code-mcp--sessions)
+  (remhash session-id ai-code-mcp--diagnostics-baselines))
 
 (defun ai-code-mcp-get-session-context (&optional session-id)
   "Return session context for SESSION-ID or the current session."
@@ -409,15 +426,188 @@ When START-LINE and NUM-LINES are non-nil, return only that line range."
               (ai-code-mcp--drop-trailing-newline
                (buffer-substring-no-properties start-pos (point))))))))))
 
-(defun ai-code-mcp-get-diagnostics (&optional uri)
-  "Return JSON diagnostics for URI or the active project."
-  (let ((diagnostics-by-file
-         (if uri
-             (ai-code-mcp--diagnostics-for-uri uri)
-           (ai-code-mcp--diagnostics-for-project))))
-    (if diagnostics-by-file
-        (json-encode (vconcat diagnostics-by-file))
-      "[]")))
+(defun ai-code-mcp-get-diagnostics (&optional uri since)
+  "Return a JSON diagnostics observation envelope for URI or the project.
+The envelope has `status', `summary', `files', `next_actions', and
+`artifacts' keys so the agent's verification loop reads an actionable
+signal instead of a raw list.  When SINCE is the string \"baseline\",
+report only diagnostics that are new relative to the baseline recorded by
+`ai-code-mcp-diagnostics-baseline', so the agent can confirm it introduced
+no new problems before finishing."
+  (let* ((entries (if uri
+                      (ai-code-mcp--diagnostics-for-uri uri)
+                    (ai-code-mcp--diagnostics-for-project)))
+         (delta (and (stringp since) (string-equal since "baseline"))))
+    (json-encode
+     (cond
+      ((and delta (not (ai-code-mcp--diagnostics-baseline-recorded-p)))
+       (ai-code-mcp--diagnostics-no-baseline-envelope))
+      (delta
+       (ai-code-mcp--diagnostics-envelope
+        (ai-code-mcp--diagnostics-new-since-baseline entries) 'delta))
+      (t
+       (ai-code-mcp--diagnostics-envelope entries 'current))))))
+
+(defun ai-code-mcp--diagnostics-summary (entries)
+  "Return a one-line human summary string for diagnostics ENTRIES."
+  (let ((file-count (length entries))
+        (total 0)
+        (errors 0)
+        (warnings 0))
+    (dolist (entry entries)
+      (seq-doseq (diagnostic (alist-get 'diagnostics entry))
+        (setq total (1+ total))
+        (pcase (alist-get 'severity diagnostic)
+          ("Error" (setq errors (1+ errors)))
+          ("Warning" (setq warnings (1+ warnings))))))
+    (if (zerop total)
+        "No diagnostics found."
+      (format "%d diagnostic%s across %d file%s (%d Error, %d Warning)."
+              total (if (= total 1) "" "s")
+              file-count (if (= file-count 1) "" "s")
+              errors warnings))))
+
+(defun ai-code-mcp--diagnostic-action-line (uri diagnostic)
+  "Return a one-line fix suggestion for DIAGNOSTIC located via URI."
+  (let* ((range (alist-get 'range diagnostic))
+         (start (alist-get 'start range))
+         (line (alist-get 'line start))
+         (column (alist-get 'character start))
+         (severity (alist-get 'severity diagnostic))
+         (message (alist-get 'message diagnostic))
+         (path (or (ignore-errors
+                     (ai-code-mcp--display-path
+                      (ai-code-mcp--uri-to-file-path uri)))
+                   uri)))
+    (format "Fix %s at %s:%s:%s - %s"
+            (or severity "issue") path (or line "?") (or column "?")
+            (or message ""))))
+
+(defun ai-code-mcp--diagnostics-next-actions (entries)
+  "Return a vector of fix suggestions for diagnostics ENTRIES."
+  (let (actions)
+    (dolist (entry entries)
+      (let ((uri (alist-get 'uri entry)))
+        (seq-doseq (diagnostic (alist-get 'diagnostics entry))
+          (push (ai-code-mcp--diagnostic-action-line uri diagnostic) actions))))
+    (vconcat (nreverse actions))))
+
+(defun ai-code-mcp--diagnostics-envelope (entries &optional context)
+  "Return a diagnostics observation envelope alist for ENTRIES.
+CONTEXT is `current' (default) or `delta'.  In the `delta' context the
+status and summary describe diagnostics that are new since the baseline
+and express the done-condition the agent must reach (new == 0)."
+  (let* ((has-issues (and entries t))
+         (status (cond ((not has-issues) "clean")
+                       ((eq context 'delta) "regression")
+                       (t "issues")))
+         (summary (cond
+                   ((eq context 'delta)
+                    (if has-issues
+                        (concat (ai-code-mcp--diagnostics-summary entries)
+                                " These are NEW versus the baseline;"
+                                " not done until new == 0.")
+                      (concat "No new diagnostics versus the baseline;"
+                              " done-condition met (new == 0).")))
+                   (t (ai-code-mcp--diagnostics-summary entries)))))
+    `((status . ,status)
+      (summary . ,summary)
+      (files . ,(vconcat entries))
+      (next_actions . ,(ai-code-mcp--diagnostics-next-actions entries))
+      (artifacts . ,(vconcat nil)))))
+
+(defun ai-code-mcp--diagnostics-baseline-key ()
+  "Return the baseline storage key for the active MCP session."
+  (or ai-code-mcp--current-session-id "default"))
+
+(defun ai-code-mcp--diagnostics-baseline-recorded-p ()
+  "Return non-nil when a diagnostics baseline exists for the active session."
+  (and (gethash (ai-code-mcp--diagnostics-baseline-key)
+                ai-code-mcp--diagnostics-baselines)
+       t))
+
+(defun ai-code-mcp--diagnostics-total-count (entries)
+  "Return the total number of diagnostics across ENTRIES."
+  (let ((total 0))
+    (dolist (entry entries total)
+      (setq total (+ total (length (alist-get 'diagnostics entry)))))))
+
+(defun ai-code-mcp--diagnostics-no-baseline-envelope ()
+  "Return an envelope explaining that no diagnostics baseline was recorded.
+This avoids reporting pre-existing diagnostics as regressions when the agent
+requests `since=\"baseline\"' without first calling `diagnostics_baseline'."
+  `((status . "no_baseline")
+    (summary . ,(concat "No diagnostics baseline recorded for this session;"
+                        " current diagnostics are not reported as regressions."))
+    (files . ,(vconcat nil))
+    (next_actions . ,(vector
+                      (concat "Call the diagnostics_baseline MCP tool, then"
+                              " re-run get_diagnostics with since=\"baseline\".")))
+    (artifacts . ,(vconcat nil))))
+
+(defun ai-code-mcp--diagnostic-identity (uri diagnostic)
+  "Return a stable identity string for DIAGNOSTIC located in URI.
+Position is intentionally excluded so edits that shift line numbers do not
+make a pre-existing diagnostic look new.  Trade-off: two diagnostics sharing
+uri/severity/source/message are treated as one, so a newly introduced
+duplicate of an existing message is not reported as new."
+  (format "%s\0%s\0%s\0%s"
+          (or uri "")
+          (or (alist-get 'severity diagnostic) "")
+          (or (alist-get 'source diagnostic) "")
+          (or (alist-get 'message diagnostic) "")))
+
+(defun ai-code-mcp--diagnostics-identity-set (entries)
+  "Return a hash set of identity strings for diagnostics ENTRIES."
+  (let ((set (make-hash-table :test 'equal)))
+    (dolist (entry entries set)
+      (let ((uri (alist-get 'uri entry)))
+        (seq-doseq (diagnostic (alist-get 'diagnostics entry))
+          (puthash (ai-code-mcp--diagnostic-identity uri diagnostic) t set))))))
+
+(defun ai-code-mcp--diagnostics-new-since-baseline (entries)
+  "Return ENTRIES filtered to diagnostics absent from the session baseline.
+When no baseline has been recorded, return ENTRIES unchanged."
+  (let ((baseline (gethash (ai-code-mcp--diagnostics-baseline-key)
+                           ai-code-mcp--diagnostics-baselines)))
+    (if (null baseline)
+        entries
+      (delq nil
+            (mapcar
+             (lambda (entry)
+               (let* ((uri (alist-get 'uri entry))
+                      (new (seq-filter
+                            (lambda (diagnostic)
+                              (not (gethash
+                                    (ai-code-mcp--diagnostic-identity uri diagnostic)
+                                    baseline)))
+                            (append (alist-get 'diagnostics entry) nil))))
+                 (when new
+                   `((uri . ,uri)
+                     (diagnostics . ,(vconcat new))))))
+             entries)))))
+
+(defun ai-code-mcp-diagnostics-baseline ()
+  "Record current project diagnostics as the session baseline.
+Return a JSON observation envelope describing what was recorded.  Later
+`get_diagnostics' calls with `since' set to \"baseline\" report only NEW
+diagnostics relative to this snapshot, which lets the agent verify it did
+not introduce new problems."
+  (let* ((entries (ai-code-mcp--diagnostics-for-project))
+         (set (ai-code-mcp--diagnostics-identity-set entries))
+         (count (ai-code-mcp--diagnostics-total-count entries)))
+    (puthash (ai-code-mcp--diagnostics-baseline-key) set
+             ai-code-mcp--diagnostics-baselines)
+    (json-encode
+     `((status . "baseline_recorded")
+       (summary . ,(format (concat "Recorded %d diagnostic%s as the baseline."
+                                   " Edit, then call get_diagnostics with"
+                                   " since=\"baseline\" and finish only when"
+                                   " status is \"clean\".")
+                           count (if (= count 1) "" "s")))
+       (files . ,(vconcat entries))
+       (next_actions . ,(vconcat nil))
+       (artifacts . ,(vconcat nil))))))
 
 (defun ai-code-mcp--diagnostics-for-uri (uri)
   "Return a list with diagnostics for URI, or nil when none exist."

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -82,10 +82,10 @@ Use `auto' to prefer Flycheck and then Flymake when available."
 
 (defvar ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal)
   "Hash table mapping MCP session ids to recorded diagnostics baselines.
-Each value is a hash set whose keys are diagnostic identity strings.  The
-baseline lets `get_diagnostics' report only NEW diagnostics so the agent
-can verify it introduced no regressions, without tracking the baseline in
-the model context itself.")
+Each value is a hash table mapping diagnostic identity strings to counts.
+The baseline lets `get_diagnostics' report only NEW diagnostics so the
+agent can verify it introduced no regressions, without tracking the
+baseline in the model context itself.")
 
 (defconst ai-code-mcp--protocol-version "2024-11-05"
   "Protocol version reported by the MCP core.")
@@ -548,22 +548,23 @@ requests `since=\"baseline\"' without first calling `diagnostics_baseline'."
 (defun ai-code-mcp--diagnostic-identity (uri diagnostic)
   "Return a stable identity string for DIAGNOSTIC located in URI.
 Position is intentionally excluded so edits that shift line numbers do not
-make a pre-existing diagnostic look new.  Trade-off: two diagnostics sharing
-uri/severity/source/message are treated as one, so a newly introduced
-duplicate of an existing message is not reported as new."
+make a pre-existing diagnostic look new.  Multiplicity is tracked by the
+baseline count table, so duplicate diagnostics beyond the recorded count
+are still reported as new."
   (format "%s\0%s\0%s\0%s"
           (or uri "")
           (or (alist-get 'severity diagnostic) "")
           (or (alist-get 'source diagnostic) "")
           (or (alist-get 'message diagnostic) "")))
 
-(defun ai-code-mcp--diagnostics-identity-set (entries)
-  "Return a hash set of identity strings for diagnostics ENTRIES."
-  (let ((set (make-hash-table :test 'equal)))
-    (dolist (entry entries set)
+(defun ai-code-mcp--diagnostics-identity-counts (entries)
+  "Return a hash table of identity counts for diagnostics ENTRIES."
+  (let ((counts (make-hash-table :test 'equal)))
+    (dolist (entry entries counts)
       (let ((uri (alist-get 'uri entry)))
         (seq-doseq (diagnostic (alist-get 'diagnostics entry))
-          (puthash (ai-code-mcp--diagnostic-identity uri diagnostic) t set))))))
+          (let ((identity (ai-code-mcp--diagnostic-identity uri diagnostic)))
+            (puthash identity (1+ (gethash identity counts 0)) counts)))))))
 
 (defun ai-code-mcp--diagnostics-new-since-baseline (entries)
   "Return ENTRIES filtered to diagnostics absent from the session baseline.
@@ -572,20 +573,31 @@ When no baseline has been recorded, return ENTRIES unchanged."
                            ai-code-mcp--diagnostics-baselines)))
     (if (null baseline)
         entries
-      (delq nil
-            (mapcar
-             (lambda (entry)
-               (let* ((uri (alist-get 'uri entry))
-                      (new (seq-filter
-                            (lambda (diagnostic)
-                              (not (gethash
-                                    (ai-code-mcp--diagnostic-identity uri diagnostic)
-                                    baseline)))
-                            (append (alist-get 'diagnostics entry) nil))))
-                 (when new
-                   `((uri . ,uri)
-                     (diagnostics . ,(vconcat new))))))
-             entries)))))
+      (let ((remaining (copy-hash-table baseline)))
+        (delq nil
+              (mapcar
+               (lambda (entry)
+                 (let* ((uri (alist-get 'uri entry))
+                        (new (delq nil
+                                   (mapcar
+                                    (lambda (diagnostic)
+                                      (let* ((identity
+                                              (ai-code-mcp--diagnostic-identity
+                                               uri diagnostic))
+                                             (count (gethash identity
+                                                             remaining 0)))
+                                        (if (> count 0)
+                                            (progn
+                                              (puthash identity (1- count)
+                                                       remaining)
+                                              nil)
+                                          diagnostic)))
+                                    (append (alist-get 'diagnostics entry)
+                                            nil)))))
+                   (when new
+                     `((uri . ,uri)
+                       (diagnostics . ,(vconcat new))))))
+               entries))))))
 
 (defun ai-code-mcp-diagnostics-baseline ()
   "Record current project diagnostics as the session baseline.
@@ -594,9 +606,9 @@ Return a JSON observation envelope describing what was recorded.  Later
 diagnostics relative to this snapshot, which lets the agent verify it did
 not introduce new problems."
   (let* ((entries (ai-code-mcp--diagnostics-for-project))
-         (set (ai-code-mcp--diagnostics-identity-set entries))
+         (counts (ai-code-mcp--diagnostics-identity-counts entries))
          (count (ai-code-mcp--diagnostics-total-count entries)))
-    (puthash (ai-code-mcp--diagnostics-baseline-key) set
+    (puthash (ai-code-mcp--diagnostics-baseline-key) counts
              ai-code-mcp--diagnostics-baselines)
     (json-encode
      `((status . "baseline_recorded")

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -610,11 +610,18 @@ not introduce new problems."
        (artifacts . ,(vconcat nil))))))
 
 (defun ai-code-mcp--diagnostics-for-uri (uri)
-  "Return a list with diagnostics for URI, or nil when none exist."
+  "Return a list with diagnostics for URI, or nil when none exist.
+The entry uses the canonical file URI of the resolved buffer (via
+`ai-code-mcp--file-path-to-uri') so its identity matches the baseline that
+`ai-code-mcp-diagnostics-baseline' records from the project scan, even when
+URI is given in a non-canonical form such as a localhost or bare-path URI."
   (when-let* ((file-path (ai-code-mcp--uri-to-file-path uri))
               (buffer (get-file-buffer file-path))
               (diagnostics (ai-code-mcp--buffer-diagnostics buffer)))
-    (when-let ((entry (ai-code-mcp--diagnostics-file-entry uri diagnostics)))
+    (when-let ((entry (ai-code-mcp--diagnostics-file-entry
+                       (ai-code-mcp--file-path-to-uri
+                        (or (buffer-file-name buffer) file-path))
+                       diagnostics)))
       (list entry))))
 
 (defun ai-code-mcp--diagnostics-for-project ()

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -66,7 +66,10 @@
       (should (string-match-p "get_diagnostics" suffix))
       (should (string-match-p "get_diagnostics MCP tool" suffix))
       (should (string-match-p "baseline" suffix))
-      (should (string-match-p "no new diagnostics" suffix)))))
+      (should (string-match-p "no new diagnostics" suffix))
+      (should (string-match-p "diagnostics_baseline" suffix))
+      (should (string-match-p "since=\"baseline\"" suffix))
+      (should (string-match-p "clean" suffix)))))
 
 (ert-deftest ai-code-test-resolve-tdd-suffix-omits-diagnostics-for-non-mcp-backend ()
   "Test that TDD suffix omits diagnostics for unsupported backends."

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -505,7 +505,7 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       (delete-directory project-dir t))))
 
 (ert-deftest ai-code-test-mcp-get-diagnostics-envelope-reports-issues ()
-  "get_diagnostics should wrap results in an observation envelope."
+  "The get_diagnostics tool should wrap results in an observation envelope."
   (let* ((project-dir (make-temp-file "ai-code-mcp-envelope-issues-" t))
          (file-path (expand-file-name "sample.el" project-dir))
          (file-uri (concat "file://" file-path))
@@ -549,7 +549,7 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       (delete-directory project-dir t))))
 
 (ert-deftest ai-code-test-mcp-get-diagnostics-envelope-reports-clean ()
-  "get_diagnostics should report a clean status when there are no diagnostics."
+  "The get_diagnostics tool should report clean when there are no diagnostics."
   (let* ((project-dir (make-temp-file "ai-code-mcp-envelope-clean-" t))
          (file-path (expand-file-name "sample.el" project-dir))
          (file-uri (concat "file://" file-path))
@@ -682,6 +682,59 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
         (kill-buffer session-buffer))
       (delete-directory project-dir t))))
 
+(ert-deftest ai-code-test-mcp-get-diagnostics-since-baseline-counts-duplicates ()
+  "A duplicate diagnostic beyond the baseline count should be a regression."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-baseline-duplicates-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-baseline-duplicates*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-baseline-duplicates")
+         (existing (make-ai-code-test-mcp-mock-diagnostic
+                    :beg (point-min) :end (point-min)
+                    :type :warning :text "Repeated problem"
+                    :backend 'mock-backend))
+         (duplicate (make-ai-code-test-mcp-mock-diagnostic
+                     :beg (point-min) :end (point-min)
+                     :type :warning :text "Repeated problem"
+                     :backend 'mock-backend))
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-baseline-duplicates" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics (list existing)
+              (ai-code-mcp-dispatch
+               "tools/call"
+               '((name . "diagnostics_baseline")
+                 (arguments . ()))))
+            (ai-code-test-mcp--with-flymake-diagnostics (list existing duplicate)
+              (let* ((delta (ai-code-test-mcp--read-json
+                             (ai-code-test-mcp--content-text
+                              (ai-code-mcp-dispatch
+                               "tools/call"
+                               '((name . "get_diagnostics")
+                                 (arguments . ((since . "baseline"))))))))
+                     (files (alist-get 'files delta)))
+                (should (equal "regression" (alist-get 'status delta)))
+                (should (= 1 (length files)))
+                (should (= 1 (length (alist-get 'diagnostics (aref files 0)))))
+                (should (equal "Repeated problem"
+                               (alist-get 'message
+                                          (aref (alist-get 'diagnostics
+                                                           (aref files 0))
+                                                0))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
 (ert-deftest ai-code-test-mcp-unregister-session-clears-diagnostics-baseline ()
   "Unregistering a session should free its recorded diagnostics baseline."
   (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
@@ -702,7 +755,7 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       (delete-directory project-dir t))))
 
 (ert-deftest ai-code-test-mcp-get-diagnostics-since-baseline-without-baseline-reports-no-baseline ()
-  "since=\"baseline\" before recording a baseline must not report regressions."
+  "Using since=\"baseline\" before recording a baseline must not report regressions."
   (let* ((project-dir (make-temp-file "ai-code-mcp-no-baseline-" t))
          (file-path (expand-file-name "sample.el" project-dir))
          (session-buffer (generate-new-buffer " *ai-code-mcp-no-baseline*"))

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -29,8 +29,34 @@
 (cl-defstruct ai-code-test-mcp-mock-diagnostic
   beg end type text backend)
 
+(defun ai-code-test-mcp--read-json (payload)
+  "Parse PAYLOAD as JSON using alist objects and vector arrays."
+  (let ((json-object-type 'alist)
+        (json-array-type 'vector)
+        (json-key-type 'symbol))
+    (json-read-from-string payload)))
+
+(defmacro ai-code-test-mcp--with-flymake-diagnostics (diagnostics &rest body)
+  "Evaluate BODY with Flymake diagnostic accessors mocked.
+DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'flymake-diagnostics)
+              (lambda (&rest _) ,diagnostics))
+             ((symbol-function 'flymake-diagnostic-beg)
+              #'ai-code-test-mcp-mock-diagnostic-beg)
+             ((symbol-function 'flymake-diagnostic-end)
+              #'ai-code-test-mcp-mock-diagnostic-end)
+             ((symbol-function 'flymake-diagnostic-type)
+              #'ai-code-test-mcp-mock-diagnostic-type)
+             ((symbol-function 'flymake-diagnostic-backend)
+              #'ai-code-test-mcp-mock-diagnostic-backend)
+             ((symbol-function 'flymake-diagnostic-text)
+              #'ai-code-test-mcp-mock-diagnostic-text))
+     ,@body))
+
 (defconst ai-code-test-mcp--builtin-tool-names
   '("buffer_query"
+    "diagnostics_baseline"
     "editor_state"
     "get_diagnostics"
     "get_project_buffers"
@@ -136,6 +162,7 @@
                                     ai-code-mcp-server-tools)
                             #'string<)))
        (should (equal '("buffer_query"
+                        "diagnostics_baseline"
                         "editor_state"
                         "get_diagnostics"
                         "get_project_buffers"
@@ -340,12 +367,14 @@
                                     "tools/call"
                                     `((name . "get_diagnostics")
                                       (arguments . ((uri . ,file-uri)))))))
-                         (items (json-read-from-string payload))
+                         (envelope (json-read-from-string payload))
+                         (items (alist-get 'files envelope))
                          (entry (aref items 0))
                          (diagnostics (alist-get 'diagnostics entry))
                          (first-diagnostic (aref diagnostics 0))
                          (range (alist-get 'range first-diagnostic))
                          (start (alist-get 'start range)))
+                    (should (equal "issues" (alist-get 'status envelope)))
                     (should (equal file-uri (alist-get 'uri entry)))
                     (should (equal "Warning"
                                    (alist-get 'severity first-diagnostic)))
@@ -408,7 +437,8 @@
                                     "tools/call"
                                     '((name . "get_diagnostics")
                                       (arguments . ())))))
-                         (items (json-read-from-string payload))
+                         (envelope (json-read-from-string payload))
+                         (items (alist-get 'files envelope))
                          (entry (aref items 0)))
                     (should (equal expected-uri
                                    (alist-get 'uri entry)))))))))
@@ -465,8 +495,246 @@
                                     "tools/call"
                                     `((name . "get_diagnostics")
                                       (arguments . ((uri . ,file-uri)))))))
-                         (items (json-read-from-string payload)))
+                         (envelope (json-read-from-string payload))
+                         (items (alist-get 'files envelope)))
                     (should (= 1 (length items)))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-envelope-reports-issues ()
+  "get_diagnostics should wrap results in an observation envelope."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-envelope-issues-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (file-uri (concat "file://" file-path))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-envelope-issues*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-envelope-issues")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-envelope-issues" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics
+                (list (make-ai-code-test-mcp-mock-diagnostic
+                       :beg (point-min) :end (line-end-position)
+                       :type :warning :text "Unused value" :backend 'mock-backend))
+              (let* ((payload (ai-code-test-mcp--content-text
+                               (ai-code-mcp-dispatch
+                                "tools/call"
+                                `((name . "get_diagnostics")
+                                  (arguments . ((uri . ,file-uri)))))))
+                     (envelope (ai-code-test-mcp--read-json payload))
+                     (files (alist-get 'files envelope))
+                     (actions (alist-get 'next_actions envelope)))
+                (should (equal "issues" (alist-get 'status envelope)))
+                (should (stringp (alist-get 'summary envelope)))
+                (should (= 1 (length files)))
+                (should (equal file-uri (alist-get 'uri (aref files 0))))
+                (should (vectorp actions))
+                (should (> (length actions) 0))
+                (should (string-match-p "Unused value" (aref actions 0)))
+                (should (vectorp (alist-get 'artifacts envelope)))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-envelope-reports-clean ()
+  "get_diagnostics should report a clean status when there are no diagnostics."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-envelope-clean-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (file-uri (concat "file://" file-path))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-envelope-clean*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-envelope-clean")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-envelope-clean" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics nil
+              (let* ((payload (ai-code-test-mcp--content-text
+                               (ai-code-mcp-dispatch
+                                "tools/call"
+                                `((name . "get_diagnostics")
+                                  (arguments . ((uri . ,file-uri)))))))
+                     (envelope (ai-code-test-mcp--read-json payload)))
+                (should (equal "clean" (alist-get 'status envelope)))
+                (should (= 0 (length (alist-get 'files envelope))))
+                (should (= 0 (length (alist-get 'next_actions envelope))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-diagnostics-baseline-then-no-new-is-clean ()
+  "After recording a baseline, identical diagnostics yield a clean delta."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-baseline-clean-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-baseline-clean*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-baseline-clean")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-baseline-clean" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics
+                (list (make-ai-code-test-mcp-mock-diagnostic
+                       :beg (point-min) :end (line-end-position)
+                       :type :warning :text "Existing problem"
+                       :backend 'mock-backend))
+              (let ((baseline (ai-code-test-mcp--read-json
+                               (ai-code-test-mcp--content-text
+                                (ai-code-mcp-dispatch
+                                 "tools/call"
+                                 '((name . "diagnostics_baseline")
+                                   (arguments . ())))))))
+                (should (equal "baseline_recorded"
+                               (alist-get 'status baseline))))
+              (let ((delta (ai-code-test-mcp--read-json
+                            (ai-code-test-mcp--content-text
+                             (ai-code-mcp-dispatch
+                              "tools/call"
+                              '((name . "get_diagnostics")
+                                (arguments . ((since . "baseline")))))))))
+                (should (equal "clean" (alist-get 'status delta)))
+                (should (= 0 (length (alist-get 'files delta))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-since-baseline-reports-regression ()
+  "Diagnostics that appear after the baseline are reported as a regression."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-baseline-regression-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-baseline-regression*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-baseline-regression")
+         (existing (make-ai-code-test-mcp-mock-diagnostic
+                    :beg (point-min) :end (point-min)
+                    :type :warning :text "Existing problem"
+                    :backend 'mock-backend))
+         (introduced (make-ai-code-test-mcp-mock-diagnostic
+                      :beg (point-min) :end (point-min)
+                      :type :error :text "New problem"
+                      :backend 'mock-backend))
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-baseline-regression" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics (list existing)
+              (ai-code-mcp-dispatch
+               "tools/call"
+               '((name . "diagnostics_baseline")
+                 (arguments . ()))))
+            (ai-code-test-mcp--with-flymake-diagnostics (list existing introduced)
+              (let* ((delta (ai-code-test-mcp--read-json
+                             (ai-code-test-mcp--content-text
+                              (ai-code-mcp-dispatch
+                               "tools/call"
+                               '((name . "get_diagnostics")
+                                 (arguments . ((since . "baseline"))))))))
+                     (files (alist-get 'files delta))
+                     (actions (alist-get 'next_actions delta)))
+                (should (equal "regression" (alist-get 'status delta)))
+                (should (= 1 (length files)))
+                (should (= 1 (length (alist-get 'diagnostics (aref files 0)))))
+                (should (equal "New problem"
+                               (alist-get 'message
+                                          (aref (alist-get 'diagnostics
+                                                           (aref files 0))
+                                                0))))
+                (should (string-match-p "New problem" (aref actions 0)))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-unregister-session-clears-diagnostics-baseline ()
+  "Unregistering a session should free its recorded diagnostics baseline."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+        (session-id "session-cleanup")
+        (buffer (generate-new-buffer " *ai-code-mcp-cleanup*"))
+        (project-dir (make-temp-file "ai-code-mcp-cleanup-" t)))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session session-id project-dir buffer)
+          (puthash session-id (make-hash-table :test 'equal)
+                   ai-code-mcp--diagnostics-baselines)
+          (should (gethash session-id ai-code-mcp--diagnostics-baselines))
+          (ai-code-mcp-unregister-session session-id)
+          (should-not (gethash session-id ai-code-mcp--diagnostics-baselines)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-since-baseline-without-baseline-reports-no-baseline ()
+  "since=\"baseline\" before recording a baseline must not report regressions."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-no-baseline-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-no-baseline*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-no-baseline")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-no-baseline" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics
+                (list (make-ai-code-test-mcp-mock-diagnostic
+                       :beg (point-min) :end (line-end-position)
+                       :type :warning :text "Existing problem"
+                       :backend 'mock-backend))
+              (let* ((delta (ai-code-test-mcp--read-json
+                             (ai-code-test-mcp--content-text
+                              (ai-code-mcp-dispatch
+                               "tools/call"
+                               '((name . "get_diagnostics")
+                                 (arguments . ((since . "baseline"))))))))
+                     (actions (alist-get 'next_actions delta)))
+                (should (equal "no_baseline" (alist-get 'status delta)))
+                (should (= 0 (length (alist-get 'files delta))))
+                (should (> (length actions) 0))
+                (should (string-match-p "diagnostics_baseline" (aref actions 0)))))))
       (when (buffer-live-p visited-buffer)
         (kill-buffer visited-buffer))
       (when (buffer-live-p session-buffer)

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -741,6 +741,51 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
         (kill-buffer session-buffer))
       (delete-directory project-dir t))))
 
+(ert-deftest ai-code-test-mcp-get-diagnostics-since-baseline-canonicalizes-uri ()
+  "Per-file delta should match the baseline regardless of the request URI form."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-baseline-uri-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (localhost-uri (concat "file://localhost" file-path))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-baseline-uri*"))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-baseline-uri")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode t)
+            (ai-code-mcp-register-session
+             "session-baseline-uri" project-dir session-buffer)
+            (ai-code-test-mcp--with-flymake-diagnostics
+                (list (make-ai-code-test-mcp-mock-diagnostic
+                       :beg (point-min) :end (line-end-position)
+                       :type :warning :text "Existing problem"
+                       :backend 'mock-backend))
+              ;; Baseline is recorded via the project scan (canonical file:// URIs).
+              (ai-code-mcp-dispatch
+               "tools/call"
+               '((name . "diagnostics_baseline")
+                 (arguments . ())))
+              ;; Query the delta for the same file using a non-canonical localhost URI.
+              (let ((delta (ai-code-test-mcp--read-json
+                            (ai-code-test-mcp--content-text
+                             (ai-code-mcp-dispatch
+                              "tools/call"
+                              `((name . "get_diagnostics")
+                                (arguments . ((uri . ,localhost-uri)
+                                              (since . "baseline")))))))))
+                (should (equal "clean" (alist-get 'status delta)))
+                (should (= 0 (length (alist-get 'files delta))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
 (ert-deftest ai-code-test-mcp-project-info-uses-session-project-dir ()
   "Project info should report the session project directory."
   (let* ((project-dir (make-temp-file "ai-code-mcp-project-info-" t))


### PR DESCRIPTION
## What & why

The `get_diagnostics` MCP tool returned a bare JSON array, and the diagnostics-first prompt asked the *model* to remember a baseline and diff it by hand across a long task. Models forget that, so the agent could "finish" while having introduced new diagnostics. This change makes Emacs own the verification signal instead, so the agent's own loop reads something reliable, cheap, and actionable. The agent's harness (loop/hooks/etc.) stays untouched — this is purely the Emacs↔agent interaction layer.

## Changes

- **Observation envelope**: `get_diagnostics` now returns `{status, summary, files, next_actions, artifacts}` instead of a raw array. `status` is `clean`/`issues`, and `next_actions` gives a one-line fix hint per diagnostic.
- **Baseline + delta**: a new `diagnostics_baseline` MCP tool records the current project diagnostics per session (kept in Emacs, not the model context). `get_diagnostics` gains an optional `since="baseline"` argument that reports only *new* diagnostics with `status` `regression`/`clean` plus an explicit done-condition (`new == 0`). Diagnostic identity is `uri+severity+source+message` so edits that shift line numbers do not create false positives.
- **Safe edges**: calling `since="baseline"` before a baseline is recorded returns a distinct `no_baseline` status (instead of misreporting everything as a regression), and a session's baseline is freed when the session is unregistered.
- **Send-time guidance**: the diagnostics-first instruction now points at `diagnostics_baseline` + `since="baseline"` + the `clean` done-condition rather than asking the model to diff manually.

## Verification

- New ERT tests cover the envelope (issues/clean), baseline→clean delta, regression detection, the no-baseline path, and session cleanup.
- Full suite green: 825 tests, 0 unexpected, 13 skipped (same invocation as CI).
- `ai-code-mcp-server.el` and `ai-code-harness.el` byte-compile with no warnings.
