### PR TITLE
fix: keep terminal multiline bindings buffer-local

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -492,15 +492,27 @@ Constructs function name as `ai-code-backends-infra-<backend>-<operation>'."
   (ai-code-backends-infra--terminal-send-string
    ai-code-backends-infra--multiline-input-sequence))
 
+(defun ai-code-backends-infra--ensure-buffer-local-keymap ()
+  "Use a buffer-local copy of the current local keymap."
+  (use-local-map (copy-keymap (or (current-local-map)
+                                  (make-sparse-keymap))))
+  (current-local-map))
+
 (defun ai-code-backends-infra--configure-multiline-input (sequence)
   "Configure multiline input keybindings in the current session buffer.
 SEQUENCE is the terminal sequence sent for `S-<return>' and `C-<return>'."
-  (when sequence
-    (setq-local ai-code-backends-infra--multiline-input-sequence sequence)
-    (local-set-key (kbd "S-<return>")
-                   #'ai-code-backends-infra--terminal-send-multiline-input)
-    (local-set-key (kbd "C-<return>")
-                   #'ai-code-backends-infra--terminal-send-multiline-input)))
+  (if sequence
+      (progn
+        (setq-local ai-code-backends-infra--multiline-input-sequence sequence)
+        (define-key (current-local-map) (kbd "S-<return>")
+                    #'ai-code-backends-infra--terminal-send-multiline-input)
+        (define-key (current-local-map) (kbd "C-<return>")
+                    #'ai-code-backends-infra--terminal-send-multiline-input))
+    (setq-local ai-code-backends-infra--multiline-input-sequence nil)
+    (dolist (key (list (kbd "S-<return>") (kbd "C-<return>")))
+      (when (eq (lookup-key (current-local-map) key)
+                #'ai-code-backends-infra--terminal-send-multiline-input)
+        (define-key (current-local-map) key nil)))))
 
 (defun ai-code-backends-infra--configure-session-buffer (buffer
                                                          &optional escape-fn
@@ -509,8 +521,9 @@ SEQUENCE is the terminal sequence sent for `S-<return>' and `C-<return>'."
 ESCAPE-FN is bound to `C-<escape>' when non-nil.
 MULTILINE-INPUT-SEQUENCE configures `S-<return>' and `C-<return>' when non-nil."
   (with-current-buffer buffer
+    (ai-code-backends-infra--ensure-buffer-local-keymap)
     (when escape-fn
-      (local-set-key (kbd "C-<escape>") escape-fn))
+      (define-key (current-local-map) (kbd "C-<escape>") escape-fn))
     (ai-code-backends-infra--configure-multiline-input
      multiline-input-sequence)
     (ai-code-session-link--linkify-session-region (point-min) (point-max))))

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -2465,6 +2465,44 @@ The result is a cons of whether SYMBOL is bound and its default value."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ai-code-backends-infra-configure-session-buffer-keeps-multiline-local ()
+  "Multiline keybindings should not leak through shared mode maps."
+  (let ((shared-map (make-sparse-keymap))
+        (configured (generate-new-buffer " *ai-code-configured*"))
+        (unconfigured (generate-new-buffer " *ai-code-unconfigured*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-session-link--linkify-session-region)
+                   (lambda (&rest _args) nil)))
+          (with-current-buffer configured
+            (use-local-map shared-map))
+          (with-current-buffer unconfigured
+            (use-local-map shared-map))
+          (ai-code-backends-infra--configure-session-buffer
+           configured nil "\\\r\n")
+          (with-current-buffer configured
+            (should (eq (lookup-key (current-local-map) (kbd "S-<return>"))
+                        #'ai-code-backends-infra--terminal-send-multiline-input))
+            (should (equal ai-code-backends-infra--multiline-input-sequence
+                           "\\\r\n")))
+          (should-not (lookup-key shared-map (kbd "S-<return>")))
+          (with-current-buffer unconfigured
+            (should-not (lookup-key (current-local-map) (kbd "S-<return>"))))
+          (define-key shared-map (kbd "S-<return>")
+                      #'ai-code-backends-infra--terminal-send-multiline-input)
+          (with-current-buffer unconfigured
+            (use-local-map shared-map))
+          (ai-code-backends-infra--configure-session-buffer
+           unconfigured nil nil)
+          (with-current-buffer unconfigured
+            (should-not ai-code-backends-infra--multiline-input-sequence)
+            (should-not (lookup-key (current-local-map) (kbd "S-<return>"))))
+          (should (eq (lookup-key shared-map (kbd "S-<return>"))
+                      #'ai-code-backends-infra--terminal-send-multiline-input)))
+      (when (buffer-live-p configured)
+        (kill-buffer configured))
+      (when (buffer-live-p unconfigured)
+        (kill-buffer unconfigured)))))
+
 (ert-deftest test-ai-code-backends-infra-toggle-or-create-session-calls-post-start-hook ()
   "POST-START-FN should receive the created buffer, process, and instance."
   (let* ((working-dir "/tmp/ai-code-post-start/")


### PR DESCRIPTION
## Problem

`ai-code-backends-infra--configure-session-buffer` used `local-set-key`, which mutates the buffer's local keymap. Terminal buffers (eat/vterm) share their major-mode keymap as the local map, so binding `S-<return>` / `C-<return>` / `C-<escape>` in one session buffer leaked those bindings into every other buffer of the same mode.

## Fix

- Install a buffer-local `copy-keymap` of the current local map before defining any keys, so bindings stay confined to the session buffer.
- When no multiline sequence is configured, remove stale multiline bindings instead of leaving them around.

## Tests

Added an ERT test verifying that configuring one buffer does not leak the multiline bindings into another buffer sharing the same mode map, and that the unconfigured buffer keeps its original bindings.