### PR TITLE
Unify structured agent briefs across code change and question flows

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,8 @@
 * Release history
 
 ** Main branch change
+- Unify structured agent briefs across code change and question flows
+- More Refactor: Reduce function size. Extract and reuse helper functions.
 - Refactor: refactor boilerplate cli session start code, and add tests
 
 ** 1.82

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -11,12 +11,18 @@
 
 (require 'ai-code-input)
 (require 'ai-code-prompt-mode)
+(require 'ai-code-change)
+(require 'subr-x)
 (require 'thingatpt)
 (require 'which-func)
 
 (declare-function ai-code--insert-prompt "ai-code-prompt-mode" (prompt-text))
 (declare-function ai-code--get-context-files-string "ai-code-utils")
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
+(declare-function dired-current-directory "dired" ())
+(declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
+(declare-function dired-get-marked-files "dired"
+                  (&optional localp arg filter distinguish-one-marked error-if-none-p))
 
 (defconst ai-code--refactoring-techniques-catalog
   '((:name "Suggest Refactoring Strategy"
@@ -490,6 +496,51 @@ otherwise falls back to absolute paths."
           (concat "\nFiles:\n" (mapconcat #'identity paths "\n")))
       (ai-code--get-context-files-string))))
 
+(defconst ai-code--refactoring-code-change-boundaries
+  (concat
+   "Preserve existing behavior. Make only the requested refactoring. "
+   "Avoid unrelated cleanup, feature changes, or broad rewrites.")
+  "Boundaries for structured refactoring code-change briefs.")
+
+(defun ai-code--agile-current-scope-string (&optional function-name file-info)
+  "Return scope text for current agile prompt.
+FUNCTION-NAME is the current function when available.
+FILE-INFO is additional visible-file context."
+  (concat
+   (if buffer-file-name
+       (format "Current file: %s" buffer-file-name)
+     (format "Current buffer: %s" (buffer-name)))
+   (when function-name
+     (format "\nFunction: %s" function-name))
+   file-info))
+
+(defun ai-code--refactoring-scope-string (context file-info)
+  "Return structured scope text for refactoring CONTEXT and FILE-INFO."
+  (let ((region-active (plist-get context :region-active))
+        (region-text (plist-get context :region-text))
+        (current-function (plist-get context :current-function))
+        (dired-targets (plist-get context :dired-targets))
+        (context-description (plist-get context :context-description))
+        (file-name (plist-get context :file-name)))
+    (concat
+     (cond
+      (dired-targets
+       (concat "Selected files/directories:\n"
+               (mapconcat #'identity dired-targets "\n")))
+      (buffer-file-name
+       (format "Current file: %s" buffer-file-name))
+      (file-name
+       (format "Current file: %s" file-name))
+      (t
+       (format "Current buffer: %s" (buffer-name))))
+     (when context-description
+       (format "\nRefactoring context: %s" context-description))
+     (when current-function
+       (format "\nFunction: %s" current-function))
+     (when region-active
+       (format "\nSelected code:\n%s" region-text))
+     file-info)))
+
 (defun ai-code--get-refactoring-techniques (region-active)
   "Return appropriate refactoring techniques based on REGION-ACTIVE."
   (let ((scope (if region-active 'region 'global))
@@ -556,9 +607,7 @@ TECHNIQUE-DESCRIPTION is the base prompt text."
   "Handle the case where a specific refactoring technique is chosen.
 Uses SELECTED-TECHNIQUE, ALL-TECHNIQUES, CONTEXT, and TDD-MODE.
 If TDD-MODE is non-nil, adds TDD constraints to the instruction."
-  (let* ((region-active (plist-get context :region-active))
-         (region-text (plist-get context :region-text))
-         (context-description (plist-get context :context-description))
+  (let* ((context-description (plist-get context :context-description))
          (technique-description (cdr (assoc selected-technique all-techniques)))
          (prompt-with-params (ai-code--process-refactoring-parameters
                               selected-technique technique-description context))
@@ -572,12 +621,11 @@ If TDD-MODE is non-nil, adds TDD constraints to the instruction."
          (final-instruction (ai-code-read-string "Edit refactoring instruction: " initial-instruction))
          ;; Add file information to context
          (file-info (ai-code--get-context-files-string))
-         (command (if region-active
-                      (format "%s%s\n\nSelected code:\n%s"
-                              final-instruction
-                              file-info
-                              region-text)
-                    (format "%s%s" final-instruction file-info)))
+         (command (ai-code--compose-code-change-brief
+                   :goal final-instruction
+                   :scope (ai-code--refactoring-scope-string context file-info)
+                   :boundaries ai-code--refactoring-code-change-boundaries
+                   :code-change-note ai-code-change--generic-note))
          (message-suffix (if tdd-mode " during TDD refactor stage" "")))
     (when (ai-code--insert-prompt command)
       (message "%s refactoring request sent to AI Code Interface%s. After code refactored, better to re-run unit-tests."
@@ -685,6 +733,50 @@ If no such buffer is found, report a user-error."
   " Stage 3 - Blue: after Green is passing, refactor only the files changed in Red/Green. Preserve behavior and do not add features. First review the code diff (including tests) and identify the highest-impact cleanup. Then apply focused refactoring that improves readability, keeps classes/functions small and cohesive / easy to test, reduces duplication, and simplifies naming and control flow."
   "Refactoring extension shared by Red+Green+Blue style TDD prompts.")
 
+(defconst ai-code--tdd-red-boundaries
+  (concat
+   "Follow TDD principles - write only the test now, not the implementation. "
+   "The test should fail when run because the functionality doesn't exist yet. "
+   "Only update test file code.")
+  "Boundaries for Red-stage structured code-change briefs.")
+
+(defconst ai-code--tdd-green-boundaries
+  (concat
+   "Follow TDD principles - implement the minimum source code needed to make "
+   "the failing test pass. Do not refactor during Green.")
+  "Boundaries for Green-stage structured code-change briefs.")
+
+(defconst ai-code--tdd-failure-fix-boundaries
+  (concat
+   "Follow TDD principles - fix only the failing behavior described by the "
+   "test output. Keep the change narrowly scoped and avoid unrelated cleanup.")
+  "Boundaries for TDD failure-fix structured code-change briefs.")
+
+(defconst ai-code--tdd-red-green-boundaries
+  (string-trim
+   (concat ai-code--tdd-red-green-base-instruction
+           ai-code--tdd-red-green-tail-instruction))
+  "Boundaries for Red+Green structured code-change briefs.")
+
+(defconst ai-code--tdd-red-green-blue-boundaries
+  (string-trim
+   (concat ai-code--tdd-red-green-base-instruction
+           ai-code--tdd-with-refactoring-extension-instruction
+           ai-code--tdd-red-green-tail-instruction))
+  "Boundaries for Red+Green+Blue structured code-change briefs.")
+
+(defun ai-code--tdd-compose-code-change-brief (goal function-name boundaries instruction)
+  "Return a structured TDD code-change brief.
+GOAL is the requested task, FUNCTION-NAME is the current function,
+BOUNDARIES defines the stage limits, and INSTRUCTION is appended guidance."
+  (ai-code--compose-code-change-brief
+   :goal goal
+   :scope (ai-code--agile-current-scope-string
+           function-name
+           (ai-code--get-context-files-string))
+   :boundaries boundaries
+   :code-change-note instruction))
+
 (defun ai-code--tdd-red-stage (function-name)
   "Handle the Red stage of TDD for FUNCTION-NAME: Write a failing test."
   (let ((test-pattern-instruction ai-code--tdd-test-pattern-instruction))
@@ -694,25 +786,26 @@ If no such buffer is found, report a user-error."
         ;; Use it as initial prompt to fix the source code.
         (let* ((failure-info (buffer-substring-no-properties (region-beginning) (region-end)))
                (prompt (ai-code-read-string "Confirm test failure to fix: " failure-info))
-               (file-info (ai-code--get-context-files-string))
-               (tdd-instructions (format "Fix the code to resolve the following error:\n%s%s%s"
-                                         prompt
-                                         file-info
-                                         test-pattern-instruction)))
+               (tdd-instructions
+                (ai-code--tdd-compose-code-change-brief
+                 (format "Fix the code to resolve the following error:\n%s" prompt)
+                 function-name
+                 ai-code--tdd-failure-fix-boundaries
+                 test-pattern-instruction)))
           (ai-code--insert-prompt tdd-instructions))
       ;; Original path: write a failing test
       (ai-code--ensure-test-buffer-visible)
       (let* ((feature-desc (ai-code-read-string
-                            (if function-name
-                                (format "Describe the feature to test for '%s': " function-name)
-                              "Describe the feature to test: ") "Implement test functions using test cases described in the comments."))
-             (file-info (ai-code--get-context-files-string))
+                             (if function-name
+                                 (format "Describe the feature to test for '%s': " function-name)
+                               "Describe the feature to test: ") "Implement test functions using test cases described in the comments."))
              (tdd-instructions
-              (format "%s%s\nFollow TDD principles - write only the test now, not the implementation. The test should fail when run because the functionality doesn't exist yet. Only update test file code.%s"
-                      feature-desc
-                      file-info
-                      (concat ai-code--tdd-run-test-after-this-stage-instruction
-                              test-pattern-instruction))))
+              (ai-code--tdd-compose-code-change-brief
+               feature-desc
+               function-name
+               ai-code--tdd-red-boundaries
+               (concat ai-code--tdd-run-test-after-this-stage-instruction
+                       test-pattern-instruction))))
         (ai-code--insert-prompt tdd-instructions)))))
 
 (defun ai-code--tdd-source-function-context-p (function-name)
@@ -735,12 +828,12 @@ If no such buffer is found, report a user-error."
                            (format "Write test for '%s' in %s."
                                    function-name
                                    test-file-hint)))
-         (file-info (ai-code--get-context-files-string))
          (tdd-instructions
-          (format "%s%s\nFollow TDD principles - write only the test now, not the implementation. Only update test file code.%s"
-                  write-test-desc
-                  file-info
-                  ai-code--tdd-test-pattern-instruction)))
+          (ai-code--tdd-compose-code-change-brief
+           write-test-desc
+           function-name
+           "Follow TDD principles - write only the test now, not the implementation. Only update test file code."
+           ai-code--tdd-test-pattern-instruction)))
     (ai-code--insert-prompt tdd-instructions)))
 
 (defun ai-code--tdd-red-green-stage (function-name)
@@ -751,15 +844,13 @@ If no such buffer is found, report a user-error."
                             (format "Describe the feature to test for '%s': " function-name)
                           "Describe the feature to test: ")
                         "Implement test functions using test cases described in the comments."))
-         (file-info (ai-code--get-context-files-string))
          (tdd-instructions
-          (format "%s%s\n%s%s%s%s"
-                  feature-desc
-                  file-info
-                  ai-code--tdd-red-green-base-instruction
-                  ai-code--tdd-red-green-tail-instruction
-                  ai-code--tdd-run-test-after-each-stage-instruction
-                  ai-code--tdd-test-pattern-instruction)))
+          (ai-code--tdd-compose-code-change-brief
+           feature-desc
+           function-name
+           ai-code--tdd-red-green-boundaries
+           (concat ai-code--tdd-run-test-after-each-stage-instruction
+                   ai-code--tdd-test-pattern-instruction))))
     (ai-code--insert-prompt tdd-instructions)))
 
 (defun ai-code--tdd-red-green-blue-stage (function-name)
@@ -770,16 +861,13 @@ If no such buffer is found, report a user-error."
                             (format "Describe the feature to test for '%s': " function-name)
                           "Describe the feature to test: ")
                         "Implement test functions using test cases described in the comments."))
-         (file-info (ai-code--get-context-files-string))
          (tdd-instructions
-          (format "%s%s\n%s%s%s%s%s"
-                  feature-desc
-                  file-info
-                  ai-code--tdd-red-green-base-instruction
-                  ai-code--tdd-with-refactoring-extension-instruction
-                  ai-code--tdd-red-green-tail-instruction
-                  ai-code--tdd-run-test-after-each-stage-instruction
-                  ai-code--tdd-test-pattern-instruction)))
+          (ai-code--tdd-compose-code-change-brief
+           feature-desc
+           function-name
+           ai-code--tdd-red-green-blue-boundaries
+           (concat ai-code--tdd-run-test-after-each-stage-instruction
+                   ai-code--tdd-test-pattern-instruction))))
     (ai-code--insert-prompt tdd-instructions)))
 
 (defun ai-code--tdd-green-stage (function-name)
@@ -797,12 +885,12 @@ to fix code."
                 (format "Implement function '%s' to make tests pass: " function-name)
               "Implement the minimal code needed to make the failing test pass: ")))
          (implementation-desc (ai-code-read-string "Implementation instruction: " initial-input))
-         (file-info (ai-code--get-context-files-string))
          (tdd-instructions
-          (format "%s%s\nFollow TDD principles - implement the code needed to make the test pass.%s"
-                  implementation-desc
-                  file-info
-                  ai-code--tdd-run-test-after-this-stage-instruction)))
+          (ai-code--tdd-compose-code-change-brief
+           implementation-desc
+           function-name
+           ai-code--tdd-green-boundaries
+           ai-code--tdd-run-test-after-this-stage-instruction)))
     (ai-code--insert-prompt tdd-instructions)))
 
 (defun ai-code--run-test-ai-assisted ()

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -924,7 +924,7 @@ to fix code."
 
 ;;;###autoload
 (defun ai-code-run-test ()
-  "Ask AI to run the relevant tests for the current context."
+  "Prompt AI to run relevant test commands for the current context."
   ;; DONE: remove pytest / jest / ert usage here, simply call ai-code--run-test-ai-assisted
   ;; DONE: Remove related information from README / autoloads / @test as well, since we want to keep the @test running experience consistent across languages and rely on AI to figure out the test pattern and command.
   (interactive)

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -559,14 +559,52 @@ Optional DEFAULT-ACTION skips the `completing-read' prompt when non-nil."
            (t "")))
          (repo-context-string (ai-code--format-repo-context-info))
          (prompt (ai-code-read-string prompt-label initial-input))
+         (clipboard-context-text (and clipboard-context
+                                      (string-match-p "\\S-" clipboard-context)
+                                      clipboard-context))
+         (code-change-scope
+          (unless ask-question-p
+            (concat
+             (cond
+              (org-todo-section-info
+               (format "Org headline on line %d:\n%s"
+                       org-line-number
+                       org-section-block))
+              (region-text
+               (format "%s\n%s"
+                       region-location-line
+                       region-text))
+              (is-comment
+               (format "TODO comment on line %d:\n%s"
+                       current-line-number
+                       current-line))
+              (t "Current context"))
+             function-context
+             files-context-string)))
+         (code-change-boundaries
+          (unless ask-question-p
+            (cond
+             (org-todo-section-info
+              "Keep the Org headline in place and keep changes scoped to the requested implementation.")
+             ((or region-text is-comment)
+              "Keep the TODO comment in place and ensure it is marked DONE after implementation; avoid unrelated cleanup.")
+             (t ai-code-change--brief-default-boundaries))))
          (final-prompt
-          (concat prompt
-                  (when (and clipboard-context
-                             (string-match-p "\\S-" clipboard-context))
-                    (concat "\n\nClipboard context:\n" clipboard-context))
-                  repo-context-string
-                  (when (string= action-intent "Ask question")
-                    (concat "\n" ai-code-change--ask-question-note)))))
+          (if ask-question-p
+              (concat prompt
+                      (when clipboard-context-text
+                        (concat "\n\nClipboard context:\n" clipboard-context-text))
+                      repo-context-string
+                      (concat "\n" ai-code-change--ask-question-note))
+            (ai-code--compose-code-change-brief
+             :goal prompt
+             :scope code-change-scope
+             :context repo-context-string
+             :clipboard-context clipboard-context-text
+             :boundaries code-change-boundaries
+             :code-change-note (if region-text
+                                   ai-code-change--selected-region-note
+                                 ai-code-change--generic-note)))))
     (ai-code--insert-prompt final-prompt)))
 
 ;;; Flycheck integration
@@ -678,23 +716,36 @@ or whole file.  Requires the `flycheck` package to be installed and available."
           (if (null errors-in-scope)
               (message "No Flycheck errors found in %s." scope-description)
             (let* ((files-context-string (ai-code--get-context-files-string))
+                   (repo-context-string (ai-code--format-repo-context-info))
                    (error-list-string
                     (ai-code-flycheck--format-error-list errors-in-scope
                                                          rel-file))
-                    (prompt
-                     (if (string-equal "the entire file" scope-description)
-                         (format "Please fix the following Flycheck errors in file %s:\n\n%s\n%s\n%s"
-                                 rel-file error-list-string
-                                 files-context-string
-                                 ai-code-change--generic-note)
-                       (format "Please fix the following Flycheck errors in %s of file %s:\n\n%s\n%s\n%s"
-                               scope-description
-                               rel-file
-                               error-list-string
-                               files-context-string
-                               ai-code-change--generic-note)))
-                    (edited-prompt (ai-code-read-string "Edit prompt for AI: "
-                                                        prompt)))
+                   (scope-string
+                    (concat
+                     (format "Current file: %s\nTarget scope: %s"
+                             buffer-file-name
+                             scope-description)
+                     files-context-string))
+                   (goal-string
+                    (if (string-equal "the entire file" scope-description)
+                        (format "Please fix the following Flycheck errors in file %s:\n\n%s"
+                                rel-file
+                                error-list-string)
+                      (format "Please fix the following Flycheck errors in %s of file %s:\n\n%s"
+                              scope-description
+                              rel-file
+                              error-list-string)))
+                   (boundaries-string
+                    "Fix only the listed Flycheck errors in the target scope. Preserve existing behavior and avoid unrelated cleanup or refactors.")
+                   (prompt
+                    (ai-code--compose-code-change-brief
+                     :goal goal-string
+                     :scope scope-string
+                     :context repo-context-string
+                     :boundaries boundaries-string
+                     :code-change-note ai-code-change--generic-note))
+                   (edited-prompt (ai-code-read-string "Edit prompt for AI: "
+                                                       prompt)))
               (when (and edited-prompt (not (string-blank-p edited-prompt)))
                 (ai-code--insert-prompt edited-prompt)
                 (message "Generated prompt to fix %d Flycheck error(s) in %s."

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -50,6 +50,60 @@
   "Note: Please only answer the question about the code above, do not make any code changes."
   "Prompt note for question-only requests without code changes.")
 
+(defconst ai-code-change--brief-default-boundaries
+  (concat
+   "Make only the requested code change. Avoid unrelated cleanup. "
+   "Preserve existing functionality unless the goal requires changing it.")
+  "Default boundaries section for structured code-change briefs.")
+
+(defconst ai-code-change--brief-agent-responsibilities
+  (concat
+   "Inspect the relevant files before editing. Plan briefly, then edit the code. "
+   "Run appropriate project verification for the change. "
+   "Fix failures caused by the change.")
+  "Default agent responsibilities section for structured code-change briefs.")
+
+(defconst ai-code-change--brief-verification-evidence
+  "Report the exact verification command(s), result, and any remaining risk or blocker."
+  "Default verification evidence section for structured code-change briefs.")
+
+(defun ai-code--code-change-brief--section (title body)
+  "Return a code-change brief section named TITLE with BODY.
+When BODY is nil or blank, return nil."
+  (when (and (stringp body)
+             (not (string-blank-p body)))
+    (format "%s:\n%s" title (string-trim body))))
+
+(defun ai-code--compose-code-change-brief (&rest plist)
+  "Return a structured agent brief for a code-change request.
+PLIST accepts `:goal', `:scope', `:context', `:boundaries',
+`:clipboard-context', and `:code-change-note'.  The brief is prompt text for
+the agent; Emacs only prepares the handoff and does not perform the engineering
+loop."
+  (let* ((goal (plist-get plist :goal))
+         (scope (plist-get plist :scope))
+         (context (plist-get plist :context))
+         (boundaries (or (plist-get plist :boundaries)
+                         ai-code-change--brief-default-boundaries))
+         (clipboard-context (plist-get plist :clipboard-context))
+         (code-change-note (plist-get plist :code-change-note))
+         (sections
+          (delq nil
+                (list
+                 (ai-code--code-change-brief--section "Goal" goal)
+                 (ai-code--code-change-brief--section "Scope" scope)
+                 (ai-code--code-change-brief--section "Context" context)
+                 (ai-code--code-change-brief--section "Clipboard context" clipboard-context)
+                 (ai-code--code-change-brief--section "Boundaries" boundaries)
+                 (ai-code--code-change-brief--section
+                  "Agent responsibilities"
+                  ai-code-change--brief-agent-responsibilities)
+                 (ai-code--code-change-brief--section
+                  "Verification evidence"
+                  ai-code-change--brief-verification-evidence)
+                 (ai-code--code-change-brief--section "Instruction" code-change-note)))))
+    (mapconcat #'identity sections "\n\n")))
+
 (defun ai-code--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.
 Returns non-nil if LINE starts with one or more comment characters,
@@ -193,25 +247,30 @@ REGION-ACTIVE indicates whether a region is selected."
          (initial-prompt (ai-code-read-string prompt-label ""))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
+         (scope-string
+          (concat
+           (format "Current file: %s" buffer-file-name)
+           (when region-text
+             (concat "\nSelected region:\n"
+                     (cond
+                      (region-location-info
+                       (concat region-location-info "\n"))
+                      (region-start-line
+                       (format "Start line: %d\n" region-start-line)))
+                     region-text))
+           (when function-name (format "\nFunction: %s" function-name))
+           files-context-string))
          (final-prompt
-          (concat initial-prompt
-                  (when region-text
-                    (concat "\nSelected region:\n"
-                            (cond
-                             (region-location-info
-                              (concat region-location-info "\n"))
-                             (region-start-line
-                              (format "Start line: %d\n" region-start-line)))
-                            region-text))
-                  (when function-name (format "\nFunction: %s" function-name))
-                  files-context-string
-                  repo-context-string
-                  (when (and clipboard-context
-                             (string-match-p "\\S-" clipboard-context))
-                    (concat "\n\nClipboard context:\n" clipboard-context))
-                  (if region-text
-                      (concat "\n" ai-code-change--selected-region-note)
-                    (concat "\n" ai-code-change--generic-note)))))
+          (ai-code--compose-code-change-brief
+           :goal initial-prompt
+           :scope scope-string
+           :context repo-context-string
+           :clipboard-context (and clipboard-context
+                                   (string-match-p "\\S-" clipboard-context)
+                                   clipboard-context)
+           :code-change-note (if region-text
+                                 ai-code-change--selected-region-note
+                               ai-code-change--generic-note))))
     (ai-code--insert-prompt final-prompt)))
 
 (defun ai-code--handle-dired-code-change (arg)
@@ -230,13 +289,14 @@ ARG is the prefix argument."
          (initial-prompt (ai-code-read-string prompt-label ""))
          (repo-context-string (ai-code--format-repo-context-info))
          (final-prompt
-          (concat initial-prompt
-                  "\nSelected files/directories:\n" files-str
-                  repo-context-string
-                  (when (and clipboard-context
-                             (string-match-p "\\S-" clipboard-context))
-                    (concat "\n\nClipboard context:\n" clipboard-context))
-                  (concat "\n" ai-code-change--selected-files-note))))
+          (ai-code--compose-code-change-brief
+           :goal initial-prompt
+           :scope (concat "Selected files/directories:\n" files-str)
+           :context repo-context-string
+           :clipboard-context (and clipboard-context
+                                   (string-match-p "\\S-" clipboard-context)
+                                   clipboard-context)
+           :code-change-note ai-code-change--selected-files-note)))
     (ai-code--insert-prompt final-prompt)))
 
 ;;;###autoload
@@ -398,7 +458,7 @@ The plist contains `:heading-line', `:content', and `:line-number'."
 (defun ai-code--implement-todo--build-and-send-prompt (arg &optional default-action)
   "Build the TODO implementation prompt and insert it.
 ARG is the prefix argument for clipboard context.
-Optional DEFAULT-ACTION skips the completing-read prompt when non-nil."
+Optional DEFAULT-ACTION skips the `completing-read' prompt when non-nil."
   ;; DONE: ask user with completing-read before build up prompt, candidate should be 1. Code change; 2. Ask question. Given selection, add suffix to them respectively to indicate AI to make code change, or do not make any code change
   ;; DONE: currently ai-code-implement-todo work on the org-mode TODO headline. But I want it be able to work on any org-mode headline, no matter it has TODO keyword or not. Please also update the ai-code-code-change and @ai-code-discussion.el#ai-code-ask-question, for the org headline detection code (currently only detect org TODO headline) to be consistent with this function.
   (let* ((clipboard-context (when arg (ai-code--get-clipboard-text)))

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -67,6 +67,16 @@
   "Report the exact verification command(s), result, and any remaining risk or blocker."
   "Default verification evidence section for structured code-change briefs.")
 
+(defconst ai-code-change--question-brief-default-boundaries
+  "Answer the question only. Do not make code changes."
+  "Default boundaries section for structured question briefs.")
+
+(defconst ai-code-change--flycheck-brief-boundaries
+  (concat
+   "Fix only the listed Flycheck errors in the target scope. "
+   "Preserve existing behavior and avoid unrelated cleanup or refactors.")
+  "Boundaries section for Flycheck fix briefs.")
+
 (defun ai-code--code-change-brief--section (title body)
   "Return a code-change brief section named TITLE with BODY.
 When BODY is nil or blank, return nil."
@@ -103,6 +113,40 @@ loop."
                   ai-code-change--brief-verification-evidence)
                  (ai-code--code-change-brief--section "Instruction" code-change-note)))))
     (mapconcat #'identity sections "\n\n")))
+
+(defun ai-code--compose-question-brief (&rest plist)
+  "Return a structured brief for question-only requests.
+PLIST accepts `:goal', `:scope', `:context', `:clipboard-context',
+`:boundaries', and `:instruction'."
+  (let* ((goal (plist-get plist :goal))
+         (scope (plist-get plist :scope))
+         (context (plist-get plist :context))
+         (clipboard-context (plist-get plist :clipboard-context))
+         (boundaries (or (plist-get plist :boundaries)
+                         ai-code-change--question-brief-default-boundaries))
+         (instruction (plist-get plist :instruction))
+         (sections
+          (delq nil
+                (list
+                 (ai-code--code-change-brief--section "Goal" goal)
+                 (ai-code--code-change-brief--section "Scope" scope)
+                 (ai-code--code-change-brief--section "Context" context)
+                 (ai-code--code-change-brief--section "Clipboard context" clipboard-context)
+                 (ai-code--code-change-brief--section "Boundaries" boundaries)
+                 (ai-code--code-change-brief--section "Instruction" instruction)))))
+    (mapconcat #'identity sections "\n\n")))
+
+(defun ai-code--flycheck-goal-string (scope-description rel-file error-list-string)
+  "Return Flycheck-fix goal text for SCOPE-DESCRIPTION in REL-FILE.
+ERROR-LIST-STRING is the formatted list of diagnostics."
+  (if (string-equal "the entire file" scope-description)
+      (format "Please fix the following Flycheck errors in file %s:\n\n%s"
+              rel-file
+              error-list-string)
+    (format "Please fix the following Flycheck errors in %s of file %s:\n\n%s"
+            scope-description
+            rel-file
+            error-list-string)))
 
 (defun ai-code--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.
@@ -562,25 +606,24 @@ Optional DEFAULT-ACTION skips the `completing-read' prompt when non-nil."
          (clipboard-context-text (and clipboard-context
                                       (string-match-p "\\S-" clipboard-context)
                                       clipboard-context))
-         (code-change-scope
-          (unless ask-question-p
-            (concat
-             (cond
-              (org-todo-section-info
-               (format "Org headline on line %d:\n%s"
-                       org-line-number
-                       org-section-block))
-              (region-text
-               (format "%s\n%s"
-                       region-location-line
-                       region-text))
-              (is-comment
-               (format "TODO comment on line %d:\n%s"
-                       current-line-number
-                       current-line))
-              (t "Current context"))
-             function-context
-             files-context-string)))
+         (todo-scope
+          (concat
+           (cond
+            (org-todo-section-info
+             (format "Org headline on line %d:\n%s"
+                     org-line-number
+                     org-section-block))
+            (region-text
+             (format "%s\n%s"
+                     region-location-line
+                     region-text))
+            (is-comment
+             (format "TODO comment on line %d:\n%s"
+                     current-line-number
+                     current-line))
+            (t "Current context"))
+           function-context
+           files-context-string))
          (code-change-boundaries
           (unless ask-question-p
             (cond
@@ -591,14 +634,15 @@ Optional DEFAULT-ACTION skips the `completing-read' prompt when non-nil."
              (t ai-code-change--brief-default-boundaries))))
          (final-prompt
           (if ask-question-p
-              (concat prompt
-                      (when clipboard-context-text
-                        (concat "\n\nClipboard context:\n" clipboard-context-text))
-                      repo-context-string
-                      (concat "\n" ai-code-change--ask-question-note))
+              (ai-code--compose-question-brief
+               :goal prompt
+               :scope todo-scope
+               :context repo-context-string
+               :clipboard-context clipboard-context-text
+               :instruction ai-code-change--ask-question-note)
             (ai-code--compose-code-change-brief
              :goal prompt
-             :scope code-change-scope
+             :scope todo-scope
              :context repo-context-string
              :clipboard-context clipboard-context-text
              :boundaries code-change-boundaries
@@ -727,22 +771,15 @@ or whole file.  Requires the `flycheck` package to be installed and available."
                              scope-description)
                      files-context-string))
                    (goal-string
-                    (if (string-equal "the entire file" scope-description)
-                        (format "Please fix the following Flycheck errors in file %s:\n\n%s"
-                                rel-file
-                                error-list-string)
-                      (format "Please fix the following Flycheck errors in %s of file %s:\n\n%s"
-                              scope-description
-                              rel-file
-                              error-list-string)))
-                   (boundaries-string
-                    "Fix only the listed Flycheck errors in the target scope. Preserve existing behavior and avoid unrelated cleanup or refactors.")
+                    (ai-code--flycheck-goal-string scope-description
+                                                   rel-file
+                                                   error-list-string))
                    (prompt
                     (ai-code--compose-code-change-brief
                      :goal goal-string
                      :scope scope-string
                      :context repo-context-string
-                     :boundaries boundaries-string
+                     :boundaries ai-code-change--flycheck-brief-boundaries
                      :code-change-note ai-code-change--generic-note))
                    (edited-prompt (ai-code-read-string "Edit prompt for AI: "
                                                        prompt)))

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -40,8 +40,9 @@
 
 (defun ai-code--ensure-note-request-history ()
   "Register persistent minibuffer history for note requests.
-Only adds the variable to savehist tracking; does not enable savehist-mode.
-Users should enable savehist-mode in their Emacs configuration to persist history."
+Only adds the variable to savehist tracking; does not enable
+`savehist-mode'.  Users should enable it in their Emacs configuration
+to persist history."
   (add-to-list 'savehist-additional-variables 'ai-code-note-request-history))
 
 (ai-code--ensure-note-request-history)
@@ -831,7 +832,8 @@ NOTE-REQUEST is included in the prompt body."
 ;;;###autoload
 (defun ai-code-take-notes (&optional arg)
   "Take notes by AI request and send prompt to the AI session.
-When in an Org buffer with a saved file, generates a prompt to insert note content.
+When in an Org buffer with a saved file, generate a prompt to insert
+note content.
 Otherwise, generates a prompt to create a new note file.
 With prefix ARG, open the default note file in other window instead."
   (interactive "P")

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -11,6 +11,7 @@
 
 (require 'which-func)
 (require 'savehist)
+(require 'subr-x)
 
 (require 'ai-code-input)
 (require 'ai-code-prompt-mode)
@@ -52,6 +53,16 @@ Users should enable savehist-mode in their Emacs configuration to persist histor
 (defconst ai-code-discussion--selected-region-note
   "Note: This is a question about the selected region - please do not modify the code."
   "Prompt note for question-only requests about the selected region.")
+
+(defconst ai-code-discussion--exception-investigation-boundaries
+  "Investigate first. Do not make code changes."
+  "Boundaries for exception investigation prompts.")
+
+(defconst ai-code-discussion--exception-investigation-note
+  (concat
+   "Report root cause, relevant evidence, and candidate next steps. "
+   "Include at least one candidate next step that explains how to fix the issue.")
+  "Instruction for exception investigation prompts.")
 
 (defconst ai-code-discussion--explain-selected-files-prefix
   "Please explain the selected files or directories."
@@ -317,9 +328,9 @@ Argument ARG is the prefix argument."
          (function-name (which-function))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
-         (context-section
+         (diagnostic-context
           (if full-buffer-context
-              (concat "\n\nContext:\n" full-buffer-context)
+              full-buffer-context
             (let ((context-blocks nil))
               (when clipboard-content
                 (push (concat "Clipboard context (error/exception):\n" clipboard-content)
@@ -331,9 +342,11 @@ Argument ARG is the prefix argument."
                 (push (concat "Selected code:\n" region-text)
                       context-blocks))
               (when context-blocks
-                (concat "\n\nContext:\n"
-                        (mapconcat #'identity (nreverse context-blocks) "\n\n"))))))
-         (default-question "How to fix the error in this code? Please analyze the error, explain the root cause, and provide the corrected code to resolve the issue: ")
+                (mapconcat #'identity (nreverse context-blocks) "\n\n")))))
+         (default-question
+          (concat
+           "Investigate this error. Explain the likely root cause and suggest "
+           "candidate next steps, including how to fix it: "))
          (prompt-label
           (cond
            (clipboard-content
@@ -350,16 +363,28 @@ Argument ARG is the prefix argument."
             (format "Investigate exceptions in function %s: " function-name))
            (t "Investigate exceptions in code: ")))
          (initial-prompt (ai-code-read-string prompt-label default-question))
+         (scope-string
+          (concat
+           (if buffer-file
+               (format "Current file: %s" buffer-file)
+             (format "Current buffer: %s" (buffer-name)))
+           (when function-name
+             (format "\nFunction: %s" function-name))
+           files-context-string))
+         (context-string
+          (string-trim
+           (concat
+            (or diagnostic-context "")
+            (when (and diagnostic-context repo-context-string)
+              "\n\n")
+            repo-context-string)))
          (final-prompt
-          (concat initial-prompt
-                  context-section
-                  (when function-name (format "\nFunction: %s" function-name))
-                  files-context-string
-                  repo-context-string
-                  (concat "\n\nNote: Please focus on how to fix the error. Your response should include:\n"
-                          "1. A brief explanation of the root cause of the error.\n"
-                          "2. A code snippet with the fix.\n"
-                          "3. An explanation of how the fix addresses the error."))))
+          (ai-code--compose-question-brief
+           :goal initial-prompt
+           :scope scope-string
+           :context context-string
+           :boundaries ai-code-discussion--exception-investigation-boundaries
+           :instruction ai-code-discussion--exception-investigation-note)))
          (ai-code--insert-prompt final-prompt)))
 
 ;;;###autoload

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -61,6 +61,8 @@ to persist history."
 
 (defconst ai-code-discussion--exception-investigation-note
   (concat
+   ai-code-discussion--question-only-note
+   "\n"
    "Report root cause, relevant evidence, and candidate next steps. "
    "Include at least one candidate next step that explains how to fix the issue.")
   "Instruction for exception investigation prompts.")

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -168,10 +168,12 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                          (t nil)))
          (git-relative-files (when context-files
                               (ai-code--get-git-relative-paths context-files)))
-         (files-context-string (when git-relative-files
-                                (concat "\nFiles:\n"
-                                       (mapconcat (lambda (f) (concat "@" f))
-                                                 git-relative-files "\n"))))
+         (scope-string
+          (if git-relative-files
+              (concat "Selected files/directories:\n"
+                      (mapconcat (lambda (f) (concat "@" f))
+                                 git-relative-files "\n"))
+            (format "Current directory: %s" default-directory)))
          (prompt-label (cond
                         ((and clipboard-context
                               (string-match-p "\\S-" clipboard-context))
@@ -185,13 +187,15 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                         (t "General question about directory: ")))
          (question (ai-code-read-string prompt-label ""))
          (repo-context-string (ai-code--format-repo-context-info))
-         (final-prompt (concat question
-                                files-context-string
-                                repo-context-string
-                                (when (and clipboard-context
-                                           (string-match-p "\\S-" clipboard-context))
-                                  (concat "\n\nClipboard context:\n" clipboard-context))
-                                (concat "\n" ai-code-discussion--question-only-note))))
+         (final-prompt
+          (ai-code--compose-question-brief
+           :goal question
+           :scope scope-string
+           :context repo-context-string
+           :clipboard-context (and clipboard-context
+                                   (string-match-p "\\S-" clipboard-context)
+                                   clipboard-context)
+           :instruction ai-code-discussion--question-only-note)))
     (ai-code--insert-prompt final-prompt)))
 
 (defun ai-code--ask-question-file (clipboard-context)
@@ -234,23 +238,30 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
          (question (ai-code-read-string prompt-label ""))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
+         (scope-string
+          (concat
+           (if buffer-file-name
+               (format "Current file: %s" buffer-file-name)
+             (format "Current buffer: %s" (buffer-name)))
+           (when region-text
+             (concat "\nSelected region:\n"
+                     (when region-location-info
+                       (concat region-location-info "\n"))
+                     region-text))
+           (when function-name
+             (format "\nFunction: %s" function-name))
+           files-context-string))
          (final-prompt
-          (concat question
-                  (when region-text
-                    (concat "\nSelected region:\n"
-                            (when region-location-info
-                              (concat region-location-info "\n"))
-                            region-text))
-                  (when function-name
-                    (format "\nFunction: %s" function-name))
-                   files-context-string
-                   repo-context-string
-                   (when (and clipboard-context
-                              (string-match-p "\\S-" clipboard-context))
-                     (concat "\n\nClipboard context:\n" clipboard-context))
-                   (if region-text
-                       (concat "\n" ai-code-discussion--selected-region-note)
-                     (concat "\n" ai-code-discussion--question-only-note)))))
+          (ai-code--compose-question-brief
+           :goal question
+           :scope scope-string
+           :context repo-context-string
+           :clipboard-context (and clipboard-context
+                                   (string-match-p "\\S-" clipboard-context)
+                                   clipboard-context)
+           :instruction (if region-text
+                            ai-code-discussion--selected-region-note
+                          ai-code-discussion--question-only-note))))
     (ai-code--insert-prompt final-prompt)))
 
 (defun ai-code--get-git-relative-paths (file-paths)

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -285,7 +285,8 @@ test suffixes."
   (append
    (ai-code--downcase-strings
     (list ai-code-discussion--question-only-note
-          ai-code-discussion--selected-region-note))
+          ai-code-discussion--selected-region-note
+          ai-code-discussion--exception-investigation-boundaries))
    (ai-code--downcase-strings
     ai-code-discussion--explain-prompt-prefixes))
   "Prompt markers that clearly indicate a non-code-change request.")

--- a/ai-code.el
+++ b/ai-code.el
@@ -483,7 +483,7 @@ Shows the current backend label to the right."
   (ai-code--infix-toggle-auto-follow-up)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("P" "AI session checkpoint" ai-code-session-checkpoint)
-  ("e" "Debug exception (C-u: clipboard)" ai-code-investigate-exception)
+  ("e" "Investigate exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)
   ("k" "Copy Cur File Name (C-u: full)" ai-code-copy-buffer-file-name-to-clipboard)
   ;; ("o" "Open recent file (C-u: insert)" ai-code-git-repo-recent-modified-files)

--- a/test/test_ai-code-agile.el
+++ b/test/test_ai-code-agile.el
@@ -65,6 +65,26 @@
         (ai-code--write-test "my-function")
         (should (string-match-p "my-function" captured-prompt))))))
 
+(ert-deftest ai-code-test-write-test-prompt-uses-structured-code-change-brief ()
+  "Verify `ai-code--write-test' uses the structured code-change brief."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (setq-local buffer-file-name "/project/src/my-module.el")
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code-read-string)
+                 (lambda (_prompt &optional initial _candidates) initial))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/project/src/my-module.el"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (text) (setq captured-prompt text))))
+        (ai-code--write-test "my-function")
+        (should (string-match-p "^Goal:\nWrite test for 'my-function'" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Function: my-function" captured-prompt))
+        (should (string-match-p "Boundaries:\nFollow TDD principles" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))))))
+
 (ert-deftest ai-code-test-write-test-prompt-includes-source-file-hint ()
   "Verify prompt includes a hint about the source file when buffer has a file name."
   (with-temp-buffer
@@ -212,6 +232,27 @@
         (should (string-match-p "summary of test result" captured-prompt))
         (should (string-match-p "List the public API / log key / config key change if there is" captured-prompt))))))
 
+(ert-deftest ai-code-test-tdd-green-stage-uses-structured-code-change-brief ()
+  "Verify Green stage uses the structured code-change brief."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (let (captured-prompt)
+      (setq-local buffer-file-name "/project/src/my-module.el")
+      (cl-letf (((symbol-function 'ai-code--ensure-test-buffer-visible) (lambda () t))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_prompt &optional initial _candidates) initial))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/project/src/my-module.el"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (text) (setq captured-prompt text))))
+        (ai-code--tdd-green-stage "my-function")
+        (should (string-match-p "^Goal:\nImplement function 'my-function'" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Function: my-function" captured-prompt))
+        (should (string-match-p "Boundaries:\nFollow TDD principles" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))))))
+
 (ert-deftest ai-code-test-tdd-red-green-stage-prompt-includes-stage-test-run-and-change-summary ()
   "Verify Red + Green stage prompt asks to run test after each stage and summarize key changes."
   (with-temp-buffer
@@ -247,6 +288,57 @@
         (should (string-match-p "Run test after each stage" captured-prompt))
         (should (string-match-p "summary of test result" captured-prompt))
         (should (string-match-p "List the public API / log key / config key change if there is" captured-prompt))))))
+
+(ert-deftest ai-code-test-tdd-red-green-blue-stage-uses-structured-code-change-brief ()
+  "Verify Red + Green + Blue stage uses the structured code-change brief."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (let (captured-prompt)
+      (setq-local buffer-file-name "/project/src/my-module.el")
+      (cl-letf (((symbol-function 'ai-code-read-string)
+                 (lambda (_prompt &optional initial _candidates) initial))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/project/src/my-module.el"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (text) (setq captured-prompt text))))
+        (ai-code--tdd-red-green-blue-stage "my-function")
+        (should (string-match-p "^Goal:\nImplement test functions" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Function: my-function" captured-prompt))
+        (should (string-match-p "Boundaries:\nFollow strict TDD stages" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))))))
+
+(ert-deftest ai-code-test-specific-refactoring-uses-structured-code-change-brief ()
+  "Verify specific refactoring requests use the structured code-change brief."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (setq-local buffer-file-name "/project/src/my-module.el")
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code-read-string)
+                 (lambda (_prompt &optional initial _candidates) initial))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/project/src/my-module.el"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (text)
+                   (setq captured-prompt text)
+                   t)))
+        (ai-code--handle-specific-refactoring
+         "Extract Method"
+         '(("Extract Method" . "Extract the selected code into a new method named helper."))
+         '(:region-active nil
+           :region-text nil
+           :current-function "my-function"
+           :file-name "my-module.el"
+           :dired-targets nil
+           :context-description "in function 'my-function'")
+         nil)
+        (should (string-match-p "^Goal:\nExtract Method in function 'my-function'" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Function: my-function" captured-prompt))
+        (should (string-match-p "Boundaries:\nPreserve existing behavior" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))))))
 
 (ert-deftest ai-code-test-refactor-book-method-dired-skips-technique-selection ()
   "Verify Dired refactoring jumps straight to suggestion mode."

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -11,6 +11,7 @@
 
 (require 'ert)
 (require 'ai-code-change)
+(defvar flycheck-current-errors)
 
 (ert-deftest ai-code-test-ai-code--get-function-name-for-comment-basic ()
   "Test function name detection when on a comment line before function body.
@@ -466,6 +467,10 @@ is between the function definition and its body."
         (ai-code--implement-todo--build-and-send-prompt nil)
 
         (should (stringp captured-prompt))
+        (should (string-match-p "^Goal:\n" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))
         ;; Should contain implementation-oriented wording
         (should (string-match-p "Please implement code" captured-prompt))
         ;; Should NOT contain no-code-change suffix
@@ -533,6 +538,10 @@ is between the function definition and its body."
         (ai-code-implement-todo nil)
 
         (should (stringp captured-prompt))
+        (should (string-match-p "^Goal:\n" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))
         (should (string-match-p "Please implement code" captured-prompt))
         (should (string-match-p "TODO Build backend switcher" captured-prompt))
         (should (string-match-p "Use Codex for implementation\\." captured-prompt))
@@ -770,6 +779,50 @@ is between the function definition and its body."
         (should (string-match-p "Boundaries:" captured-prompt))
         (should (string-match-p "Agent responsibilities:" captured-prompt))
         (should (string-match-p "Verification evidence:" captured-prompt))))))
+
+(ert-deftest ai-code-test-flycheck-fix-errors-uses-structured-brief ()
+  "Test `ai-code-flycheck-fix-errors-in-scope' uses structured code-change brief."
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/test.el")
+    (insert "(defun old-helper ()\n  nil)\n")
+    (goto-char (point-min))
+    (setq-local flycheck-mode t)
+    (let ((flycheck-current-errors '(fake-error))
+          captured-prompt)
+      (let ((original-featurep (symbol-function 'featurep)))
+        (cl-letf (((symbol-function 'featurep)
+                   (lambda (feature)
+                     (if (eq feature 'flycheck)
+                         t
+                       (funcall original-featurep feature))))
+                  ((symbol-function 'ai-code--git-root) (lambda () "/tmp/project"))
+                ((symbol-function 'ai-code--choose-flycheck-scope)
+                 (lambda () (list (point-min) (point-max) "current line (1)")))
+                ((symbol-function 'ai-code-flycheck--get-errors-in-scope)
+                 (lambda (_start _end) '(fake-error)))
+                ((symbol-function 'ai-code-flycheck--format-error-list)
+                 (lambda (_errors _file)
+                   "File: test.el:1:1\nError: fake diagnostic"))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nVisible context files:\n/tmp/project/test.el"))
+                ((symbol-function 'ai-code--format-repo-context-info)
+                 (lambda () "\nStored repository context:\n  - /tmp/project/test.el#old-helper"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+          (ai-code-flycheck-fix-errors-in-scope)
+          (should (stringp captured-prompt))
+          (should (string-match-p
+                   "Goal:\nPlease fix the following Flycheck errors in current line (1) of file test\\.el:"
+                   captured-prompt))
+          (should (string-match-p "Scope:\nCurrent file: /tmp/project/test\\.el\nTarget scope: current line (1)"
+                                  captured-prompt))
+          (should (string-match-p "Context:\nStored repository context" captured-prompt))
+          (should (string-match-p "Boundaries:\nFix only the listed Flycheck errors in the target scope"
+                                  captured-prompt))
+          (should (string-match-p "Agent responsibilities:" captured-prompt))
+          (should (string-match-p "Verification evidence:" captured-prompt)))))))
 
 (ert-deftest ai-code-test-get-org-section-info-plain-headline ()
   "Test `ai-code--implement-todo--get-org-todo-section-info' returns info for plain Org headline."

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -727,6 +727,50 @@ is between the function definition and its body."
 
         (should (equal captured-default-action "Code change"))))))
 
+(ert-deftest ai-code-test-compose-code-change-brief-includes-contract-sections ()
+  "Test code-change brief composer emits the reliability contract sections."
+  (let ((brief (ai-code--compose-code-change-brief
+                :goal "Rename the helper"
+                :scope "Current file: test.el\nFunction: old-helper"
+                :context "Stored repository context:\n  - test.el#old-helper"
+                :boundaries "Only update the helper and direct call sites."
+                :clipboard-context "Prefer the existing naming pattern."
+                :code-change-note ai-code-change--generic-note)))
+    (should (string-match-p "Goal:\nRename the helper" brief))
+    (should (string-match-p "Scope:\nCurrent file: test\\.el" brief))
+    (should (string-match-p "Context:\nStored repository context" brief))
+    (should (string-match-p "Boundaries:\nOnly update the helper" brief))
+    (should (string-match-p "Agent responsibilities:" brief))
+    (should (string-match-p "run appropriate project verification" brief))
+    (should (string-match-p "Verification evidence:" brief))
+    (should (string-match-p "Note: Please make the code change" brief))))
+
+(ert-deftest ai-code-test-code-change-uses-structured-brief-for-regular-change ()
+  "Test `ai-code-code-change' sends a structured brief for normal code changes."
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/test.el")
+    (insert "(defun old-helper ()\n  nil)\n")
+    (goto-char (point-min))
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label _input) "Rename old-helper to new-helper"))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/tmp/project/test.el"))
+                ((symbol-function 'ai-code--format-repo-context-info)
+                 (lambda () "\nStored repository context:\n  - /tmp/project/test.el#old-helper"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+        (ai-code-code-change nil)
+        (should (stringp captured-prompt))
+        (should (string-match-p "Goal:\nRename old-helper to new-helper" captured-prompt))
+        (should (string-match-p "Scope:" captured-prompt))
+        (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Boundaries:" captured-prompt))
+        (should (string-match-p "Agent responsibilities:" captured-prompt))
+        (should (string-match-p "Verification evidence:" captured-prompt))))))
+
 (ert-deftest ai-code-test-get-org-section-info-plain-headline ()
   "Test `ai-code--implement-todo--get-org-todo-section-info' returns info for plain Org headline."
   (with-temp-buffer

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -263,6 +263,58 @@
 
         (should implement-todo-called)))))
 
+(ert-deftest ai-code-test-ask-question-file-uses-structured-brief ()
+  "Test `ai-code--ask-question-file' emits a structured question brief."
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/test.el")
+    (insert "(defun old-helper ()\n  nil)\n")
+    (goto-char (point-min))
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label _input) "Why does old-helper return nil?"))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/tmp/project/test.el"))
+                ((symbol-function 'ai-code--format-repo-context-info)
+                 (lambda () "\nStored repository context:\n  - /tmp/project/test.el#old-helper"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+        (ai-code--ask-question-file nil)
+        (should (stringp captured-prompt))
+        (should (string-match-p "Goal:\nWhy does old-helper return nil\\?" captured-prompt))
+        (should (string-match-p "Scope:\nCurrent file: /tmp/project/test\\.el" captured-prompt))
+        (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Context:\nStored repository context" captured-prompt))
+        (should (string-match-p "Boundaries:\nAnswer the question only\\. Do not make code changes\\."
+                                captured-prompt))
+        (should (string-match-p "Instruction:\nNote: This is a question only" captured-prompt))))))
+
+(ert-deftest ai-code-test-ask-question-dired-uses-structured-brief ()
+  "Test `ai-code--ask-question-dired' emits a structured question brief."
+  (let (captured-prompt)
+    (cl-letf (((symbol-function 'dired-get-filename)
+               (lambda (&rest _) "/tmp/project/a.el"))
+              ((symbol-function 'dired-get-marked-files)
+               (lambda (&rest _) '("/tmp/project/a.el" "/tmp/project/b.el")))
+              ((symbol-function 'ai-code--get-git-relative-paths)
+               (lambda (files)
+                 (mapcar #'file-name-nondirectory files)))
+              ((symbol-function 'ai-code-read-string)
+               (lambda (_label _input) "What changed in these files?"))
+              ((symbol-function 'ai-code--format-repo-context-info)
+               (lambda () "\nStored repository context:\n  - /tmp/project/a.el"))
+              ((symbol-function 'ai-code--insert-prompt)
+               (lambda (prompt) (setq captured-prompt prompt))))
+      (ai-code--ask-question-dired "clipboard details")
+      (should (stringp captured-prompt))
+      (should (string-match-p "Goal:\nWhat changed in these files\\?" captured-prompt))
+      (should (string-match-p "Scope:\nSelected files/directories:\n@b\\.el" captured-prompt))
+      (should (string-match-p "Context:\nStored repository context" captured-prompt))
+      (should (string-match-p "Clipboard context:\nclipboard details" captured-prompt))
+      (should (string-match-p "Boundaries:\nAnswer the question only\\. Do not make code changes\\."
+                              captured-prompt)))))
+
 (ert-deftest ai-code-test-take-notes-org-buffer-sends-insert-prompt ()
   "Test `ai-code-take-notes' sends an AI prompt for Org insertion."
   (with-temp-buffer

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -342,7 +342,8 @@
         (should (string-match-p
                  "Boundaries:\nInvestigate first\\. Do not make code changes\\."
                  captured-prompt))
-        (should (string-match-p "Instruction:\nReport root cause" captured-prompt))
+        (should (string-match-p "Instruction:\nNote: This is a question only" captured-prompt))
+        (should (string-match-p "Report root cause" captured-prompt))
         (should (string-match-p "candidate next steps" captured-prompt))
         (should (string-match-p "how to fix" captured-prompt))))))
 

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -315,6 +315,37 @@
       (should (string-match-p "Boundaries:\nAnswer the question only\\. Do not make code changes\\."
                               captured-prompt)))))
 
+(ert-deftest ai-code-test-investigate-exception-uses-structured-question-brief ()
+  "Test `ai-code-investigate-exception' emits an investigation-first question brief."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (setq buffer-file-name "/tmp/project/test.el")
+    (insert "(defun old-helper ()\n  (error \"boom\"))\n")
+    (goto-char (point-min))
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_label input) input))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () "\nFiles:\n/tmp/project/test.el"))
+                ((symbol-function 'ai-code--format-repo-context-info)
+                 (lambda () "\nStored repository context:\n  - /tmp/project/test.el#old-helper"))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+        (ai-code-investigate-exception nil)
+        (should (stringp captured-prompt))
+        (should (string-match-p "^Goal:\nInvestigate this error" captured-prompt))
+        (should (string-match-p "\n\nScope:\nCurrent file: /tmp/project/test\\.el" captured-prompt))
+        (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Context:\nStored repository context" captured-prompt))
+        (should (string-match-p
+                 "Boundaries:\nInvestigate first\\. Do not make code changes\\."
+                 captured-prompt))
+        (should (string-match-p "Instruction:\nReport root cause" captured-prompt))
+        (should (string-match-p "candidate next steps" captured-prompt))
+        (should (string-match-p "how to fix" captured-prompt))))))
+
 (ert-deftest ai-code-test-take-notes-org-buffer-sends-insert-prompt ()
   "Test `ai-code-take-notes' sends an AI prompt for Org insertion."
   (with-temp-buffer

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -581,6 +581,7 @@
   (should (boundp 'ai-code-change--selected-files-note))
   (should (boundp 'ai-code-discussion--question-only-note))
   (should (boundp 'ai-code-discussion--selected-region-note))
+  (should (boundp 'ai-code-discussion--exception-investigation-boundaries))
   (should (boundp 'ai-code-discussion--explain-prompt-prefixes))
   (should (equal ai-code--code-change-prompt-markers
                  (mapcar #'downcase
@@ -591,9 +592,20 @@
                  (append
                   (mapcar #'downcase
                           (list ai-code-discussion--question-only-note
-                                ai-code-discussion--selected-region-note))
+                                ai-code-discussion--selected-region-note
+                                ai-code-discussion--exception-investigation-boundaries))
                   (mapcar #'downcase
                           ai-code-discussion--explain-prompt-prefixes)))))
+
+(ert-deftest ai-code-test-simple-classifier-treats-exception-investigation-as-non-code-change ()
+  "Test that exception investigation prompts skip code-change routing."
+  (let ((prompt (ai-code--compose-question-brief
+                 :goal "Investigate this error."
+                 :scope "Current file: /tmp/project/test.el"
+                 :boundaries ai-code-discussion--exception-investigation-boundaries
+                 :instruction ai-code-discussion--exception-investigation-note)))
+    (should (eq 'non-code-change
+                (ai-code--simple-classify-prompt-code-change prompt)))))
 
 (ert-deftest ai-code-test-prompt-classification-docstrings-are-not-gptel-specific ()
   "Test that prompt classification docstrings are not GPTel-specific."

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -246,6 +246,15 @@
     (should (equal (plist-get (cdr suffix) :description)
                    "Debug Emacs runtime"))))
 
+(ert-deftest ai-code-test-menu-other-tools-labels-exception-as-investigation ()
+  "Test that the exception entry is labeled as investigation-first."
+  (let ((suffix (transient-get-suffix 'ai-code--menu-other-tools "e")))
+    (should suffix)
+    (should (eq (plist-get (cdr suffix) :command)
+                'ai-code-investigate-exception))
+    (should (equal (plist-get (cdr suffix) :description)
+                   "Investigate exception (C-u: clipboard)"))))
+
 (ert-deftest ai-code-test-menu-other-tools-removes-architecture-guardrails-entry ()
   "Test that the Other Tools menu no longer exposes a dedicated guardrails item."
   (should-error (transient-get-suffix 'ai-code--menu-other-tools "A")


### PR DESCRIPTION
## Summary
This PR makes AI handoffs more consistent and reliable by routing code-changing and question-only actions through structured briefs. The package stays focused on the Emacs-to-agent interaction layer: Emacs assembles goal, scope, context, and constraints, while the agent owns investigation, implementation, verification, and follow-up judgment.

## What changed
- Added reusable structured brief composers for code-change and question prompts, including explicit sections for goal, scope, context, boundaries, agent responsibilities, verification evidence, and instruction.
- Routed the main code-change flows through the code-change brief: regular changes, Dired changes, TODO implementation, Flycheck fixes, refactoring, and TDD Red/Green/Blue prompts.
- Routed question-style flows through the question brief: ask-question file/Dired paths, TODO ask-question routing, and exception investigation.
- Made exception handling investigation-first: the menu now says "Investigate exception", the prompt forbids code changes, and the agent is asked to report root cause plus candidate next steps including how to fix.
- Expanded ERT coverage for the new prompt contracts across code-change, TODO, Flycheck, ask-question, refactoring, TDD, exception investigation, and menu labeling.

## User-visible impact
Users should see clearer, more predictable prompts sent to the selected AI backend. Code-changing actions now give the agent a stronger contract for scope, boundaries, and verification, while question/investigation actions avoid implying that Emacs or the package should perform the engineering work directly.

## Testing
- `emacs -batch -L test/stubs -L . --eval "(setq load-prefer-newer t)" -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit` (838 tests, 825 expected, 0 unexpected, 13 skipped)
- `emacs -batch -L test/stubs -L . --eval "(setq load-prefer-newer t)" -f batch-byte-compile ai-code-change.el ai-code-agile.el ai-code-discussion.el`
- `emacs -batch -L test/stubs -L . --eval "(setq load-prefer-newer t)" --eval "(require 'checkdoc)" --eval "(checkdoc-file \"ai-code-change.el\")" --eval "(checkdoc-file \"ai-code-agile.el\")" --eval "(checkdoc-file \"ai-code-discussion.el\")" --eval "(checkdoc-file \"ai-code.el\")"