### PR TITLE
Fix Helm prompt special character input

### DIFF
--- a/ai-code-input.el
+++ b/ai-code-input.el
@@ -19,7 +19,8 @@
 (require 'subr-x)
 
 (declare-function browse-url "browse-url" (url &optional new-window))
-(declare-function helm-comp-read "helm-mode" (prompt collection &rest args))
+(declare-function helm-read-string "helm-core" (prompt &optional initial-input history
+                                                       default-value inherit-input-method))
 (declare-function ai-code-backends-infra--session-buffer-p "ai-code-backends-infra" (buffer))
 (declare-function ai-code-backends-infra--linkify-session-region "ai-code-backends-infra" (start end))
 (declare-function ai-code-backends-infra--terminal-send-string "ai-code-backends-infra" (string))
@@ -50,6 +51,9 @@ Uses `read-string' directly to avoid `helm-mode' intercepting `completing-read'.
 (defvar ai-code--read-string-fn #'ai-code-plain-read-string
   "Function used by `ai-code-read-string' to read user input.")
 
+(defvar ai-code-helm-read-string--history nil
+  "Minibuffer history used by `ai-code-helm-read-string-with-history'.")
+
 ;;;###autoload
 (defun ai-code-read-string (prompt &optional initial-input candidate-list)
   "Read a string from the user with PROMPT and optional INITIAL-INPUT.
@@ -63,11 +67,15 @@ Returns non-nil on successful send."
     (ai-code--insert-prompt prompt)))
 
 (defun ai-code-helm-read-string-with-history (prompt history-file-name &optional initial-input candidate-list)
-  "Read a string with Helm completion using specified history file.
+  "Read a string with Helm history using specified history file.
 PROMPT is the prompt string.
 HISTORY-FILE-NAME is the base name for history file.
 INITIAL-INPUT is optional initial input string.
-CANDIDATE-LIST is an optional list of candidate strings to show before history."
+CANDIDATE-LIST is an optional list of strings to add to minibuffer history.
+
+Read free-form input with a literal string reader instead of
+`helm-comp-read', because Helm completion patterns treat characters
+such as `!', spaces, and backslashes as matching syntax."
   ;; Load history from file
   (let* ((helm-history-file (expand-file-name history-file-name user-emacs-directory))
          (helm-history (if (file-exists-p helm-history-file)
@@ -79,41 +87,26 @@ CANDIDATE-LIST is an optional list of candidate strings to show before history."
                                      (read content))))
                              (error nil))
                          '()))
-         ;; Use only Helm history, no CLI history
          (history helm-history)
-         ;; Extract the most recent item from history (if exists)
-         (most-recent (when history
-                        (car history)))
-         ;; Remove the first item to add it back later
-         (rest-history (when history
-                         (cl-remove-duplicates (cdr history) :test #'equal)))
-         ;; Combine completion list: most recent + candidates + separator + rest of history
-         (completion-list
-          (append
-           ;; If most recent item exists, put it at the top
-           (when most-recent
-             (list most-recent))
-           ;; Add candidate list
-           (or candidate-list '())
-           ;; Add separator and rest of history
-           (when rest-history
-             (cons "==================== HISTORY ========================================" rest-history))))
-         ;; Read input with helm
-         (input (helm-comp-read
-                 prompt
-                 completion-list
-                 :must-match nil
-                 :name "Helm Read String, Use C-c C-y to edit selected command. C-b and C-f to move cursor during editing"
-                 :fuzzy nil
-                 :initial-input initial-input)))
+         (ai-code-helm-read-string--history
+          (cl-remove-duplicates
+           (append history (or candidate-list '()))
+           :test #'equal))
+         (input (if (fboundp 'helm-read-string)
+                    (helm-read-string prompt initial-input
+                                      'ai-code-helm-read-string--history)
+                  (read-string prompt initial-input
+                               'ai-code-helm-read-string--history))))
     ;; Add to history if non-empty, single-line and save
-    (unless (or (string-empty-p input) (string-match "\n" input))
+    (unless (or (not (stringp input))
+                (string-empty-p input)
+                (string-match "\n" input))
       (push input history)
-      ;; (setq history (mapcar #'substring-no-properties history))
       (with-temp-file helm-history-file ; Save to the Helm-specific history file
-        (let ((history-entries (cl-subseq history
-                                          0 (min (length history)
-                                                 1000))))  ; Keep last 1000 entries
+        (let* ((deduped-history (cl-remove-duplicates history :test #'equal))
+               (history-entries (cl-subseq deduped-history
+                                           0 (min (length deduped-history)
+                                                  1000))))  ; Keep last 1000 entries
           (insert (let ((print-circle nil))
                     (prin1-to-string history-entries))))))
     input))

--- a/ai-code-input.el
+++ b/ai-code-input.el
@@ -19,6 +19,7 @@
 (require 'subr-x)
 
 (declare-function browse-url "browse-url" (url &optional new-window))
+(declare-function helm-comp-read "helm-mode" (prompt collection &rest args))
 (declare-function helm-read-string "helm-core" (prompt &optional initial-input history
                                                        default-value inherit-input-method))
 (declare-function ai-code-backends-infra--session-buffer-p "ai-code-backends-infra" (buffer))
@@ -54,6 +55,9 @@ Uses `read-string' directly to avoid `helm-mode' intercepting `completing-read'.
 (defvar ai-code-helm-read-string--history nil
   "Minibuffer history used by `ai-code-helm-read-string-with-history'.")
 
+(defconst ai-code-helm-read-string--new-prompt-candidate "[New prompt]"
+  "Candidate used to skip history selection and write a new prompt.")
+
 ;;;###autoload
 (defun ai-code-read-string (prompt &optional initial-input candidate-list)
   "Read a string from the user with PROMPT and optional INITIAL-INPUT.
@@ -71,11 +75,12 @@ Returns non-nil on successful send."
 PROMPT is the prompt string.
 HISTORY-FILE-NAME is the base name for history file.
 INITIAL-INPUT is optional initial input string.
-CANDIDATE-LIST is an optional list of strings to add to minibuffer history.
+CANDIDATE-LIST is an optional list of strings to show before history.
 
-Read free-form input with a literal string reader instead of
-`helm-comp-read', because Helm completion patterns treat characters
-such as `!', spaces, and backslashes as matching syntax."
+Use Helm completion only to choose a history or candidate entry, then
+read the final free-form prompt with a literal string reader.  This
+keeps history navigation while preventing Helm completion patterns from
+interpreting prompt characters such as `!', spaces, and backslashes."
   ;; Load history from file
   (let* ((helm-history-file (expand-file-name history-file-name user-emacs-directory))
          (helm-history (if (file-exists-p helm-history-file)
@@ -88,14 +93,30 @@ such as `!', spaces, and backslashes as matching syntax."
                              (error nil))
                          '()))
          (history helm-history)
-         (ai-code-helm-read-string--history
+         (completion-list
           (cl-remove-duplicates
-           (append history (or candidate-list '()))
+           (append (or candidate-list '()) history)
            :test #'equal))
+         (history-choice
+          (when (and completion-list (fboundp 'helm-comp-read))
+            (helm-comp-read
+             "Prompt history: "
+             (cons ai-code-helm-read-string--new-prompt-candidate
+                   completion-list)
+             :must-match t
+             :name "Helm Prompt History"
+             :fuzzy nil)))
+         (initial-edit
+          (if (or (null history-choice)
+                  (string= history-choice
+                           ai-code-helm-read-string--new-prompt-candidate))
+              initial-input
+            history-choice))
+         (ai-code-helm-read-string--history completion-list)
          (input (if (fboundp 'helm-read-string)
-                    (helm-read-string prompt initial-input
+                    (helm-read-string prompt initial-edit
                                       'ai-code-helm-read-string--history)
-                  (read-string prompt initial-input
+                  (read-string prompt initial-edit
                                'ai-code-helm-read-string--history))))
     ;; Add to history if non-empty, single-line and save
     (unless (or (not (stringp input))

--- a/test/test_ai-code-input.el
+++ b/test/test_ai-code-input.el
@@ -16,32 +16,43 @@
 
 ;;; Tests for ai-code--comment-context-p
 
-(ert-deftest ai-code-test-helm-read-string-keeps-special-pattern-characters-literal ()
-  "Helm prompt reading should keep pattern-like characters literal."
+(ert-deftest ai-code-test-helm-read-string-completes-history-then-edits-literally ()
+  "Helm prompt reading should complete history before literal editing."
   (let* ((user-emacs-directory (file-name-as-directory
                                 (make-temp-file "ai-code-helm-history-" t)))
          (history-file-name "history.el")
+         (history-prompt "Previous prompt with ! & special characters")
          (literal-prompt "Explain why ! & ^ $ ? [abc] (x) foo\\ bar should stay literal.")
+         (helm-comp-read-called nil)
          (helm-read-called nil))
     (unwind-protect
-        (cl-letf (((symbol-function 'helm-comp-read)
-                   (lambda (&rest _args)
-                     (ert-fail "Free-form prompt input should not use `helm-comp-read' pattern matching.")))
-                  ((symbol-function 'helm-read-string)
-                   (lambda (prompt initial-input history &rest _args)
-                     (setq helm-read-called t)
-                     (should (equal prompt "Prompt: "))
-                     (should (equal initial-input ""))
-                     (should (eq history 'ai-code-helm-read-string--history))
-                     literal-prompt)))
-          (should (equal (ai-code-helm-read-string-with-history
-                          "Prompt: " history-file-name "" '("Use ! in candidate"))
-                         literal-prompt))
-          (should helm-read-called)
-          (with-temp-buffer
-            (insert-file-contents
-             (expand-file-name history-file-name user-emacs-directory))
-            (should (equal (read (current-buffer)) (list literal-prompt)))))
+        (progn
+          (with-temp-file (expand-file-name history-file-name user-emacs-directory)
+            (prin1 (list history-prompt) (current-buffer)))
+          (cl-letf (((symbol-function 'helm-comp-read)
+                     (lambda (prompt collection &rest args)
+                       (setq helm-comp-read-called t)
+                       (should (equal prompt "Prompt history: "))
+                       (should (member history-prompt collection))
+                       (should (plist-get args :must-match))
+                       history-prompt))
+                    ((symbol-function 'helm-read-string)
+                     (lambda (prompt initial-input history &rest _args)
+                       (setq helm-read-called t)
+                       (should (equal prompt "Prompt: "))
+                       (should (equal initial-input history-prompt))
+                       (should (eq history 'ai-code-helm-read-string--history))
+                       literal-prompt)))
+            (should (equal (ai-code-helm-read-string-with-history
+                            "Prompt: " history-file-name "" '("Use ! in candidate"))
+                           literal-prompt))
+            (should helm-comp-read-called)
+            (should helm-read-called)
+            (with-temp-buffer
+              (insert-file-contents
+               (expand-file-name history-file-name user-emacs-directory))
+              (should (equal (read (current-buffer))
+                             (list literal-prompt history-prompt))))))
       (delete-directory user-emacs-directory t))))
 
 (ert-deftest ai-code-test-comment-context-p-inside-line-comment ()

--- a/test/test_ai-code-input.el
+++ b/test/test_ai-code-input.el
@@ -16,6 +16,34 @@
 
 ;;; Tests for ai-code--comment-context-p
 
+(ert-deftest ai-code-test-helm-read-string-keeps-special-pattern-characters-literal ()
+  "Helm prompt reading should keep pattern-like characters literal."
+  (let* ((user-emacs-directory (file-name-as-directory
+                                (make-temp-file "ai-code-helm-history-" t)))
+         (history-file-name "history.el")
+         (literal-prompt "Explain why ! & ^ $ ? [abc] (x) foo\\ bar should stay literal.")
+         (helm-read-called nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'helm-comp-read)
+                   (lambda (&rest _args)
+                     (ert-fail "Free-form prompt input should not use `helm-comp-read' pattern matching.")))
+                  ((symbol-function 'helm-read-string)
+                   (lambda (prompt initial-input history &rest _args)
+                     (setq helm-read-called t)
+                     (should (equal prompt "Prompt: "))
+                     (should (equal initial-input ""))
+                     (should (eq history 'ai-code-helm-read-string--history))
+                     literal-prompt)))
+          (should (equal (ai-code-helm-read-string-with-history
+                          "Prompt: " history-file-name "" '("Use ! in candidate"))
+                         literal-prompt))
+          (should helm-read-called)
+          (with-temp-buffer
+            (insert-file-contents
+             (expand-file-name history-file-name user-emacs-directory))
+            (should (equal (read (current-buffer)) (list literal-prompt)))))
+      (delete-directory user-emacs-directory t))))
+
 (ert-deftest ai-code-test-comment-context-p-inside-line-comment ()
   "Test that ai-code--comment-context-p detects point inside a line comment."
   (with-temp-buffer


### PR DESCRIPTION
## Summary
Fixes #387 by making Helm-backed prompt input keep history completion while treating the final edited prompt as literal text.

Previously, `ai-code-helm-read-string` used `helm-comp-read` for free-form prompt editing. Helm interprets minibuffer text as matching syntax, so characters such as `!`, `&`, `^`, `$`, `?`, brackets, parentheses, and escaped spaces could require manual escaping before prompts were sent. An initial fix avoided that parser but also removed the Helm history picker, which made it harder to navigate previous prompts.

This now uses a two-stage flow: Helm completion is used only to choose a previous prompt or candidate, and the selected value is then passed into a literal string editor for final prompt editing. That preserves prompt history navigation while keeping the final prompt text safe for special characters. Regression coverage verifies that Helm history completion is still invoked and that the final prompt with pattern-like characters is saved unchanged.

Verification:
- Added and ran the targeted regression test for Helm history completion plus literal special-character editing.
- Ran `test/test_ai-code-input.el`: 85/85 passed.
- Ran the full ERT suite: 880 tests, 867 passed, 13 skipped, 0 unexpected.
- Byte-compiled `ai-code-input.el`, ran `checkdoc` on `ai-code-input.el`, and ran `git diff --check`.