### PR TITLE
Chore: Add context levels to Emacs runtime debug prompts

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Chore: Add context levels to Emacs runtime debug prompts
 - Fix: keep terminal multiline bindings buffer-local, by Silex
 - Fix: Use Git branch names for AI session defaults
   

--- a/ai-code.el
+++ b/ai-code.el
@@ -95,6 +95,7 @@
 (require 'magit)
 (require 'transient)
 (require 'seq)
+(require 'subr-x)
 
 (defgroup ai-code nil
   "Unified interface for multiple AI coding CLIs."
@@ -258,35 +259,82 @@ ARG is the prefix argument."
     (ai-code--insert-prompt prompt)))
 
 (defun ai-code--emacs-runtime-debug-prompt (description eval-available-p
-                                                       &optional region-text region-location-info)
+                                                       &optional region-text
+                                                       region-location-info
+                                                       buffer-scope
+                                                       function-name
+                                                       files-context-string
+                                                       repo-context-string
+                                                       clipboard-context)
   "Return an Emacs runtime debugging prompt from DESCRIPTION.
 EVAL-AVAILABLE-P reports whether `eval_elisp' is globally enabled.
-Optional REGION-TEXT and REGION-LOCATION-INFO add selected-region context."
-  (format
-   "Use the Emacs MCP tools available in this session to debug my Emacs runtime.\n\
+Optional REGION-TEXT and REGION-LOCATION-INFO add selected-region context.
+BUFFER-SCOPE, FUNCTION-NAME, FILES-CONTEXT-STRING, REPO-CONTEXT-STRING,
+and CLIPBOARD-CONTEXT add broader debugging context."
+  (let ((scope-string
+         (ai-code--emacs-runtime-debug-scope-string
+          buffer-scope function-name files-context-string))
+        (context-string
+         (ai-code--emacs-runtime-debug-context-string
+          repo-context-string clipboard-context)))
+    (format
+     "Use the Emacs MCP tools available in this session to debug my Emacs runtime.\n\
 The issue may involve an interactive function or a key binding.\n\
 %s\n\n\
 Inspect the relevant runtime state first: keymaps, command metadata,\n\
 variables, recent messages, load state, and the last backtrace when useful.\n\
 Explain what you find, then recommend the smallest fix or next step.\n\n\
 Runtime issue description:\n\
-%s%s"
-   (if eval-available-p
-       "eval_elisp is enabled in your Emacs MCP config."
-     "eval_elisp is disabled in your Emacs MCP config, so rely on non-eval inspection tools unless you first enable ai-code-mcp-debug-tools-enable-eval-elisp.")
-   description
-   (if region-text
-       (concat
-        "\n\nSelected region:\n"
-        (when region-location-info
-          (concat region-location-info "\n"))
-        region-text)
-     "")))
+%s%s%s%s"
+     (if eval-available-p
+         "eval_elisp is enabled in your Emacs MCP config."
+       "eval_elisp is disabled in your Emacs MCP config, so rely on non-eval inspection tools unless you first enable ai-code-mcp-debug-tools-enable-eval-elisp.")
+     description
+     (if (string-empty-p scope-string)
+         ""
+       (concat "\n\nScope:\n" scope-string))
+     (if region-text
+         (concat
+          "\n\nSelected region:\n"
+          (when region-location-info
+            (concat region-location-info "\n"))
+          region-text)
+       "")
+     (if (string-empty-p context-string)
+         ""
+       (concat "\n\nContext:\n" context-string)))))
+
+(defun ai-code--emacs-runtime-debug-scope-string (buffer-scope function-name
+                                                              files-context-string)
+  "Return scope text for one Emacs runtime debug prompt.
+BUFFER-SCOPE describes the current file or buffer.  FUNCTION-NAME and
+FILES-CONTEXT-STRING are optional additional scope levels."
+  (string-trim
+   (concat
+    (or buffer-scope "")
+    (when function-name
+      (format "\nFunction: %s" function-name))
+    (or files-context-string ""))))
+
+(defun ai-code--emacs-runtime-debug-context-string (repo-context-string
+                                                    clipboard-context)
+  "Return context text for one Emacs runtime debug prompt.
+REPO-CONTEXT-STRING is stored repository context.  CLIPBOARD-CONTEXT is
+optional runtime/debugging text from the clipboard."
+  (string-trim
+   (concat
+    (or repo-context-string "")
+    (when (and repo-context-string
+               clipboard-context)
+      "\n\n")
+    (when clipboard-context
+      (concat "Clipboard context:\n" clipboard-context)))))
 
 ;;;###autoload
 (defun ai-code-debug-emacs-runtime ()
   "Assemble and send an Emacs runtime debugging prompt for the current AI session."
   (interactive)
+  ;; DONE: similar to ai-code-investigate-exception, this function should support multiple level of context: file, function, selected region, clipboard, etc
   (unless (bound-and-true-p ai-code-mcp-debug-tools-enabled)
     (user-error
      "Enable ai-code-mcp-debug-tools-enabled before using Emacs runtime debugging"))
@@ -299,6 +347,17 @@ Runtime issue description:\n\
                                  (ai-code--get-region-location-info
                                   (region-beginning)
                                   (region-end))))
+         (buffer-scope (if buffer-file-name
+                           (format "Current file: %s" buffer-file-name)
+                         (format "Current buffer: %s" (buffer-name))))
+         (function-name (which-function))
+         (files-context-string (ai-code--get-context-files-string))
+         (repo-context-string (ai-code--format-repo-context-info))
+         (clipboard-context (when current-prefix-arg
+                              (let ((text (ai-code--get-clipboard-text)))
+                                (when (and text
+                                           (string-match-p "\\S-" text))
+                                  text))))
          (eval-available-p
           (bound-and-true-p ai-code-mcp-debug-tools-enable-eval-elisp)))
     (if eval-available-p
@@ -313,7 +372,12 @@ Runtime issue description:\n\
         description
         eval-available-p
         region-text
-        region-location-info)))))
+        region-location-info
+        buffer-scope
+        function-name
+        files-context-string
+        repo-context-string
+        clipboard-context)))))
 
 ;;;###autoload
 (defun ai-code-cli-switch-to-buffer-or-hide ()

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -209,6 +209,66 @@
              (cadr confirm-read-args)))
     (should (equal sent-prompt (cadr confirm-read-args)))))
 
+(ert-deftest ai-code-test-debug-emacs-runtime-includes-context-levels ()
+  "Debug Emacs runtime should include file, function, region, clipboard, and stored context."
+  (let ((ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-debug-tools-enable-eval-elisp t)
+        (current-prefix-arg '(4))
+        confirm-read-args
+        sent-prompt)
+    (cl-letf (((symbol-function 'message)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'use-region-p)
+               (lambda () t))
+              ((symbol-function 'region-beginning)
+               (lambda () 10))
+              ((symbol-function 'region-end)
+               (lambda () 42))
+              ((symbol-function 'buffer-substring-no-properties)
+               (lambda (_beg _end)
+                 "(define-key test-map (kbd \"C-c x\") #'broken-command)"))
+              ((symbol-function 'ai-code--get-region-location-info)
+               (lambda (_beg _end)
+                 "ai-code.el#L10-L11"))
+              ((symbol-function 'which-function)
+               (lambda () "ai-code-test-command"))
+              ((symbol-function 'ai-code--get-context-files-string)
+               (lambda () "\nFiles:\n/tmp/project/ai-code.el\n/tmp/project/ai-code-discussion.el"))
+              ((symbol-function 'ai-code--format-repo-context-info)
+               (lambda () "\nStored repository context:\n  - ai-code.el#ai-code-test-command"))
+              ((symbol-function 'ai-code--get-clipboard-text)
+               (lambda () "Debugger entered--Lisp error: (void-function broken-command)"))
+              ((symbol-function 'ai-code-read-string)
+               (lambda (prompt &optional initial-input _candidate-list)
+                 (cond
+                  ((string-match-p "Describe the Emacs runtime issue" prompt)
+                   "C-c x fails at runtime")
+                  ((string-match-p "Confirm and edit Emacs runtime debug prompt" prompt)
+                   (setq confirm-read-args (list prompt initial-input))
+                   initial-input)
+                  (t
+                   (ert-fail (format "Unexpected prompt: %s" prompt))))))
+              ((symbol-function 'ai-code--insert-prompt)
+               (lambda (prompt)
+                 (setq sent-prompt prompt))))
+      (with-temp-buffer
+        (setq buffer-file-name "/tmp/project/ai-code.el")
+        (ai-code-debug-emacs-runtime)))
+    (should (string-match-p "Current file: /tmp/project/ai-code\\.el"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Function: ai-code-test-command"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Selected region:" (cadr confirm-read-args)))
+    (should (string-match-p "ai-code.el#L10-L11" (cadr confirm-read-args)))
+    (should (string-match-p "Clipboard context:" (cadr confirm-read-args)))
+    (should (string-match-p "void-function broken-command"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Files:\n/tmp/project/ai-code\\.el\n/tmp/project/ai-code-discussion\\.el"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Stored repository context:"
+                            (cadr confirm-read-args)))
+    (should (equal sent-prompt (cadr confirm-read-args)))))
+
 (ert-deftest ai-code-test-debug-emacs-runtime-removes-stale-done-comment ()
   "The source should not keep the stale DONE note for the runtime debug menu item."
   (with-temp-buffer


### PR DESCRIPTION
## Summary
Add richer context assembly to `ai-code-debug-emacs-runtime` so Emacs runtime debugging prompts include the current file or buffer, function, selected region, visible file context, stored repo context, and optional clipboard diagnostics via prefix argument.

## Approach
The prompt builder now formats explicit scope and context sections while preserving the existing eval availability guidance and selected-region behavior. The runtime command collects the same kinds of context used by nearby investigation workflows, and the TODO was marked DONE in place after implementation.

## Verification
Validated with focused runtime-debug ERT coverage, the full `test/test_ai-code.el` suite, full project ERT, `checkdoc-file` on touched files, and batch byte compilation of the top-level Emacs Lisp files.