### PR TITLE
[codex] Normalize vterm dim SGR foreground

### DIFF
--- a/ai-code-backends-infra-vterm.el
+++ b/ai-code-backends-infra-vterm.el
@@ -66,6 +66,13 @@ updates are handled separately via carriage return counting.")
 
 (defvar-local ai-code-backends-infra--vterm-render-queue nil)
 (defvar-local ai-code-backends-infra--vterm-render-timer nil)
+(defvar-local ai-code-backends-infra--vterm-dim-foreground-active nil
+  "Non-nil when AI Code injected an ANSI gray foreground for SGR dim text.")
+
+(defvar-local ai-code-backends-infra--vterm-foreground-state nil
+  "Current foreground state tracked for AI Code vterm SGR normalization.
+The value is nil for the default foreground, `explicit' for a foreground
+set by the subprocess, and `injected' for AI Code's ANSI gray foreground.")
 
 (defvar ai-code-backends-infra--vterm-advices-installed nil
   "Flag indicating whether vterm filter advices have been installed globally.")
@@ -108,6 +115,98 @@ If PASTE is non-nil, send it as a pasted string."
   "Return the vterm resize handler."
   #'vterm--window-adjust-process-window-size)
 
+(defun ai-code-backends-infra--vterm-skip-sgr-color-params (codes)
+  "Skip extended SGR color parameters from CODES."
+  (pcase (car codes)
+    ("5" (nthcdr 2 codes))
+    ("2" (nthcdr 4 codes))
+    (_ (cdr codes))))
+
+(defun ai-code-backends-infra--vterm-sgr-code-number (code)
+  "Return the SGR number for CODE, treating an empty parameter as reset."
+  (string-to-number (if (string= code "") "0" code)))
+
+(defun ai-code-backends-infra--vterm-sgr-effect (codes)
+  "Return the final foreground and intensity effect of SGR CODES."
+  (let ((dim nil)
+        (normal nil)
+        (explicit-foreground nil)
+        (foreground-reset nil)
+        (foreground-state ai-code-backends-infra--vterm-foreground-state)
+        (remaining codes))
+    (while remaining
+      (let* ((code (pop remaining))
+             (number (ai-code-backends-infra--vterm-sgr-code-number code)))
+        (cond
+         ((= number 0)
+          (setq dim nil
+                normal t
+                foreground-reset t
+                foreground-state nil))
+         ((= number 2)
+          (setq dim t
+                normal nil))
+         ((= number 22)
+          (setq dim nil
+                normal t))
+         ((= number 39)
+          (setq foreground-reset t
+                foreground-state nil))
+         ((or (<= 30 number 37)
+              (<= 90 number 97))
+          (setq explicit-foreground t
+                foreground-state 'explicit))
+         ((= number 38)
+          (setq explicit-foreground t
+                foreground-state 'explicit)
+          (setq remaining
+                (ai-code-backends-infra--vterm-skip-sgr-color-params
+                 remaining)))
+         ((= number 48)
+          (setq remaining
+                (ai-code-backends-infra--vterm-skip-sgr-color-params
+                 remaining))))))
+    (list dim normal explicit-foreground foreground-reset foreground-state)))
+
+(defun ai-code-backends-infra--vterm-normalize-dim-sgr (input)
+  "Render SGR dim text with the standard ANSI gray foreground in INPUT."
+  (let ((start 0)
+        (parts nil))
+    (while (string-match "\e\\[\\([0-9;]*\\)m" input start)
+      (let* ((match-beginning (match-beginning 0))
+             (match-end (match-end 0))
+             (sequence (match-string 0 input))
+             (params (match-string 1 input))
+             (codes (if (string= params "") '("0") (split-string params ";")))
+             (was-injected
+              (eq ai-code-backends-infra--vterm-foreground-state 'injected)))
+        (cl-destructuring-bind
+            (dim normal explicit-foreground foreground-reset foreground-state)
+            (ai-code-backends-infra--vterm-sgr-effect codes)
+          (push (substring input start match-beginning) parts)
+          (push
+           (cond
+            ((and dim (null foreground-state))
+             (setq ai-code-backends-infra--vterm-foreground-state 'injected
+                   ai-code-backends-infra--vterm-dim-foreground-active t)
+             (format "\e[%sm" (mapconcat #'identity (append codes '("90")) ";")))
+            ((and normal
+                  was-injected
+                  (not foreground-reset)
+                  (not explicit-foreground))
+             (setq ai-code-backends-infra--vterm-foreground-state nil
+                   ai-code-backends-infra--vterm-dim-foreground-active nil)
+             (format "\e[%sm" (mapconcat #'identity (append codes '("39")) ";")))
+            (t
+             (setq ai-code-backends-infra--vterm-foreground-state foreground-state
+                   ai-code-backends-infra--vterm-dim-foreground-active
+                   (eq foreground-state 'injected))
+             sequence))
+           parts)
+          (setq start match-end))))
+    (push (substring input start) parts)
+    (apply #'concat (nreverse parts))))
+
 (defun ai-code-backends-infra--vterm-notification-tracker (orig-fun process input)
   "Track vterm activity for notification purposes, then call ORIG-FUN.
 When `ai-code-backends-infra-strip-alternate-screen' is non-nil,
@@ -116,7 +215,8 @@ applications write to the normal screen buffer (preserving scrollback)."
   (let ((filtered-input
          (if (ai-code-backends-infra--session-buffer-p (process-buffer process))
              (with-current-buffer (process-buffer process)
-               (ai-code-backends-infra--strip-alternate-screen-sequences input))
+               (ai-code-backends-infra--vterm-normalize-dim-sgr
+                (ai-code-backends-infra--strip-alternate-screen-sequences input)))
            input)))
     (when (ai-code-backends-infra--session-buffer-p (process-buffer process))
       (with-current-buffer (process-buffer process)
@@ -230,7 +330,7 @@ queued while copy mode was active is rendered immediately when the user
 returns to normal terminal interaction."
   (unless (bound-and-true-p vterm-copy-mode)
     (when ai-code-backends-infra--vterm-render-queue
-      (when-let ((proc (get-buffer-process (current-buffer))))
+      (when-let* ((proc (get-buffer-process (current-buffer))))
         (let ((data ai-code-backends-infra--vterm-render-queue))
           (setq ai-code-backends-infra--vterm-render-queue nil)
           (vterm--filter proc data))))))
@@ -244,7 +344,7 @@ returns to normal terminal interaction."
   (setq-local cursor-in-non-selected-windows nil)
   (setq-local blink-cursor-mode nil)
   (setq-local cursor-type nil)
-  (when-let ((proc (get-buffer-process (current-buffer))))
+  (when-let* ((proc (get-buffer-process (current-buffer))))
     (set-process-query-on-exit-flag proc nil)
     (when (fboundp 'process-put)
       (process-put proc 'read-output-max 4096)))

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -346,6 +346,94 @@ The result is a cons of whether SYMBOL is bound and its default value."
       (when (file-directory-p root)
         (delete-directory root t)))))
 
+(ert-deftest test-ai-code-backends-infra-vterm-normalize-dim-sgr-uses-ansi-gray ()
+  "SGR dim text without a foreground should use standard ANSI gray."
+  (with-temp-buffer
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[2mtext\e[22m")
+                   "\e[2;90mtext\e[22;39m"))
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[2;4mtext\e[22m")
+                   "\e[2;4;90mtext\e[22;39m"))
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[2;31mtext\e[22m")
+                   "\e[2;31mtext\e[22m"))
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[38;2;1;2;3mtext\e[39m")
+                   "\e[38;2;1;2;3mtext\e[39m"))
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[48;2;1;2;3mtext\e[49m")
+                   "\e[48;2;1;2;3mtext\e[49m"))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-normalize-dim-sgr-preserves-explicit-foreground ()
+  "SGR dim should not override an explicit foreground from an earlier sequence."
+  (with-temp-buffer
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[31mred\e[2mdim\e[22mred")
+                   "\e[31mred\e[2mdim\e[22mred"))
+    (should-not ai-code-backends-infra--vterm-dim-foreground-active)))
+
+(ert-deftest test-ai-code-backends-infra-vterm-normalize-dim-sgr-empty-param-resets ()
+  "Empty SGR parameters should be treated as reset parameters."
+  (with-temp-buffer
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[2;mtext")
+                   "\e[2;mtext"))
+    (should-not ai-code-backends-infra--vterm-dim-foreground-active)))
+
+(ert-deftest test-ai-code-backends-infra-vterm-normalize-dim-sgr-cross-chunk ()
+  "Injected gray foreground should be reset when SGR dim ends later."
+  (with-temp-buffer
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[2mtext")
+                   "\e[2;90mtext"))
+    (should ai-code-backends-infra--vterm-dim-foreground-active)
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    " more")
+                   " more"))
+    (should (equal (ai-code-backends-infra--vterm-normalize-dim-sgr
+                    "\e[22m")
+                   "\e[22;39m"))
+    (should-not ai-code-backends-infra--vterm-dim-foreground-active)))
+
+(ert-deftest test-ai-code-backends-infra-vterm-notification-tracker-normalizes-dim-sgr ()
+  "Vterm session output should normalize dim SGR before rendering."
+  (let ((buffer (generate-new-buffer "*codex[dim-sgr]*"))
+        (process 'fake-process)
+        rendered)
+    (unwind-protect
+        (cl-letf (((symbol-function 'process-buffer)
+                   (lambda (_process) buffer))
+                  ((symbol-function 'ai-code-backends-infra--note-meaningful-output)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ai-code-session-link--schedule-linkify-recent-output)
+                   (lambda (&rest _args) nil)))
+          (ai-code-backends-infra--vterm-notification-tracker
+           (lambda (_process input)
+             (setq rendered input))
+           process
+           "\e[2mplaceholder\e[22m")
+          (should (equal rendered "\e[2;90mplaceholder\e[22;39m")))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-notification-tracker-ignores-non-session ()
+  "Non-AI vterm output should pass through unchanged."
+  (let ((buffer (generate-new-buffer "*vterm*"))
+        (process 'fake-process)
+        rendered)
+    (unwind-protect
+        (cl-letf (((symbol-function 'process-buffer)
+                   (lambda (_process) buffer)))
+          (ai-code-backends-infra--vterm-notification-tracker
+           (lambda (_process input)
+             (setq rendered input))
+           process
+           "\e[2mplaceholder\e[22m")
+          (should (equal rendered "\e[2mplaceholder\e[22m")))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest test-ai-code-backends-infra-response-seen-visible ()
   "Mark responses as seen without notifying when visible."
   (let ((notification-count 0))


### PR DESCRIPTION
## Summary

- Normalize SGR dim output in AI Code vterm sessions by injecting ANSI 90 when no explicit foreground is present.
- Track the injected foreground buffer-locally so cross-chunk SGR 22 resets also restore the default foreground with ANSI 39.
- Preserve explicit foreground colors, extended foreground colors, background-only SGR sequences, and non-AI vterm buffers.

## Why

Some AI CLI placeholders emit SGR 2 without an explicit foreground. In vterm this can render with inconsistent contrast. ANSI 90 is the standard bright-black/gray system palette color used by terminal CLIs for muted text.

## Validation

- `emacs -Q --batch -L . --eval "(setq load-prefer-newer t)" --eval "(let ((default-directory \"/Users/realazy/.emacs.d/elpa/\")) (normal-top-level-add-subdirs-to-load-path))" -l ert -l test/test_ai-code-backends-infra.el -f ert-run-tests-batch-and-exit` passed: 118/118.
- `batch-byte-compile ai-code-backends-infra-vterm.el` passed with byte-compile output redirected to a temp `.elc`.
- `checkdoc-file ai-code-backends-infra-vterm.el` passed.
- Full ERT suite was also attempted: vterm-related tests passed, but the existing suite reported 22 unrelated failures in prompt/gptel/window-list tests under this local Emacs 31 batch environment.