### PR TITLE
feat: externalize follow-up prompt and support cycle options in Transient menu

### DIFF
--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -353,6 +353,31 @@ CLASSIFICATION is the optional prompt classification result."
         (_ (ai-code--read-auto-test-type-choice)))
     (ai-code--read-auto-test-type-choice)))
 
+(defun ai-code--ensure-discussion-follow-up-harness-file ()
+  "Write and return the package prompt file path for discussion follow-up."
+  (when-let ((content ai-code-next-step-suggestion-suffix))
+    (let* ((directory (ai-code--ensure-auto-test-harness-prompt-directory))
+           (file-path (expand-file-name "discussion-follow-up.v1.md" directory)))
+      (unless (file-exists-p file-path)
+        (with-temp-file file-path
+          (insert content)
+          (unless (bolp)
+            (insert "\n"))))
+      file-path)))
+
+(defun ai-code--discussion-follow-up-reference-suffix ()
+  "Return a short suffix that references the discussion follow-up prompt file.
+If the harness file cannot be prepared, fall back to the inline suffix."
+  (condition-case err
+      (when-let ((file-path (ai-code--ensure-discussion-follow-up-harness-file)))
+        (format
+         "Read the local harness file: @%s. Use its instructions for this work. Apply it without repeating its full contents."
+         (ai-code--auto-test-harness-prompt-path file-path)))
+    (file-error
+     (message "Failed to prepare discussion follow-up harness file: %s"
+              (error-message-string err))
+     ai-code-next-step-suggestion-suffix)))
+
 (defun ai-code--resolve-auto-follow-up-suffix-for-send (&optional prompt-text classification)
   "Resolve next-step suggestion suffix for current send action for PROMPT-TEXT.
 CLASSIFICATION is the optional prompt classification result."
@@ -361,9 +386,13 @@ CLASSIFICATION is the optional prompt classification result."
     (let ((classification (or classification
                               (and ai-code-use-gptel-classify-prompt
                                    (ai-code--classify-prompt-code-change prompt-text)))))
-      (unless (eq classification 'code-change)
-        (and (ai-code--read-auto-follow-up-choice)
-             ai-code-next-step-suggestion-suffix)))))
+      (unless (and (eq classification 'code-change)
+                   (not ai-code-discussion-auto-follow-up-on-code-change))
+        (and (pcase ai-code-discussion-auto-follow-up-enabled
+               ('always t)
+               ((or 't 'ask-me) (ai-code--read-auto-follow-up-choice))
+               (_ nil))
+             (ai-code--discussion-follow-up-reference-suffix))))))
 
 (defun ai-code--resolve-auto-test-suffix-for-send (&optional prompt-text classification)
   "Resolve auto test suffix for current send action for PROMPT-TEXT.
@@ -416,6 +445,14 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   (setq ai-code-discussion-auto-follow-up-enabled value)
   value)
 
+(defun ai-code--cycle-discussion-auto-follow-up-value (current-val)
+  "Return the next cycled value of `ai-code-discussion-auto-follow-up-enabled` for CURRENT-VAL."
+  (pcase current-val
+    ('nil 'ask-me)
+    ((or 't 'ask-me) 'always)
+    ('always 'nil)
+    (_ 'ask-me)))
+
 (defcustom ai-code-auto-test-type nil
   "Select how prompts request tests after code changes."
   :type '(choice (const :tag "Ask every time" ask-me)
@@ -423,13 +460,21 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   :set #'ai-code--test-after-code-change--set
   :group 'ai-code)
 
+;;;###autoload
+(defcustom ai-code-discussion-auto-follow-up-on-code-change nil
+  "Whether to allow discussion follow-up suggestions for code-change prompts.
+When non-nil, next-step suggestions can be appended to code-change prompts
+as well, depending on the routing choice."
+  :type 'boolean
+  :group 'ai-code)
+
 (defcustom ai-code-discussion-auto-follow-up-enabled t
   "When non-nil, prompts may request numbered next-step suggestions.
-This is enabled by default; customize it to nil to turn the send-time
-choice off globally.  Pair it with `ai-code-use-gptel-classify-prompt`
-when you want code-change prompts to skip these discussion follow-up
-suggestions."
-  :type 'boolean
+This can be nil to disable it, always to always append without prompt,
+or ask-me (or t) to ask the user on each send."
+  :type '(choice (const :tag "Ask each send" ask-me)
+                 (const :tag "Always" always)
+                 (const :tag "Off" nil))
   :set (lambda (symbol value)
          (set-default symbol value)
          (set symbol value))

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -440,6 +440,12 @@ Send-time routing uses this result for test and discussion follow-up suffixes."
   (ai-code--test-after-code-change--set 'ai-code-auto-test-type value)
   value)
 
+(defun ai-code--cycle-auto-test-type-value (current-val)
+  "Return the next cycled value of `ai-code-auto-test-type` for CURRENT-VAL."
+  (if (eq current-val 'ask-me)
+      nil
+    'ask-me))
+
 (defun ai-code--apply-discussion-auto-follow-up-enabled (value)
   "Set `ai-code-discussion-auto-follow-up-enabled` to VALUE."
   (setq ai-code-discussion-auto-follow-up-enabled value)

--- a/ai-code.el
+++ b/ai-code.el
@@ -419,19 +419,14 @@ Otherwise switch to AI CLI buffer."
   :key "T"
   :description "Auto test type:"
   :reader (lambda (_prompt _initial-input _history)
-            (let* ((choices ai-code--auto-test-type-persistent-choices)
-                   (choice (completing-read "Test after code change: "
-                                            (mapcar #'car choices)
-                                            nil t nil nil
-                                            (caar choices))))
-              (let ((value (cdr (assoc choice choices))))
-                (ai-code--apply-auto-test-type value)
-                (message "Auto test type set to %s; prompt suffix is now %s"
-                         (or value "off")
-                         (if (eq value 'ask-me)
-                             "ask each send"
-                           (or ai-code-auto-test-suffix "cleared")))
-                value))))
+            (let ((next-val (ai-code--cycle-auto-test-type-value ai-code-auto-test-type)))
+              (ai-code--apply-auto-test-type next-val)
+              (message "Auto test type set to %s; prompt suffix is now %s"
+                       (or next-val "off")
+                       (if (eq next-val 'ask-me)
+                           "ask each send"
+                         (or ai-code-auto-test-suffix "cleared")))
+              next-val)))
 
 (defclass ai-code--discussion-auto-follow-up-enabled-type (transient-lisp-variable)
   ((variable :initform 'ai-code-discussion-auto-follow-up-enabled)

--- a/ai-code.el
+++ b/ai-code.el
@@ -446,7 +446,23 @@ Otherwise switch to AI CLI buffer."
   :description "Discussion follow-up:"
   :reader (lambda (_prompt _initial-input _history)
             (ai-code--apply-discussion-auto-follow-up-enabled
-             (not ai-code-discussion-auto-follow-up-enabled))))
+             (ai-code--cycle-discussion-auto-follow-up-value
+              ai-code-discussion-auto-follow-up-enabled))))
+
+(defclass ai-code--discussion-auto-follow-up-on-code-change-type (transient-lisp-variable)
+  ((variable :initform 'ai-code-discussion-auto-follow-up-on-code-change)
+   (format :initform "%k %d %v")
+   (reader :initform #'transient-lisp-variable--read-value))
+  "Selection helper for `ai-code-discussion-auto-follow-up-on-code-change`.")
+
+(transient-define-infix ai-code--infix-toggle-auto-follow-up-on-code-change ()
+  "Toggle `ai-code-discussion-auto-follow-up-on-code-change`."
+  :class 'ai-code--discussion-auto-follow-up-on-code-change-type
+  :key "C"
+  :description "Follow-up on code-change:"
+  :reader (lambda (_prompt _initial-input _history)
+            (setq ai-code-discussion-auto-follow-up-on-code-change
+                  (not ai-code-discussion-auto-follow-up-on-code-change))))
 
 (defun ai-code--select-backend-description (&rest _)
   "Dynamic description for the Select Backend menu item.
@@ -549,6 +565,7 @@ Shows the current backend label to the right."
 
 (transient-define-group ai-code--menu-other-tools
   (ai-code--infix-toggle-auto-follow-up)
+  (ai-code--infix-toggle-auto-follow-up-on-code-change)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("P" "AI session checkpoint" ai-code-session-checkpoint)
   ("e" "Investigate exception (C-u: clipboard)" ai-code-investigate-exception)

--- a/ai-code.el
+++ b/ai-code.el
@@ -449,21 +449,6 @@ Otherwise switch to AI CLI buffer."
              (ai-code--cycle-discussion-auto-follow-up-value
               ai-code-discussion-auto-follow-up-enabled))))
 
-(defclass ai-code--discussion-auto-follow-up-on-code-change-type (transient-lisp-variable)
-  ((variable :initform 'ai-code-discussion-auto-follow-up-on-code-change)
-   (format :initform "%k %d %v")
-   (reader :initform #'transient-lisp-variable--read-value))
-  "Selection helper for `ai-code-discussion-auto-follow-up-on-code-change`.")
-
-(transient-define-infix ai-code--infix-toggle-auto-follow-up-on-code-change ()
-  "Toggle `ai-code-discussion-auto-follow-up-on-code-change`."
-  :class 'ai-code--discussion-auto-follow-up-on-code-change-type
-  :key "C"
-  :description "Follow-up on code-change:"
-  :reader (lambda (_prompt _initial-input _history)
-            (setq ai-code-discussion-auto-follow-up-on-code-change
-                  (not ai-code-discussion-auto-follow-up-on-code-change))))
-
 (defun ai-code--select-backend-description (&rest _)
   "Dynamic description for the Select Backend menu item.
 Shows the current backend label to the right."
@@ -565,7 +550,6 @@ Shows the current backend label to the right."
 
 (transient-define-group ai-code--menu-other-tools
   (ai-code--infix-toggle-auto-follow-up)
-  (ai-code--infix-toggle-auto-follow-up-on-code-change)
   ("." "Init projectile and gtags" ai-code-init-project)
   ("P" "AI session checkpoint" ai-code-session-checkpoint)
   ("e" "Investigate exception (C-u: clipboard)" ai-code-investigate-exception)

--- a/prompt/discussion-follow-up.v1.md
+++ b/prompt/discussion-follow-up.v1.md
@@ -1,0 +1,7 @@
+At the end of your response, provide 3-4 numbered candidate next
+steps. Keep each option to one sentence. At least 2 candidates must
+be AI-actionable items as follow up: either a code change or tool usage. Mark the
+single best option with "(Recommended)". If the user replies with
+only a number such as 1, 2, 3, or 4, treat that as selecting the
+corresponding next step from your previous answer. The user may also
+ignore these options and send a different follow-up request instead.

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -932,6 +932,12 @@
   (should (eq 'always (ai-code--cycle-discussion-auto-follow-up-value 'ask-me)))
   (should (eq nil (ai-code--cycle-discussion-auto-follow-up-value 'always))))
 
+(ert-deftest ai-code-test-cycle-auto-test-type-value ()
+  "Test that cycling auto test type value works nil -> ask-me -> nil."
+  (should (eq 'ask-me (ai-code--cycle-auto-test-type-value nil)))
+  (should (eq nil (ai-code--cycle-auto-test-type-value 'ask-me))))
+
 (provide 'test_ai-code-harness)
 
 ;;; test_ai-code-harness.el ends here
+

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -469,7 +469,9 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda (&rest _args) t)))
+               (lambda (&rest _args) t))
+              ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+               (lambda () ai-code-next-step-suggestion-suffix)))
       (should (string-match-p
                "3-4 numbered candidate next[[:space:]\n]+steps"
                (ai-code--resolve-auto-follow-up-suffix-for-send
@@ -485,7 +487,9 @@
         (ai-code-next-step-suggestion-suffix "FOLLOW-UP")
         (ai-code-use-gptel-classify-prompt nil))
     (cl-letf (((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda () t)))
+               (lambda () t))
+              ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+               (lambda () ai-code-next-step-suggestion-suffix)))
       (should (equal "FOLLOW-UP"
                      (ai-code--resolve-auto-follow-up-suffix-for-send
                       "Explain this function"))))))
@@ -531,7 +535,9 @@
     (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
-               (lambda (&rest _args) t)))
+               (lambda (&rest _args) t))
+              ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+               (lambda () ai-code-next-step-suggestion-suffix)))
       (let ((this-command 'ai-code-ask-question))
         (should (string-match-p
                  "The user may also[[:space:]\n]+ignore these options"
@@ -555,6 +561,8 @@
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
                (lambda (&rest _args) t))
+              ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+               (lambda () ai-code-next-step-suggestion-suffix))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code--prompt-choose-target-session)
@@ -566,7 +574,7 @@
       (ai-code--write-prompt-to-file-and-send "Explain this function")
       (should (string-match-p "BASE SUFFIX" sent-command))
       (should (string-match-p "3-4 numbered candidate next[[:space:]\n]+steps"
-                              sent-command))
+                               sent-command))
       (should (string-match-p
                "At least 2 candidates must[[:space:]\n]+be AI-actionable items"
                sent-command))
@@ -588,6 +596,8 @@
                    (lambda (_prompt-text) 'non-code-change))
                   ((symbol-function 'ai-code--read-auto-follow-up-choice)
                    (lambda (&rest _args) t))
+                  ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+                   (lambda () ai-code-next-step-suggestion-suffix))
                   ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                    (lambda () prompt-file))
                   ((symbol-function 'ai-code--prompt-choose-target-session)
@@ -603,7 +613,7 @@
               (should (string-match-p "Explain this function" contents))
               (should (string-match-p "BASE SUFFIX" contents))
               (should (string-match-p "3-4 numbered candidate next[[:space:]\n]+steps"
-                                      contents))
+                                       contents))
               (should (string-match-p
                        "At least 2 candidates must[[:space:]\n]+be AI-actionable items"
                        contents)))))
@@ -620,6 +630,8 @@
                (lambda (_prompt-text) 'non-code-change))
               ((symbol-function 'ai-code--read-auto-follow-up-choice)
                (lambda (&rest _args) t))
+              ((symbol-function 'ai-code--discussion-follow-up-reference-suffix)
+               (lambda () ai-code-next-step-suggestion-suffix))
               ((symbol-function 'ai-code--get-ai-code-prompt-file-path)
                (lambda () nil))
               ((symbol-function 'ai-code--prompt-choose-target-session)
@@ -630,7 +642,7 @@
                (lambda (&rest _args) nil)))
       (ai-code--write-prompt-to-file-and-send "Summarize this design")
       (should (string-match-p "3-4 numbered candidate next[[:space:]\n]+steps"
-                              sent-command))
+                               sent-command))
       (should (string-match-p
                "either a code change or tool usage"
                sent-command)))))
@@ -769,11 +781,13 @@
                    ("Off" . nil))
                  ai-code--auto-test-type-persistent-choices)))
 
-(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-custom-option-is-boolean ()
-  "Test that discussion auto follow-up setting is a boolean toggle."
+(ert-deftest ai-code-test-discussion-auto-follow-up-enabled-custom-option-is-choice ()
+  "Test that discussion auto follow-up setting is a choice option."
   (should
    (equal
-    'boolean
+    '(choice (const :tag "Ask each send" ask-me)
+             (const :tag "Always" always)
+             (const :tag "Off" nil))
     (get 'ai-code-discussion-auto-follow-up-enabled 'custom-type))))
 
 (ert-deftest ai-code-test-discussion-auto-follow-up-enabled-default-is-on ()
@@ -843,6 +857,80 @@
       (should (string-match-p "BASE SUFFIX" sent-command))
       (should (string-match-p "Do not write or run any test\\." sent-command))
       (should-not (string-match-p "SHOULD NOT APPEAR" sent-command)))))
+
+(ert-deftest ai-code-test-ensure-discussion-follow-up-harness-file ()
+  "Test that discussion follow-up harness file is written and returned."
+  (let* ((ai-code-next-step-suggestion-suffix "TEST SUFFIX CONTENT")
+         (temp-dir (make-temp-file "ai-code-test-prompt-" t))
+         (file-path (expand-file-name "discussion-follow-up.v1.md" temp-dir)))
+    (cl-letf (((symbol-function 'ai-code--ensure-auto-test-harness-prompt-directory)
+               (lambda () temp-dir)))
+      (unwind-protect
+          (let ((result (ai-code--ensure-discussion-follow-up-harness-file)))
+            (should (equal file-path result))
+            (should (file-exists-p result))
+            (with-temp-buffer
+              (insert-file-contents result)
+              (should (equal "TEST SUFFIX CONTENT\n" (buffer-string)))))
+        (when (file-exists-p file-path)
+          (delete-file file-path))
+        (delete-directory temp-dir)))))
+
+(ert-deftest ai-code-test-discussion-follow-up-reference-suffix-resolves-path ()
+  "Test that discussion follow-up reference suffix returns the correct format."
+  (let* ((ai-code-next-step-suggestion-suffix "TEST SUFFIX CONTENT")
+         (temp-dir (make-temp-file "ai-code-test-prompt-" t))
+         (file-path (expand-file-name "discussion-follow-up.v1.md" temp-dir)))
+    (cl-letf (((symbol-function 'ai-code--ensure-auto-test-harness-prompt-directory)
+               (lambda () temp-dir))
+              ((symbol-function 'ai-code--auto-test-harness-prompt-path)
+               (lambda (path) path)))
+      (unwind-protect
+          (let ((suffix (ai-code--discussion-follow-up-reference-suffix)))
+            (should (string-match-p (regexp-quote file-path) suffix)))
+        (when (file-exists-p file-path)
+          (delete-file file-path))
+        (delete-directory temp-dir)))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-for-send-always ()
+  "Test that always mode returns follow-up suffix without asking."
+  (let ((ai-code-discussion-auto-follow-up-enabled 'always)
+        (ai-code-next-step-suggestion-suffix "FOLLOW-UP")
+        (temp-dir (make-temp-file "ai-code-test-prompt-" t)))
+    (cl-letf (((symbol-function 'ai-code--ensure-auto-test-harness-prompt-directory)
+               (lambda () temp-dir))
+              ((symbol-function 'ai-code--read-auto-follow-up-choice)
+               (lambda () (ert-fail "Should not ask in always mode"))))
+      (unwind-protect
+          (let ((result (ai-code--resolve-auto-follow-up-suffix-for-send "Explain this function")))
+            (should (string-match-p "Read the local harness file: @.*discussion-follow-up.v1.md" result)))
+        (let ((file-path (expand-file-name "discussion-follow-up.v1.md" temp-dir)))
+          (when (file-exists-p file-path) (delete-file file-path)))
+        (delete-directory temp-dir)))))
+
+(ert-deftest ai-code-test-resolve-auto-follow-up-suffix-on-code-change-enabled ()
+  "Test that code-change prompts are allowed when on-code-change variable is non-nil."
+  (let ((ai-code-discussion-auto-follow-up-enabled 'always)
+        (ai-code-discussion-auto-follow-up-on-code-change t)
+        (ai-code-next-step-suggestion-suffix "FOLLOW-UP")
+        (temp-dir (make-temp-file "ai-code-test-prompt-" t)))
+    (cl-letf (((symbol-function 'ai-code--ensure-auto-test-harness-prompt-directory)
+               (lambda () temp-dir))
+              ((symbol-function 'ai-code--classify-prompt-code-change)
+               (lambda (_) 'code-change)))
+      (unwind-protect
+          (let ((result (ai-code--resolve-auto-follow-up-suffix-for-send "Modify this function")))
+            (should (string-match-p "Read the local harness file: @.*discussion-follow-up.v1.md" result)))
+        (let ((file-path (expand-file-name "discussion-follow-up.v1.md" temp-dir)))
+          (when (file-exists-p file-path) (delete-file file-path)))
+        (delete-directory temp-dir)))))
+
+(ert-deftest ai-code-test-toggle-auto-follow-up-cycles ()
+  "Test that cycling auto follow-up value works nil -> ask-me -> always -> nil."
+  (should (eq 'ask-me (ai-code--cycle-discussion-auto-follow-up-value nil)))
+  (should (eq 'always (ai-code--cycle-discussion-auto-follow-up-value t)))
+  (should (eq 'always (ai-code--cycle-discussion-auto-follow-up-value 'ask-me)))
+  (should (eq nil (ai-code--cycle-discussion-auto-follow-up-value 'always))))
 
 (provide 'test_ai-code-harness)
 


### PR DESCRIPTION
## Summary
This PR improves the discussion follow-up prompt processing and Transient menu options cycling:
- **Prompt Externalization**: Externalizes the follow-up next-step suggestions prompt into a package-local harness file (`prompt/discussion-follow-up.v1.md`), referencing it via relative path and falling back to inline if file writing fails.
- **Auto-Approve Mode**: Extends `ai-code-discussion-auto-follow-up-enabled` to support an `'always` option to auto-append follow-up suggestions without prompt interruption.
- **Code Change Inclusion**: Introduces `ai-code-discussion-auto-follow-up-on-code-change` to optionally allow suggestions for code change requests.
- **Transient Menu Usability**: Refactors both follow-up and auto-test-type infix options to cycle directly on key press without triggering `completing-read`.

## Test Plan
The changes are fully covered by unit tests. All tests run and pass:
- Run verification command: `emacs -batch -L . -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit`
- Verified 885 tests pass successfully (0 unexpected failures).