### PR TITLE
Fix duplicate Org headline context in TODO prompts

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,7 +2,8 @@
 * Release history
 
 ** Main branch change
-- Unify structured agent briefs across code change and question flows
+- Fix: duplicate Org headline context in TODO prompts
+- Feat: Unify structured agent briefs across code change and question flows
 - More Refactor: Reduce function size. Extract and reuse helper functions.
 - Refactor: refactor boilerplate cli session start code, and add tests
 

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -605,38 +605,22 @@ ARG controls whether clipboard context is included."
 
 (defun ai-code--implement-todo--initial-input (context ask-question-p)
   "Return initial prompt input for CONTEXT and ASK-QUESTION-P."
-  (let ((current-line (plist-get context :current-line))
-        (current-line-number (plist-get context :current-line-number))
-        (is-comment (plist-get context :is-comment))
+  (let ((is-comment (plist-get context :is-comment))
         (org-todo-section-info (plist-get context :org-todo-section-info))
-        (org-line-number (plist-get context :org-line-number))
-        (org-section-block (plist-get context :org-section-block))
-        (function-context (plist-get context :function-context))
-        (region-text (plist-get context :region-text))
-        (region-location-line (plist-get context :region-location-line))
-        (files-context-string (plist-get context :files-context-string)))
+        (region-text (plist-get context :region-text)))
     (cond
      ((and ask-question-p org-todo-section-info)
-      (format "Regarding this Org headline on line %d:\n%s%s%s"
-              org-line-number org-section-block function-context files-context-string))
+      "Please answer my question about this Org headline.")
      ((and ask-question-p region-text)
-      (format "Regarding this TODO comment block in the selected region:\n%s\n%s%s%s"
-              region-location-line region-text function-context files-context-string))
+      "Please answer my question about this selected TODO comment block.")
      ((and ask-question-p is-comment)
-      (format "Regarding this TODO comment on line %d: '%s'%s%s"
-              current-line-number current-line function-context files-context-string))
+      "Please answer my question about this TODO comment.")
      (org-todo-section-info
-      (format "Please implement code for this Org headline first. After implementing, keep the Org headline in place and use the headline and content as prompt context.\nLine %d:\n%s%s%s"
-              org-line-number org-section-block function-context
-              files-context-string))
+      "Please implement code for this Org headline first.")
      (region-text
-      (format
-       "Please implement code for this requirement comment block in the selected region first. After implementing, keep the comment in place and ensure it begins with a DONE prefix (change TODO to DONE or prepend DONE if no prefix). If this is a pure new code block, place it after the comment; otherwise keep the existing structure and make corresponding change for the context.\n%s\n%s%s%s"
-       region-location-line region-text function-context
-       files-context-string))
+      "Please implement code for this selected TODO comment block first.")
      (is-comment
-      (format "Please implement code for this requirement comment on line %d: '%s' first. After implementing, keep the comment in place and ensure it begins with a DONE prefix (change TODO to DONE or prepend DONE if needed). If this is a pure new code block, place it after the comment; otherwise keep the existing structure and make corresponding change for the context.%s%s"
-              current-line-number current-line function-context files-context-string))
+      "Please implement code for this TODO comment first.")
      (t ""))))
 
 (defun ai-code--implement-todo--scope (context)

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -13,6 +13,15 @@
 (require 'ai-code-change)
 (defvar flycheck-current-errors)
 
+(defun ai-code-change-test--count-string-occurrences (needle haystack)
+  "Return the number of non-overlapping NEEDLE occurrences in HAYSTACK."
+  (let ((start 0)
+        (count 0))
+    (while (string-match (regexp-quote needle) haystack start)
+      (setq start (match-end 0))
+      (setq count (1+ count)))
+    count))
+
 (ert-deftest ai-code-test-ai-code--get-function-name-for-comment-basic ()
   "Test function name detection when on a comment line before function body.
 This simulates the Ruby example from the issue where a TODO comment
@@ -586,9 +595,16 @@ is between the function definition and its body."
         (ai-code-implement-todo nil)
 
         (should (stringp captured-prompt))
-        (should (string-match-p "Regarding this Org headline" captured-prompt))
+        (should (string-match-p
+                 "Please answer my question about this Org headline"
+                 captured-prompt))
+        (should (string-match-p "Scope:\nOrg headline on line 1"
+                                captured-prompt))
         (should (string-match-p "TODO: what is the most important verse in Bible"
-                                captured-prompt))))))
+                                captured-prompt))
+        (should (= 1 (ai-code-change-test--count-string-occurrences
+                      "TODO: what is the most important verse in Bible"
+                      captured-prompt)))))))
 
 (ert-deftest ai-code-test-detect-todo-info-org-todo-headline ()
   "Test `ai-code--detect-todo-info' detects Org TODO headlines."
@@ -653,7 +669,7 @@ is between the function definition and its body."
         (should (string-match-p "TODO:" (nth 0 result)))))))
 
 (ert-deftest ai-code-test-implement-todo-default-action-skips-completing-read ()
-  "Test that passing default-action skips the completing-read prompt."
+  "Test that passing default-action skips the `completing-read' prompt."
   (with-temp-buffer
     (setq buffer-file-name "test.el")
     (setq-local comment-start ";")
@@ -684,7 +700,7 @@ is between the function definition and its body."
         (should (string-match-p "Please implement code" captured-prompt))))))
 
 (ert-deftest ai-code-test-implement-todo-nil-default-action-prompts-user ()
-  "Test that nil default-action still prompts user with completing-read."
+  "Test that nil default-action still prompts user with `completing-read'."
   (with-temp-buffer
     (setq buffer-file-name "test.el")
     (setq-local comment-start ";")

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -15,6 +15,15 @@
 
 (defvar org-roam-directory)
 
+(defun ai-code-discussion-test--count-string-occurrences (needle haystack)
+  "Return the number of non-overlapping NEEDLE occurrences in HAYSTACK."
+  (let ((start 0)
+        (count 0))
+    (while (string-match (regexp-quote needle) haystack start)
+      (setq start (match-end 0))
+      (setq count (1+ count)))
+    count))
+
 (ert-deftest ai-code-test-explain-dired-uses-marked-files-as-git-relative-context ()
   "Test that marked Dired files are explained using git relative paths."
   (let (captured-initial-prompt captured-final-prompt)
@@ -221,6 +230,39 @@
 
         (should implement-todo-called)))))
 
+(ert-deftest ai-code-test-ask-question-org-headline-does-not-duplicate-context ()
+  "Test Org headline context appears once in the structured question brief."
+  (with-temp-buffer
+    (require 'org)
+    (setq buffer-file-name "plan.org")
+    (insert "* TODO Build search feature\n")
+    (insert "Use fuzzy matching.\n")
+    (org-mode)
+    (goto-char (point-min))
+
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code-read-string)
+                 (lambda (_label input &optional _candidate-list) input))
+                ((symbol-function 'ai-code--get-clipboard-text) (lambda () nil))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () ""))
+                ((symbol-function 'which-function) (lambda () nil))
+                ((symbol-function 'region-active-p) (lambda () nil))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+
+        (ai-code-ask-question nil)
+
+        (should (stringp captured-prompt))
+        (should (string-match-p "^Goal:\n" captured-prompt))
+        (should (string-match-p "\n\nScope:\n" captured-prompt))
+        (should (= 1 (ai-code-discussion-test--count-string-occurrences
+                      "TODO Build search feature"
+                      captured-prompt)))
+        (should (= 1 (ai-code-discussion-test--count-string-occurrences
+                      "Use fuzzy matching."
+                      captured-prompt)))))))
+
 (ert-deftest ai-code-test-ask-question-passes-ask-question-action ()
   "Test that `ai-code-ask-question' passes \"Ask question\" as default-action."
   (with-temp-buffer
@@ -394,8 +436,7 @@
   (let* ((tmp-root (make-temp-file "ai-code-note-roam" t))
          (org-roam-directory (expand-file-name "roam" tmp-root))
          (default-directory tmp-root)
-         (captured-prompt nil)
-         (captured-default-prompt nil))
+         (captured-prompt nil))
     (unwind-protect
         (with-temp-buffer
           (cl-letf (((symbol-function 'read-string)
@@ -409,7 +450,6 @@
                      (lambda (prompt initial-input &optional _candidate-list)
                        (cond
                         ((string-match-p "Prompt:" prompt)
-                         (setq captured-default-prompt initial-input)
                          initial-input)
                         (t initial-input))))
                     ((symbol-function 'ai-code--ensure-files-directory)

--- a/test/test_ai-code-refactor-safety.el
+++ b/test/test_ai-code-refactor-safety.el
@@ -111,7 +111,8 @@
         (ai-code--implement-todo--build-and-send-prompt t)
         (should (equal captured-label
                        "Question about TODO comment (clipboard context): "))
-        (should (string-match-p "Regarding this TODO comment" captured-initial-input))
+        (should (string-match-p "Please answer my question about this TODO comment"
+                                captured-initial-input))
         (should-not (string-match-p "Please implement code" captured-initial-input))
         (should (string-match-p "Context files" captured-final-prompt))
         (should (string-match-p "Clipboard context:\nclipboard details" captured-final-prompt))


### PR DESCRIPTION
## Summary
Fix duplicate Org headline content in structured TODO/question prompts after the structured brief refactor.

The issue was that `ai-code--implement-todo--initial-input` still embedded the selected Org headline/body into the editable goal text, while `ai-code--implement-todo--scope` also emitted the same content into the structured `Scope` section. This made `C-c a q` on an Org headline send the headline content twice.

This change keeps the initial editable prompt as a short intent sentence and leaves the selected Org/comment/region context in `Scope`. It also adds regression coverage for the `ai-code-ask-question` Org headline path and updates the existing prompt wording assertions.

## Verification
- `emacs -Q -batch -L . --eval "(setq load-prefer-newer t)" --eval "(progn (provide 'magit) (defalias 'magit-get-current-branch (lambda () nil)))" -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit`
- `emacs -Q -batch -L . --eval "(setq load-prefer-newer t)" --eval "(progn (provide 'magit) (defalias 'magit-get-current-branch (lambda () nil)))" -f batch-byte-compile ai-code-change.el ai-code-discussion.el test/test_ai-code-change.el test/test_ai-code-discussion.el test/test_ai-code-refactor-safety.el`
- `emacs -Q -batch -l checkdoc --eval "(mapc #'checkdoc-file '(\"ai-code-change.el\" \"test/test_ai-code-change.el\" \"test/test_ai-code-discussion.el\" \"test/test_ai-code-refactor-safety.el\"))"`