### PR TITLE
Restore Ghostel session state after startup

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Fix: Restore Ghostel session state after startup
 - Fix: Remove citation to ghostel private function (--)
 - Feat: Track Ghostel lifecycle and progress metadata
 - Chore: Prompt for working directory on prefixed AI CLI start/resume

--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -32,9 +32,6 @@
 (declare-function ghostel-send-string "ghostel" (string))
 (declare-function ghostel-paste-string "ghostel" (string))
 
-;; TODO: I just merged this PR: https://github.com/tninja/ai-code-interface.el/pull/414, how this impact ghostel backend user experience? Eg. I didn't see the progress related information in ghostel buffer.
-;; You can find ghostel package source code at: /home/tninja/git/ghostel
-
 (defvar ai-code-backends-infra--session-terminal-backend)
 (eval-when-compile
   (defvar ghostel-command-finish-functions)

--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -32,6 +32,9 @@
 (declare-function ghostel-send-string "ghostel" (string))
 (declare-function ghostel-paste-string "ghostel" (string))
 
+;; TODO: I just merged this PR: https://github.com/tninja/ai-code-interface.el/pull/414, how this impact ghostel backend user experience? Eg. I didn't see the progress related information in ghostel buffer.
+;; You can find ghostel package source code at: /home/tninja/git/ghostel
+
 (defvar ai-code-backends-infra--session-terminal-backend)
 (eval-when-compile
   (defvar ghostel-command-finish-functions)
@@ -65,7 +68,8 @@
   "Return non-nil when BUFFER is an AI Code Ghostel session buffer."
   (when (buffer-live-p (or buffer (current-buffer)))
     (with-current-buffer (or buffer (current-buffer))
-      (eq ai-code-backends-infra--session-terminal-backend 'ghostel))))
+      (and (boundp 'ai-code-backends-infra--session-terminal-backend)
+           (eq ai-code-backends-infra--session-terminal-backend 'ghostel)))))
 
 (defun ai-code-backends-infra-ghostel--update-session-metadata (buffer metadata)
   "Merge METADATA into the AI Code session associated with BUFFER."
@@ -164,6 +168,7 @@ Ghostel owns terminal-model resizing through its mode-local window hooks."
 
 (defun ai-code-backends-infra--configure-ghostel-buffer ()
   "Configure the current Ghostel buffer for AI Code sessions."
+  (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
   (setq-local ghostel-set-title-function nil)
   (setq-local ghostel-kill-buffer-on-exit nil)
   (ai-code-backends-infra-ghostel--install-lifecycle-hooks)
@@ -201,6 +206,9 @@ variables for the terminal process."
       (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
       (let ((default-directory working-dir)
             (proc (ai-code-backends-infra--start-ghostel-process buffer command)))
+        (setq-local default-directory working-dir)
+        (ai-code-backends-infra--set-session-directory buffer working-dir)
+        (ai-code-backends-infra--configure-ghostel-buffer)
         (when (processp proc)
           (ignore-errors
             (set-process-query-on-exit-flag proc nil))

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -17,6 +17,46 @@
 (defvar ghostel-progress-function)
 (defvar ghostel-set-title-function)
 (defvar ghostel-kill-buffer-on-exit)
+(defvar ai-code-backends-infra--session-directory)
+
+(ert-deftest test-ai-code-backends-infra-ghostel-create-session-restores-ai-state ()
+  "Ghostel session creation should restore AI Code local state after mode reset."
+  (let* ((working-dir (file-name-as-directory
+                       (expand-file-name default-directory)))
+         (buffer-name " *ai-code-ghostel-reset-test*")
+         (buffer nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-backends-infra--set-session-directory)
+                   (lambda (target directory)
+                     (with-current-buffer target
+                       (setq-local ai-code-backends-infra--session-directory
+                                   (file-name-as-directory
+                                    (expand-file-name directory))))))
+                  ((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+                   (lambda () nil))
+                  ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+                   (lambda () nil))
+                  ((symbol-function 'ghostel-exec)
+                   (lambda (_buffer _program _args)
+                     (kill-local-variable
+                      'ai-code-backends-infra--session-terminal-backend)
+                     (kill-local-variable
+                      'ai-code-backends-infra--session-directory)
+                     nil)))
+          (setq buffer
+                (car (ai-code-backends-infra-ghostel-create-session
+                      buffer-name working-dir "codex" nil)))
+          (with-current-buffer buffer
+            (should (eq (and (boundp
+                              'ai-code-backends-infra--session-terminal-backend)
+                             ai-code-backends-infra--session-terminal-backend)
+                        'ghostel))
+            (should (equal ai-code-backends-infra--session-directory
+                           working-dir))
+            (should
+             (ai-code-backends-infra-ghostel--ai-session-buffer-p buffer))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-configures-lifecycle-hooks ()
   "Ghostel AI session configuration should install lifecycle hooks locally."


### PR DESCRIPTION
## Summary

This fixes the Ghostel backend losing AI Code session-local state during startup. `ghostel-exec` enters `ghostel-mode`, which resets buffer-local variables; after that reset, the AI Code Ghostel session marker and session directory need to be restored so lifecycle and progress hooks can recognize the buffer as an AI Code Ghostel session.

## Details

- Restore the Ghostel terminal backend marker during Ghostel buffer configuration and after session startup.
- Restore the session directory after `ghostel-exec` so session matching and metadata updates keep working.
- Guard the Ghostel AI-session predicate so ordinary Ghostel buffers without AI Code locals are ignored cleanly.

## Verification

- `emacs -batch -L . -l ert --eval "(load-file \"ai-code-backends-infra-ghostel.el\")" -l test/test_ai-code-backends-infra-ghostel.el -f ert-run-tests-batch-and-exit`