### PR TITLE
Chore: Prompt for draft PR selection in PR creation flow

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Chore: Prompt for draft PR selection in PR creation flow
 - Fix: Support Ghostel paste API and add tests
 - Feat: Add Test Context derivation, refactor doc module, and require relative links
 

--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -106,59 +106,6 @@ Candidate values:
       "master")
      (t nil))))
 
-(defun ai-code--send-current-branch-pr-source-instruction (review-source)
-  "Return PR creation instructions for REVIEW-SOURCE."
-  (pcase review-source
-    ('gh-cli
-     (concat
-      "Use GitHub CLI to create the pull request. "
-      "Run `gh pr create` with the current branch as the head branch, "
-      "target the requested base branch, and include the final title and body."))
-    ('github-mcp
-     (concat
-      "Use GitHub MCP tools to create the pull request directly. "
-      "Do not fetch review comments before the PR exists; "
-      "create the PR first, then return the resulting PR URL."))
-    (_
-     (concat
-      "Create the pull request using the backend's PR creation capability. "
-      "Do not treat this as a PR review flow before the PR exists."))))
-
-(defun ai-code--build-send-current-branch-pr-init-prompt
-    (review-source current-branch target-branch &optional pr-title)
-  "Build a PR creation prompt.
-REVIEW-SOURCE, CURRENT-BRANCH, TARGET-BRANCH, and PR-TITLE
-define the PR request."
-  (let* ((source-instruction
-          (ai-code--send-current-branch-pr-source-instruction review-source))
-         (draft-pr-p
-          (y-or-n-p "Create this PR as a draft? "))
-         (pr-type-instruction
-          (if draft-pr-p
-              "Create a draft pull request. If you use GitHub CLI, pass `--draft`.\n"
-            "Create a normal pull request, not a draft.\n"))
-         (title-instruction
-          (if (string-empty-p (or pr-title ""))
-              "2. Generate a concise PR title based on the code change.\n"
-            (format "2. Use this PR title exactly: %s\n" pr-title))))
-    (format "Create a pull request from branch %s into %s.
-
-%s
-
-PR Creation Steps:
-1. Inspect the current branch changes and open or send out a pull request into %s.
-   %s
-%s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
-4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
-5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
-6. Return the final PR URL, the exact PR title, and the exact description that were used."
-            current-branch
-            target-branch
-            source-instruction
-            target-branch
-            pr-type-instruction
-            title-instruction)))
-
 (defun ai-code--validate-git-repository ()
   "Validate that current directory is in a git repository.
 Return the git root directory if valid, otherwise signal an error."

--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -13,7 +13,6 @@
 
 (require 'ai-code-input)
 (require 'ai-code-prompt-mode)
-(require 'ai-code-github)
 
 (declare-function helm-gtags-create-tags "helm-gtags" (dir &optional label))
 (declare-function magit-anything-modified-p "magit" ())
@@ -28,6 +27,9 @@
 (declare-function magit-run-git "magit-git" (&rest args))
 (declare-function magit-worktree-status "magit-worktree" ())
 (declare-function difftastic-magit-diff "difftastic" ())
+(declare-function ai-code-pull-or-review-diff-file "ai-code-github" ())
+ (declare-function ai-code--open-git-web-compare "ai-code-github" (start end))
+ (declare-function ai-code--open-git-web-commit "ai-code-github" (commit))
 
 (defcustom ai-code-init-project-gtags-label "pygments"
   "Default label passed to Helm-Gtags when initializing a project.

--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -129,18 +129,25 @@ Candidate values:
   "Build a PR creation prompt.
 REVIEW-SOURCE, CURRENT-BRANCH, TARGET-BRANCH, and PR-TITLE
 define the PR request."
-  (let ((source-instruction
-         (ai-code--send-current-branch-pr-source-instruction review-source))
-        (title-instruction
-         (if (string-empty-p (or pr-title ""))
-             "2. Generate a concise PR title based on the code change.\n"
-           (format "2. Use this PR title exactly: %s\n" pr-title))))
+  (let* ((source-instruction
+          (ai-code--send-current-branch-pr-source-instruction review-source))
+         (draft-pr-p
+          (y-or-n-p "Create this PR as a draft? "))
+         (pr-type-instruction
+          (if draft-pr-p
+              "Create a draft pull request. If you use GitHub CLI, pass `--draft`.\n"
+            "Create a normal pull request, not a draft.\n"))
+         (title-instruction
+          (if (string-empty-p (or pr-title ""))
+              "2. Generate a concise PR title based on the code change.\n"
+            (format "2. Use this PR title exactly: %s\n" pr-title))))
     (format "Create a pull request from branch %s into %s.
 
 %s
 
 PR Creation Steps:
 1. Inspect the current branch changes and open or send out a pull request into %s.
+   %s
 %s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
 4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
 5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
@@ -149,6 +156,7 @@ PR Creation Steps:
             target-branch
             source-instruction
             target-branch
+            pr-type-instruction
             title-instruction)))
 
 (defun ai-code--validate-git-repository ()

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -254,18 +254,26 @@ Signal a helpful error when difftastic is unavailable."
   "Build a PR creation prompt.
 REVIEW-SOURCE, CURRENT-BRANCH, TARGET-BRANCH, and PR-TITLE
 define the PR request."
-  (let ((source-instruction
-         (ai-code--send-current-branch-pr-source-instruction review-source))
-        (title-instruction
-         (if (string-empty-p (or pr-title ""))
-             "2. Generate a concise PR title based on the code change.\n"
-           (format "2. Use this PR title exactly: %s\n" pr-title))))
+  ;; DONE: it should ask user if this is a draft PR or not (y/n). If yes, the PR should be created as a draft PR. If no, the PR should be created as a normal PR.
+  (let* ((source-instruction
+          (ai-code--send-current-branch-pr-source-instruction review-source))
+         (draft-pr-p
+          (y-or-n-p "Create this PR as a draft? "))
+         (pr-type-instruction
+          (if draft-pr-p
+              "Create a draft pull request. If you use GitHub CLI, pass `--draft`.\n"
+            "Create a normal pull request, not a draft.\n"))
+         (title-instruction
+          (if (string-empty-p (or pr-title ""))
+              "2. Generate a concise PR title based on the code change.\n"
+            (format "2. Use this PR title exactly: %s\n" pr-title))))
     (format "Create a pull request from branch %s into %s.
 
 %s
 
 PR Creation Steps:
 1. Inspect the current branch changes and open or send out a pull request into %s.
+   %s
 %s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
 4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
 5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
@@ -274,6 +282,7 @@ PR Creation Steps:
             target-branch
             source-instruction
             target-branch
+            pr-type-instruction
             title-instruction)))
 
 (defun ai-code--build-pr-init-prompt (review-source target-url review-mode)

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -116,6 +116,42 @@ Review Steps:
 Provide an overall assessment at the end."
             pr-url source-instruction)))
 
+(defun ai-code--build-send-current-branch-pr-init-prompt
+    (review-source current-branch target-branch &optional pr-title)
+  "Build a PR creation prompt.
+REVIEW-SOURCE, CURRENT-BRANCH, TARGET-BRANCH, and PR-TITLE
+define the PR request."
+  ;; DONE: it should ask user if this is a draft PR or not (y/n). If yes, the PR should be created as a draft PR. If no, the PR should be created as a normal PR.
+  (let* ((source-instruction
+          (ai-code--send-current-branch-pr-source-instruction review-source))
+         (draft-pr-p
+          (y-or-n-p "Create this PR as a draft? "))
+         (pr-type-instruction
+          (if draft-pr-p
+              "Create a draft pull request. If you use GitHub CLI, pass `--draft`.\n"
+            "Create a normal pull request, not a draft.\n"))
+         (title-instruction
+          (if (string-empty-p (or pr-title ""))
+              "2. Generate a concise PR title based on the code change.\n"
+            (format "2. Use this PR title exactly: %s\n" pr-title))))
+    (format "Create a pull request from branch %s into %s.
+
+%s
+
+PR Creation Steps:
+1. Inspect the current branch changes and open or send out a pull request into %s.
+   %s
+%s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
+4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
+5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
+6. Return the final PR URL, the exact PR title, and the exact description that were used."
+            current-branch
+            target-branch
+            source-instruction
+            target-branch
+            pr-type-instruction
+            title-instruction)))
+
 (defun ai-code--build-pr-feedback-check-init-prompt (review-source pr-url)
   "Build unresolved feedback check prompt for REVIEW-SOURCE with PR-URL."
   (let ((source-instruction
@@ -248,42 +284,6 @@ Signal a helpful error when difftastic is unavailable."
      (concat
       "Create the pull request using the backend's PR creation capability. "
       "Do not treat this as a PR review flow before the PR exists."))))
-
-(defun ai-code--build-send-current-branch-pr-init-prompt
-    (review-source current-branch target-branch &optional pr-title)
-  "Build a PR creation prompt.
-REVIEW-SOURCE, CURRENT-BRANCH, TARGET-BRANCH, and PR-TITLE
-define the PR request."
-  ;; DONE: it should ask user if this is a draft PR or not (y/n). If yes, the PR should be created as a draft PR. If no, the PR should be created as a normal PR.
-  (let* ((source-instruction
-          (ai-code--send-current-branch-pr-source-instruction review-source))
-         (draft-pr-p
-          (y-or-n-p "Create this PR as a draft? "))
-         (pr-type-instruction
-          (if draft-pr-p
-              "Create a draft pull request. If you use GitHub CLI, pass `--draft`.\n"
-            "Create a normal pull request, not a draft.\n"))
-         (title-instruction
-          (if (string-empty-p (or pr-title ""))
-              "2. Generate a concise PR title based on the code change.\n"
-            (format "2. Use this PR title exactly: %s\n" pr-title))))
-    (format "Create a pull request from branch %s into %s.
-
-%s
-
-PR Creation Steps:
-1. Inspect the current branch changes and open or send out a pull request into %s.
-   %s
-%s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
-4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
-5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
-6. Return the final PR URL, the exact PR title, and the exact description that were used."
-            current-branch
-            target-branch
-            source-instruction
-            target-branch
-            pr-type-instruction
-            title-instruction)))
 
 (defun ai-code--build-pr-init-prompt (review-source target-url review-mode)
   "Build initial prompt for REVIEW-SOURCE, TARGET-URL and REVIEW-MODE."

--- a/test/test_ai-code-git.el
+++ b/test/test_ai-code-git.el
@@ -15,6 +15,10 @@
 (declare-function difftastic-magit-diff "difftastic" ())
 (declare-function magit-worktree-status "magit-worktree" ())
 
+(ert-deftest ai-code-test-ai-code-git-does-not-eagerly-load-github-module ()
+  "Loading `ai-code-git' should not eagerly load `ai-code-github'."
+  (should-not (featurep 'ai-code-github)))
+
 (defun ai-code-test--gitignore-required-entries ()
   "Return the default ignore entries expected from `ai-code-update-git-ignore'."
   (list (concat ai-code-files-dir-name "/")
@@ -236,7 +240,7 @@ other-file"))
       (should (eq captured-fn #'ai-code-git-worktree-branch)))))
 
 (ert-deftest ai-code-test-git-worktree-action-with-prefix-opens-dired ()
-  "With prefix arg, open dired on the repo worktree directory."
+  "With prefix arg, open Dired on the repo worktree directory."
   (let* ((temp-worktree-root (make-temp-file "wt-root" t))
          (repo-dir (expand-file-name "ai-code-interface.el" temp-worktree-root))
          (ai-code-git-worktree-root temp-worktree-root)
@@ -259,7 +263,7 @@ other-file"))
       (should-error (ai-code-git-worktree-action '(4)) :type 'user-error))))
 
 (ert-deftest ai-code-test-git-worktree-branch-opens-dired-after-creation ()
-  "After creating worktree, open dired on the worktree path instead of magit status."
+  "After creating worktree, open Dired on the worktree path instead of Magit status."
   (let* ((temp-worktree-root (make-temp-file "ai-code-worktree-root-" t))
          (ai-code-git-worktree-root temp-worktree-root)
          (git-root "/tmp/sample-repo/")
@@ -330,6 +334,8 @@ other-file"))
                   ((symbol-function 'completing-read)
                    (lambda (_prompt choices &rest _args)
                      (if (listp choices) (car choices) "")))
+                  ((symbol-function 'ai-code-current-backend-label)
+                   (lambda () "Codex"))
                   ((symbol-function 'find-file-other-window)
                    (lambda (file) (setq find-file-called-with file)))
                   ((symbol-function 'ai-code--generate-task-filename)

--- a/test/test_ai-code-git.el
+++ b/test/test_ai-code-git.el
@@ -17,7 +17,23 @@
 
 (ert-deftest ai-code-test-ai-code-git-does-not-eagerly-load-github-module ()
   "Loading `ai-code-git' should not eagerly load `ai-code-github'."
-  (should-not (featurep 'ai-code-github)))
+  (let ((git-library (locate-library "ai-code-git"))
+        (github-library (locate-library "ai-code-github")))
+    (unwind-protect
+        (progn
+          ;; Isolate the load behavior under test instead of relying on
+          ;; whatever other test files already required globally.
+          (when (featurep 'ai-code-git)
+            (unload-feature 'ai-code-git t))
+          (when (featurep 'ai-code-github)
+            (unload-feature 'ai-code-github t))
+          (load git-library nil 'nomessage)
+          (should (featurep 'ai-code-git))
+          (should-not (featurep 'ai-code-github)))
+      (unless (featurep 'ai-code-git)
+        (load git-library nil 'nomessage))
+      (unless (featurep 'ai-code-github)
+        (load github-library nil 'nomessage)))))
 
 (defun ai-code-test--gitignore-required-entries ()
   "Return the default ignore entries expected from `ai-code-update-git-ignore'."

--- a/test/test_ai-code-github.el
+++ b/test/test_ai-code-github.el
@@ -172,20 +172,33 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
     (should (string-match-p "diff" (downcase instruction)))
     (should-not (string-match-p "review comments" (downcase instruction)))))
 
-(ert-deftest ai-code-test-build-send-current-branch-pr-init-prompt ()
-  "Build a concise PR creation prompt for the current branch."
-  (let ((prompt (ai-code--build-send-current-branch-pr-init-prompt
-                 'gh-cli
-                 "feature/improve-pr-flow"
-                 "main")))
-    (let ((case-fold-search nil))
-      (should (string-match-p "Use GitHub CLI to create the pull request" prompt)))
-    (should (string-match-p "feature/improve-pr-flow" prompt))
-    (should (string-match-p "main" prompt))
-    (should (string-match-p "create a pull request" (downcase prompt)))
-    (should (string-match-p "short" (downcase prompt)))
-    (should (string-match-p "author" (downcase prompt)))
-    (should-not (string-match-p "review comments" (downcase prompt)))))
+(ert-deftest ai-code-test-build-send-current-branch-pr-init-prompt-draft ()
+  "Build a draft PR creation prompt for the current branch."
+  (cl-letf (((symbol-function 'y-or-n-p)
+             (lambda (_prompt) t)))
+    (let ((prompt (ai-code--build-send-current-branch-pr-init-prompt
+                   'gh-cli
+                   "feature/improve-pr-flow"
+                   "main")))
+      (let ((case-fold-search nil))
+        (should (string-match-p "Use GitHub CLI to create the pull request" prompt)))
+      (should (string-match-p "feature/improve-pr-flow" prompt))
+      (should (string-match-p "main" prompt))
+      (should (string-match-p "create a draft pull request" (downcase prompt)))
+      (should (string-match-p "short" (downcase prompt)))
+      (should (string-match-p "author" (downcase prompt)))
+      (should-not (string-match-p "review comments" (downcase prompt))))))
+
+(ert-deftest ai-code-test-build-send-current-branch-pr-init-prompt-ready-for-review ()
+  "Build a normal PR creation prompt when draft mode is declined."
+  (cl-letf (((symbol-function 'y-or-n-p)
+             (lambda (_prompt) nil)))
+    (let ((prompt (ai-code--build-send-current-branch-pr-init-prompt
+                   'gh-cli
+                   "feature/improve-pr-flow"
+                   "main")))
+      (should (string-match-p "create a normal pull request" (downcase prompt)))
+      (should-not (string-match-p "draft pull request" (downcase prompt))))))
 
 (ert-deftest ai-code-test-default-pr-target-branch-uses-origin-head-when-main-and-master-absent ()
   "Fallback target branch should use origin HEAD when available."
@@ -227,6 +240,8 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
                  (if (string= prompt "PR title (optional, leave empty for AI to generate): ")
                      ""
                    initial-input)))
+              ((symbol-function 'y-or-n-p)
+               (lambda (_prompt) nil))
               ((symbol-function 'ai-code--insert-prompt)
                (lambda (prompt)
                  (setq captured-inserted-prompt prompt))))
@@ -237,7 +252,9 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
       (should (member "Enter PR creation prompt: " captured-read-prompts))
       (should-not (member "Enter review prompt: " captured-read-prompts))
       (should (string-match-p "feature/improve-pr-flow" captured-inserted-prompt))
-      (should (string-match-p "generate a concise pr title" (downcase captured-inserted-prompt))))))
+      (should (string-match-p "generate a concise pr title" (downcase captured-inserted-prompt)))
+      (should (string-match-p "create a normal pull request"
+                              (downcase captured-inserted-prompt))))))
 
 (ert-deftest ai-code-test-pull-or-review-pr-with-source-explain-code-change-shares-flow ()
   "Explain code change mode should dispatch to the shared explanation flow."


### PR DESCRIPTION
## Summary
Add a draft-versus-normal PR selection step to the current-branch PR creation flow so the generated prompt tells the backend which kind of PR to open.

## What changed
The PR creation prompt builder now asks whether the PR should be a draft and injects the corresponding instruction into the generated prompt text. I also marked the original TODO in `ai-code-github.el` as done and kept the duplicate prompt builder implementation in `ai-code-git.el` in sync because that definition can override the GitHub-specific one at load time.

## Test coverage
The GitHub prompt tests now cover both draft and normal PR instructions, and the existing current-branch PR flow test stubs the new `y-or-n-p` prompt so it does not block batch execution.

## Verification
I did not run tests for this PR because the request for this PR explicitly said not to run any test.