### PR TITLE
Fix: Use Git branch names for AI session defaults

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,7 +2,8 @@
 * Release history
 
 ** Main branch change
-
+- Fix: Use Git branch names for AI session defaults
+  
 ** 1.84
 - Avoid eager session file resolution during terminal linkification
 - Chore: improve worktree experience and task file for worktree creation

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -672,14 +672,21 @@ from the window where it was initially created."
 
 (declare-function magit-get-current-branch "magit-git" ())
 
+(defun ai-code-backends-infra--sanitize-instance-name (instance-name)
+  "Return INSTANCE-NAME with buffer name delimiters sanitized."
+  (replace-regexp-in-string "]" "-" instance-name t t))
+
 (defun ai-code-backends-infra--branch-instance-name (&optional existing-instance-names)
   "Return the current branch as an instance name, unless already used.
 EXISTING-INSTANCE-NAMES is a list of existing instance names."
-  (let ((branch (ignore-errors (magit-get-current-branch))))
-    (when (and (stringp branch)
-               (not (string-empty-p branch))
-               (not (member branch existing-instance-names)))
-      branch)))
+  (let* ((branch (ignore-errors (magit-get-current-branch)))
+         (instance (and (stringp branch)
+                        (ai-code-backends-infra--sanitize-instance-name
+                         branch))))
+    (when (and instance
+               (not (string-empty-p instance))
+               (not (member instance existing-instance-names)))
+      instance)))
 
 (defun ai-code-backends-infra--default-instance-name (&optional existing-instance-names)
   "Return the default instance name for the current buffer, or nil.

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -28,8 +28,6 @@
 (declare-function ai-code--session-handle-at-input "ai-code-input" ())
 (declare-function ai-code--session-project-root "ai-code-utils" ())
 
-;; DONE: In previous PR: https://github.com/tninja/ai-code-interface.el/pull/349, it set default new AI session instance names from prompt buffer filenames
-;; But now we want to set the default new AI session instance names as current branch name. If this name has been used for an existing session, then we can fallback to using the prompt buffer filename as the default new AI session instance name.
 
 ;;; Customization
 
@@ -687,12 +685,8 @@ EXISTING-INSTANCE-NAMES is a list of existing instance names."
 (defun ai-code-backends-infra--default-instance-name (&optional existing-instance-names)
   "Return the default instance name for the current buffer, or nil.
 When the current git branch is available and not in EXISTING-INSTANCE-NAMES,
-use the branch name.  Otherwise fall back to the prompt buffer filename."
-  (or (ai-code-backends-infra--branch-instance-name existing-instance-names)
-      (when (and (derived-mode-p 'ai-code-prompt-mode)
-                 (stringp buffer-file-name)
-                 (> (length buffer-file-name) 0))
-        (file-name-nondirectory buffer-file-name))))
+use the branch name."
+  (ai-code-backends-infra--branch-instance-name existing-instance-names))
 
 (defun ai-code-backends-infra--file-session-map-key (prefix source-buffer)
   "Return file-session map key for PREFIX and SOURCE-BUFFER."

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -28,7 +28,6 @@
 (declare-function ai-code--session-handle-at-input "ai-code-input" ())
 (declare-function ai-code--session-project-root "ai-code-utils" ())
 
-
 ;;; Customization
 
 (defgroup ai-code-backends-infra nil

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -679,13 +679,17 @@ from the window where it was initially created."
   "Return the default instance name for the current buffer, or nil.
 When the current git branch is available and not in EXISTING-INSTANCE-NAMES,
 use the branch name.  Otherwise fall back to the prompt buffer filename."
-  (when (and (derived-mode-p 'ai-code-prompt-mode)
-             (stringp buffer-file-name)
-             (> (length buffer-file-name) 0))
-    (let ((branch (ignore-errors (magit-get-current-branch))))
-      (if (and branch (not (member branch existing-instance-names)))
-          branch
-        (file-name-nondirectory buffer-file-name)))))
+  (let ((branch (ignore-errors (magit-get-current-branch))))
+    (cond
+     ((and (stringp branch)
+           (not (string-empty-p branch))
+           (not (member branch existing-instance-names)))
+      branch)
+     ((and (derived-mode-p 'ai-code-prompt-mode)
+           (stringp buffer-file-name)
+           (> (length buffer-file-name) 0))
+      (file-name-nondirectory buffer-file-name))
+     (t nil))))
 
 (defun ai-code-backends-infra--file-session-map-key (prefix source-buffer)
   "Return file-session map key for PREFIX and SOURCE-BUFFER."
@@ -960,12 +964,14 @@ DEFAULT-INSTANCE-NAME seeds the minibuffer when prompting."
         (while (or (string= proposed-name "")
                    (member proposed-name existing-instance-names))
           (setq proposed-name
-                (read-string (if existing-instance-names
-                                 (format "Instance name (existing: %s): "
-                                         (mapconcat #'identity existing-instance-names ", "))
-                                "Instance name: ")
-                             nil nil (or (and (> (length proposed-name) 0) proposed-name)
+                (let ((default-input (or (and (> (length proposed-name) 0)
+                                              proposed-name)
                                          default-instance-name)))
+                  (read-string (if existing-instance-names
+                                   (format "Instance name (existing: %s): "
+                                           (mapconcat #'identity existing-instance-names ", "))
+                                  "Instance name: ")
+                               default-input nil default-input)))
           (cond
            ((string= proposed-name "")
             (message "Instance name cannot be empty. Please enter a name.")

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -675,21 +675,24 @@ from the window where it was initially created."
 
 (declare-function magit-get-current-branch "magit-git" ())
 
+(defun ai-code-backends-infra--branch-instance-name (&optional existing-instance-names)
+  "Return the current branch as an instance name, unless already used.
+EXISTING-INSTANCE-NAMES is a list of existing instance names."
+  (let ((branch (ignore-errors (magit-get-current-branch))))
+    (when (and (stringp branch)
+               (not (string-empty-p branch))
+               (not (member branch existing-instance-names)))
+      branch)))
+
 (defun ai-code-backends-infra--default-instance-name (&optional existing-instance-names)
   "Return the default instance name for the current buffer, or nil.
 When the current git branch is available and not in EXISTING-INSTANCE-NAMES,
 use the branch name.  Otherwise fall back to the prompt buffer filename."
-  (let ((branch (ignore-errors (magit-get-current-branch))))
-    (cond
-     ((and (stringp branch)
-           (not (string-empty-p branch))
-           (not (member branch existing-instance-names)))
-      branch)
-     ((and (derived-mode-p 'ai-code-prompt-mode)
-           (stringp buffer-file-name)
-           (> (length buffer-file-name) 0))
-      (file-name-nondirectory buffer-file-name))
-     (t nil))))
+  (or (ai-code-backends-infra--branch-instance-name existing-instance-names)
+      (when (and (derived-mode-p 'ai-code-prompt-mode)
+                 (stringp buffer-file-name)
+                 (> (length buffer-file-name) 0))
+        (file-name-nondirectory buffer-file-name))))
 
 (defun ai-code-backends-infra--file-session-map-key (prefix source-buffer)
   "Return file-session map key for PREFIX and SOURCE-BUFFER."
@@ -957,7 +960,8 @@ Returns the selected buffer or nil if none exist."
                                                          default-instance-name)
   "Prompt for a new instance name.
 EXISTING-INSTANCE-NAMES is a list of existing instance names.
-If FORCE-PROMPT is nil and there are no existing instances, return \"default\".
+If FORCE-PROMPT is nil and there are no existing instances, return the current
+branch name when available; otherwise return \"default\".
 DEFAULT-INSTANCE-NAME seeds the minibuffer when prompting."
   (if (or existing-instance-names force-prompt)
       (let ((proposed-name ""))
@@ -980,7 +984,8 @@ DEFAULT-INSTANCE-NAME seeds the minibuffer when prompting."
             (message "Instance name '%s' already exists. Please choose a different name." proposed-name)
             (sit-for 1))))
         proposed-name)
-    "default"))
+    (or (ai-code-backends-infra--branch-instance-name existing-instance-names)
+        "default")))
 
 (defun ai-code-backends-infra--resolve-start-command (program switches arg &optional prompt-label)
   "Build command string for PROGRAM.

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -112,6 +112,7 @@ Argument _ARG is ignored."
 
 ;;;###autoload
 ;; TODO: this function (and ai-code-cli-resume), when start the >=2nd session for the same repo, it will ask user for the session name. The current code suppose to use the current branch name as session name default value for user to confirm, however it doesn't work. 
+;; TODO: current the first session always use default as name. Can we also use current branch name as default for the first session? If the starting dir is not a git repo, keep using default as session name.
 (defun ai-code-cli-start (&optional arg)
   "Start the current backend's CLI session when supported.
 Argument ARG is passed to the backend's start function."

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -111,8 +111,6 @@ Argument _ARG is ignored."
               (ai-code-current-backend-label)))
 
 ;;;###autoload
-;; TODO: this function (and ai-code-cli-resume), when start the >=2nd session for the same repo, it will ask user for the session name. The current code suppose to use the current branch name as session name default value for user to confirm, however it doesn't work. 
-;; TODO: current the first session always use default as name. Can we also use current branch name as default for the first session? If the starting dir is not a git repo, keep using default as session name.
 (defun ai-code-cli-start (&optional arg)
   "Start the current backend's CLI session when supported.
 Argument ARG is passed to the backend's start function."

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -111,6 +111,7 @@ Argument _ARG is ignored."
               (ai-code-current-backend-label)))
 
 ;;;###autoload
+;; TODO: this function (and ai-code-cli-resume), when start the >=2nd session for the same repo, it will ask user for the session name. The current code suppose to use the current branch name as session name default value for user to confirm, however it doesn't work. 
 (defun ai-code-cli-start (&optional arg)
   "Start the current backend's CLI session when supported.
 Argument ARG is passed to the backend's start function."

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -1579,6 +1579,43 @@ The result is a cons of whether SYMBOL is bound and its default value."
     (should (equal (plist-get context :session-key)
                    (cons working-dir "review-notes.org")))))
 
+(ert-deftest test-ai-code-backends-infra-resolve-session-target-prefills-source-buffer-branch ()
+  "Source buffers should seed new instance names from the current branch."
+  (let* ((working-dir "/tmp/ai-code-session-target/")
+         (prefix "codex")
+         (existing-buffer (get-buffer-create "*codex[ai-code-session-target]*"))
+         seen-initial-input
+         seen-default
+         context)
+    (unwind-protect
+        (with-temp-buffer
+          (setq-local major-mode 'emacs-lisp-mode)
+          (setq-local buffer-file-name "/tmp/project/source.el")
+          (cl-letf (((symbol-function 'ai-code-backends-infra--find-session-buffers)
+                     (lambda (&rest _args)
+                       (list existing-buffer)))
+                    ((symbol-function 'magit-get-current-branch)
+                     (lambda () "feat/source-session"))
+                    ((symbol-function 'read-string)
+                     (lambda (_prompt &optional initial-input _history default-value &rest _args)
+                       (setq seen-initial-input initial-input
+                             seen-default default-value)
+                       initial-input)))
+            (setq context
+                  (ai-code-backends-infra--resolve-session-target
+                   working-dir
+                   nil
+                   prefix
+                   nil
+                   nil))))
+      (when (buffer-live-p existing-buffer)
+        (kill-buffer existing-buffer)))
+    (should (equal seen-initial-input "feat/source-session"))
+    (should (equal seen-default "feat/source-session"))
+    (should (equal (plist-get context :instance-name) "feat/source-session"))
+    (should (equal (plist-get context :buffer-name)
+                   "*codex[ai-code-session-target:feat/source-session]*"))))
+
 (ert-deftest test-ai-code-backends-infra-resolve-session-context-includes-runtime-state ()
   "Resolved session context should include target data plus buffer and process."
   (let* ((working-dir "/tmp/ai-code-session-context/")
@@ -2859,12 +2896,13 @@ The result is a cons of whether SYMBOL is bound and its default value."
       (should (equal (ai-code-backends-infra--default-instance-name)
                      "test.ai.code.prompt.org")))))
 
-(ert-deftest test-ai-code-backends-infra-default-instance-name-nil-outside-prompt-mode ()
-  "Default instance name should be nil outside prompt mode."
+(ert-deftest test-ai-code-backends-infra-default-instance-name-uses-branch-outside-prompt-mode ()
+  "Default instance name should use the branch outside prompt mode."
   (with-temp-buffer
     (cl-letf (((symbol-function 'magit-get-current-branch)
                (lambda () "main")))
-      (should-not (ai-code-backends-infra--default-instance-name)))))
+      (should (equal (ai-code-backends-infra--default-instance-name)
+                     "main")))))
 
 ;;; --- session-working-directory delegation tests ---
 

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -1647,6 +1647,33 @@ The result is a cons of whether SYMBOL is bound and its default value."
     (should (equal (plist-get context :session-key)
                    (cons working-dir "feat/first-session")))))
 
+(ert-deftest test-ai-code-backends-infra-resolve-session-target-sanitizes-branch-name ()
+  "Branch-derived instance names should keep session buffer names parseable."
+  (let* ((working-dir "/tmp/ai-code-session-target/")
+         (prefix "codex")
+         context)
+    (with-temp-buffer
+      (setq-local major-mode 'emacs-lisp-mode)
+      (setq-local buffer-file-name "/tmp/project/source.el")
+      (cl-letf (((symbol-function 'ai-code-backends-infra--find-session-buffers)
+                 (lambda (&rest _args) nil))
+                ((symbol-function 'magit-get-current-branch)
+                 (lambda () "feat/foo]bar")))
+        (setq context
+              (ai-code-backends-infra--resolve-session-target
+               working-dir
+               nil
+               prefix
+               nil
+               nil))))
+    (should (equal (plist-get context :instance-name) "feat/foo-bar"))
+    (should (equal (plist-get context :buffer-name)
+                   "*codex[ai-code-session-target:feat/foo-bar]*"))
+    (should (equal (ai-code-backends-infra--session-instance-name
+                    (plist-get context :buffer-name)
+                    prefix)
+                   "feat/foo-bar"))))
+
 (ert-deftest test-ai-code-backends-infra-resolve-session-target-first-session-defaults-outside-git ()
   "First session should keep the default instance name without a branch."
   (let* ((working-dir "/tmp/ai-code-session-target/")
@@ -2960,6 +2987,14 @@ The result is a cons of whether SYMBOL is bound and its default value."
                (lambda () "main")))
       (should (equal (ai-code-backends-infra--default-instance-name)
                      "main")))))
+
+(ert-deftest test-ai-code-backends-infra-default-instance-name-sanitizes-branch ()
+  "Default instance name should sanitize branch delimiters."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'magit-get-current-branch)
+               (lambda () "main]work")))
+      (should (equal (ai-code-backends-infra--default-instance-name)
+                     "main-work")))))
 
 ;;; --- session-working-directory delegation tests ---
 

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -1616,6 +1616,62 @@ The result is a cons of whether SYMBOL is bound and its default value."
     (should (equal (plist-get context :buffer-name)
                    "*codex[ai-code-session-target:feat/source-session]*"))))
 
+(ert-deftest test-ai-code-backends-infra-resolve-session-target-first-session-uses-branch ()
+  "First session should use the current branch as its instance name."
+  (let* ((working-dir "/tmp/ai-code-session-target/")
+         (prefix "codex")
+         context)
+    (with-temp-buffer
+      (setq-local major-mode 'emacs-lisp-mode)
+      (setq-local buffer-file-name "/tmp/project/source.el")
+      (cl-letf (((symbol-function 'ai-code-backends-infra--find-session-buffers)
+                 (lambda (&rest _args) nil))
+                ((symbol-function 'magit-get-current-branch)
+                 (lambda () "feat/first-session"))
+                ((symbol-function 'read-string)
+                 (lambda (&rest _args)
+                   (ert-fail "First session should not prompt for an instance name."))))
+        (setq context
+              (ai-code-backends-infra--resolve-session-target
+               working-dir
+               nil
+               prefix
+               nil
+               nil))))
+    (should (equal (plist-get context :instance-name) "feat/first-session"))
+    (should (equal (plist-get context :buffer-name)
+                   "*codex[ai-code-session-target:feat/first-session]*"))
+    (should (equal (plist-get context :session-key)
+                   (cons working-dir "feat/first-session")))))
+
+(ert-deftest test-ai-code-backends-infra-resolve-session-target-first-session-defaults-outside-git ()
+  "First session should keep the default instance name without a branch."
+  (let* ((working-dir "/tmp/ai-code-session-target/")
+         (prefix "codex")
+         context)
+    (with-temp-buffer
+      (setq-local major-mode 'ai-code-prompt-mode)
+      (setq-local buffer-file-name "/tmp/project/.ai.code.files/review-notes.org")
+      (cl-letf (((symbol-function 'ai-code-backends-infra--find-session-buffers)
+                 (lambda (&rest _args) nil))
+                ((symbol-function 'magit-get-current-branch)
+                 (lambda () nil))
+                ((symbol-function 'read-string)
+                 (lambda (&rest _args)
+                   (ert-fail "First session should not prompt for an instance name."))))
+        (setq context
+              (ai-code-backends-infra--resolve-session-target
+               working-dir
+               nil
+               prefix
+               nil
+               nil))))
+    (should (equal (plist-get context :instance-name) "default"))
+    (should (equal (plist-get context :buffer-name)
+                   "*codex[ai-code-session-target]*"))
+    (should (equal (plist-get context :session-key)
+                   (cons working-dir "default")))))
+
 (ert-deftest test-ai-code-backends-infra-resolve-session-context-includes-runtime-state ()
   "Resolved session context should include target data plus buffer and process."
   (let* ((working-dir "/tmp/ai-code-session-context/")

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -1540,12 +1540,13 @@ The result is a cons of whether SYMBOL is bound and its default value."
                      (cons working-dir "review")))
       (should-not prompt-called))))
 
-(ert-deftest test-ai-code-backends-infra-resolve-session-target-prefills-prompt-buffer-filename ()
-  "Prompt-mode buffers should seed new instance names from the file name."
+(ert-deftest test-ai-code-backends-infra-resolve-session-target-does-not-prefill-prompt-buffer-filename ()
+  "Prompt-mode buffers should not seed new instance names from the file name."
   (let* ((working-dir "/tmp/ai-code-session-target/")
          (prefix "codex")
          (existing-buffer (get-buffer-create "*codex[ai-code-session-target]*"))
          seen-prompt
+         seen-initial-input
          seen-default
          context)
     (unwind-protect
@@ -1558,10 +1559,11 @@ The result is a cons of whether SYMBOL is bound and its default value."
                     ((symbol-function 'magit-get-current-branch)
                      (lambda () nil))
                     ((symbol-function 'read-string)
-                     (lambda (prompt &optional _initial-input _history default-value &rest _args)
+                     (lambda (prompt &optional initial-input _history default-value &rest _args)
                        (setq seen-prompt prompt
+                             seen-initial-input initial-input
                              seen-default default-value)
-                       default-value)))
+                       "manual-session")))
             (setq context
                   (ai-code-backends-infra--resolve-session-target
                    working-dir
@@ -1572,12 +1574,13 @@ The result is a cons of whether SYMBOL is bound and its default value."
       (when (buffer-live-p existing-buffer)
         (kill-buffer existing-buffer)))
     (should (equal seen-prompt "Instance name (existing: default): "))
-    (should (equal seen-default "review-notes.org"))
-    (should (equal (plist-get context :instance-name) "review-notes.org"))
+    (should-not seen-initial-input)
+    (should-not seen-default)
+    (should (equal (plist-get context :instance-name) "manual-session"))
     (should (equal (plist-get context :buffer-name)
-                   "*codex[ai-code-session-target:review-notes.org]*"))
+                   "*codex[ai-code-session-target:manual-session]*"))
     (should (equal (plist-get context :session-key)
-                   (cons working-dir "review-notes.org")))))
+                   (cons working-dir "manual-session")))))
 
 (ert-deftest test-ai-code-backends-infra-resolve-session-target-prefills-source-buffer-branch ()
   "Source buffers should seed new instance names from the current branch."
@@ -2931,26 +2934,24 @@ The result is a cons of whether SYMBOL is bound and its default value."
       (should (equal (ai-code-backends-infra--default-instance-name)
                      "feat/login-page")))))
 
-(ert-deftest test-ai-code-backends-infra-default-instance-name-falls-back-to-filename-when-branch-taken ()
-  "Default instance name should fall back to filename when branch is already in use."
+(ert-deftest test-ai-code-backends-infra-default-instance-name-nil-when-branch-taken ()
+  "Default instance name should be nil when the branch is already in use."
   (with-temp-buffer
     (setq-local major-mode 'ai-code-prompt-mode)
     (setq-local buffer-file-name "/tmp/test.ai.code.prompt.org")
     (cl-letf (((symbol-function 'magit-get-current-branch)
                (lambda () "feat/login-page")))
-      (should (equal (ai-code-backends-infra--default-instance-name
-                      '("feat/login-page"))
-                     "test.ai.code.prompt.org")))))
+      (should-not (ai-code-backends-infra--default-instance-name
+                   '("feat/login-page"))))))
 
-(ert-deftest test-ai-code-backends-infra-default-instance-name-falls-back-to-filename-without-branch ()
-  "Default instance name should fall back to filename when branch is unavailable."
+(ert-deftest test-ai-code-backends-infra-default-instance-name-nil-without-branch ()
+  "Default instance name should be nil when branch is unavailable."
   (with-temp-buffer
     (setq-local major-mode 'ai-code-prompt-mode)
     (setq-local buffer-file-name "/tmp/test.ai.code.prompt.org")
     (cl-letf (((symbol-function 'magit-get-current-branch)
                (lambda () nil)))
-      (should (equal (ai-code-backends-infra--default-instance-name)
-                     "test.ai.code.prompt.org")))))
+      (should-not (ai-code-backends-infra--default-instance-name)))))
 
 (ert-deftest test-ai-code-backends-infra-default-instance-name-uses-branch-outside-prompt-mode ()
   "Default instance name should use the branch outside prompt mode."


### PR DESCRIPTION
Summary:
This updates AI CLI session naming so new sessions use the current Git branch as the default instance name when one is available, while still falling back to `default` outside a Git repo.

What changed:
- First sessions in a Git repo now use the current branch name instead of always using `default`.
- Additional sessions prefill the branch name for confirmation/editing.
- The old prompt/task org filename fallback was removed so prompt-mode files no longer become implicit session names.

Verification:
- `emacs -batch -L test/stubs -L . -l ert -l test/test_ai-code-backends-infra.el --eval "(load-file \"ai-code-backends-infra.el\")" -f ert-run-tests-batch-and-exit` (109/109 passed)
- `emacs -batch -L test/stubs -L . -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit` (875 tests, 862 passed, 13 skipped, 0 unexpected)
- `checkdoc-file` on touched files (clean)
- `batch-byte-compile` on touched files (exit 0; existing `ai-code-selected-backend` free-variable warnings remain)