### PR TITLE
Add Ghostel image previews

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,6 +122,9 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 - One of vterm (default), eat, or [[https://github.com/dakra/ghostel][ghostel]] needs to be installed to support native AI coding CLI backends, depending on `ai-code-backends-infra-terminal-backend`.
 - [[https://github.com/dakra/ghostel][ghostel]] is a newly supported native backend infra option.
   - Ghostel is an Emacs terminal emulator powered by libghostty-vt, the VT engine from Ghostty.
+  - AI Code enables Ghostel image support for AI sessions:
+    - terminal programs can use Ghostel's Kitty graphics protocol;
+    - local image paths printed by an AI CLI (for example =screenshot.png=) are previewed inline in the session buffer.
   - [[https://github.com/dakra/ghostel][ghostel]] is under active development, please install the latest version.
   - To try it:
 
@@ -540,6 +543,23 @@ To transfer development work between different AI coding backends (e.g., from Co
 - A: Ghostel trims old output after `ghostel-max-scrollback` bytes are used. The default is 5 MB, so increase it before starting Ghostel sessions.
 #+begin_src elisp
   (setq ghostel-max-scrollback (* 20 1024 1024)) ; 20 MB
+#+end_src
+
+*** Q: How does image display work with the ghostel terminal backend?
+
+- A: Ghostel supports the Kitty graphics protocol. AI Code additionally previews local image file paths printed in Ghostel AI session buffers. You can tune this with:
+#+begin_src elisp
+  ;; Native Kitty graphics file-loading mediums for trusted local sessions.
+  (setq ai-code-backends-infra-ghostel-kitty-graphics-mediums '(file temp-file))
+
+  ;; Inline preview for image paths printed by the AI CLI.
+  (setq ai-code-session-link-ghostel-image-preview-enabled t)
+  (setq ai-code-session-link-ghostel-image-preview-max-bytes (* 10 1024 1024))
+  ;; Display caps in pixels. nil (default) fits the session window and only
+  ;; scales large images down -- small images keep their native size. Set an
+  ;; integer for a fixed hard cap instead.
+  (setq ai-code-session-link-ghostel-image-preview-max-width nil)
+  (setq ai-code-session-link-ghostel-image-preview-max-height nil)
 #+end_src
 
 *** Q: Gemini CLI response is relatively slow, how to improve?

--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -8,10 +8,24 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ai-code-session-link)
 
 ;; Prefer `ghostel-exec' for Ghostel backend startup when available, as
 ;; it simplifies process startup integration.
+
+(defcustom ai-code-backends-infra-ghostel-kitty-graphics-mediums
+  '(file temp-file)
+  "Extra Kitty graphics image-loading mediums for AI Code Ghostel sessions.
+
+Ghostel always supports direct inline image transmission.  Enabling `file'
+and `temp-file' lets trusted local AI CLI tools display image files through
+the Kitty graphics protocol as well.  `shared-mem' is intentionally not
+enabled by default because it widens the terminal's local resource access."
+  :type '(set (const :tag "Local file medium" file)
+              (const :tag "Temp-file medium" temp-file)
+              (const :tag "Shared-memory medium" shared-mem))
+  :group 'ai-code-backends-infra)
 
 (declare-function ai-code-backends-infra--configure-session-input-shortcuts
                   "ai-code-backends-infra" ())
@@ -31,8 +45,17 @@
 (declare-function ghostel-send-key "ghostel" (key-name &optional mods))
 (declare-function ghostel-send-string "ghostel" (string))
 (declare-function ghostel-paste-string "ghostel" (string))
+(declare-function ghostel--run-queued-plain-link-detection
+                  "ghostel" (buffer))
+(declare-function ghostel--redispatch-scroll-event "ghostel" (event))
+(declare-function ghostel-copy-mode "ghostel" ())
+(declare-function ghostel-emacs-mode "ghostel" ())
+(declare-function ai-code-session-link--linkify-strict-image-preview-region
+                  "ai-code-session-link" (start end))
 
 (defvar ai-code-backends-infra--session-terminal-backend)
+(defvar ai-code-backends-infra--session-directory)
+(defvar ghostel-kitty-graphics-mediums)
 (eval-when-compile
   (defvar ghostel-command-finish-functions)
   (defvar ghostel-command-start-functions)
@@ -40,10 +63,38 @@
   (defvar ghostel-progress-function)
   (defvar ghostel-set-title-function)
   (defvar ghostel--copy-mode-active)
-  (defvar ghostel--input-mode))
+  (defvar ghostel--input-mode)
+  (defvar ghostel--plain-link-detection-begin)
+  (defvar ghostel--plain-link-detection-end))
 
 (defvar-local ai-code-backends-infra-ghostel--progress-function nil
   "Original Ghostel progress function captured before AI Code wrapping.")
+
+(defconst ai-code-backends-infra-ghostel--linkify-redraw-delay 0.05
+  "Seconds to wait before relinkifying recent Ghostel output.")
+
+(defcustom ai-code-backends-infra-ghostel-visible-image-linkify-delays
+  '(0.15 0.5)
+  "Delays used to scan visible Ghostel text for image previews.
+
+Only the visible window region is scanned.  This keeps restored session
+history responsive even when Ghostel has a large scrollback."
+  :type '(repeat number)
+  :group 'ai-code-backends-infra)
+
+(defcustom ai-code-backends-infra-ghostel-visible-image-linkify-max-chars
+  20000
+  "Maximum visible Ghostel characters scanned for image previews at once."
+  :type 'integer
+  :group 'ai-code-backends-infra)
+
+(defcustom ai-code-backends-infra-ghostel-scroll-image-linkify-delay 0.08
+  "Debounce delay before scanning visible Ghostel text after scrolling."
+  :type 'number
+  :group 'ai-code-backends-infra)
+
+(defvar-local ai-code-backends-infra-ghostel--visible-image-linkify-timers nil
+  "Alist of (WINDOW . TIMERS) for visible image preview scans.")
 
 (defun ai-code-backends-infra-ghostel-ensure-backend ()
   "Ensure the Ghostel backend is available."
@@ -139,6 +190,244 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
     (setq-local ghostel-progress-function
                 #'ai-code-backends-infra-ghostel--progress)))
 
+(defun ai-code-backends-infra-ghostel--visible-image-region (window)
+  "Return the bounded visible buffer region for WINDOW."
+  (when (and (window-live-p window)
+             (buffer-live-p (window-buffer window)))
+    (with-current-buffer (window-buffer window)
+      (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+        (save-excursion
+          (save-restriction
+            (widen)
+            (let* ((start (max (point-min) (window-start window)))
+                   (end (or (ignore-errors (window-end window t))
+                            (min (point-max)
+                                 (+ start
+                                    ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
+                   (end (min (point-max) end)))
+              (when (> (- end start)
+                       ai-code-backends-infra-ghostel-visible-image-linkify-max-chars)
+                (setq start (max (point-min)
+                                 (- end
+                                    ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
+              (goto-char start)
+              (setq start (line-beginning-position))
+              (goto-char end)
+              (setq end (min (point-max) (line-end-position)))
+              (when (> (- end start)
+                       ai-code-backends-infra-ghostel-visible-image-linkify-max-chars)
+                (setq end (min (point-max)
+                                (+ start
+                                   ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
+              (and (< start end) (cons start end)))))))))
+
+(defun ai-code-backends-infra-ghostel--trusted-local-session-p ()
+  "Return non-nil when this Ghostel session can safely read local files."
+  (not (file-remote-p
+        (or ai-code-backends-infra--session-directory
+            default-directory))))
+
+(defun ai-code-backends-infra-ghostel--linkify-visible-image-previews
+    (buffer window)
+  "Linkify image previews for visible text in BUFFER shown by WINDOW."
+  (when (and (buffer-live-p buffer)
+             (window-live-p window)
+             (eq (window-buffer window) buffer))
+    (with-current-buffer buffer
+      (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
+      (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
+        (when-let* ((region
+                     (ai-code-backends-infra-ghostel--visible-image-region
+                      window)))
+          (ai-code-session-link--linkify-strict-image-preview-region
+           (car region)
+           (cdr region)))))))
+
+(defun ai-code-backends-infra-ghostel--cancel-visible-image-linkify-timers
+    (window)
+  "Cancel visible image preview scan timers registered for WINDOW."
+  (when-let* ((entry
+               (assq window
+                     ai-code-backends-infra-ghostel--visible-image-linkify-timers)))
+    (dolist (timer (cdr entry))
+      (when (timerp timer)
+        (cancel-timer timer)))
+    (setq ai-code-backends-infra-ghostel--visible-image-linkify-timers
+          (assq-delete-all
+           window
+           ai-code-backends-infra-ghostel--visible-image-linkify-timers))))
+
+(defun ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers ()
+  "Remove visible image preview scan timer entries for dead windows."
+  (setq ai-code-backends-infra-ghostel--visible-image-linkify-timers
+        (cl-remove-if-not
+         (lambda (entry)
+           (and (consp entry)
+                (window-live-p (car entry))))
+         ai-code-backends-infra-ghostel--visible-image-linkify-timers)))
+
+(defun ai-code-backends-infra-ghostel--register-visible-image-linkify-timers
+    (window timers)
+  "Register visible image preview scan TIMERS for WINDOW."
+  (push (cons window timers)
+        ai-code-backends-infra-ghostel--visible-image-linkify-timers))
+
+(defun ai-code-backends-infra-ghostel--linkify-image-preview-region
+    (buffer start end)
+  "Linkify image previews in BUFFER between START and END.
+The region is bounded so Ghostel redraw/link-detection advice cannot
+accidentally scan an entire scrollback buffer."
+  (when (and (buffer-live-p buffer)
+             (integer-or-marker-p start)
+             (integer-or-marker-p end))
+    (with-current-buffer buffer
+      (when (and (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+                 (ai-code-backends-infra-ghostel--trusted-local-session-p))
+        (save-restriction
+          (widen)
+          (let ((start (if (markerp start) (marker-position start) start))
+                (end (if (markerp end) (marker-position end) end)))
+            (setq start (max (point-min) (min (point-max) start))
+                  end (max (point-min) (min (point-max) end)))
+            (when (< start end)
+              (when (> (- end start)
+                       ai-code-backends-infra-ghostel-visible-image-linkify-max-chars)
+                (setq start
+                      (max (point-min)
+                           (- end
+                              ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
+              (save-excursion
+                (goto-char start)
+                (setq start (line-beginning-position))
+                (goto-char end)
+                (setq end (min (point-max) (line-end-position)))
+                (when (> (- end start)
+                         ai-code-backends-infra-ghostel-visible-image-linkify-max-chars)
+                  (setq start
+                        (max (point-min)
+                             (- end
+                                ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
+                (when (< start end)
+                  (ai-code-session-link--linkify-strict-image-preview-region
+                   start end))))))))))
+
+(defun ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+    (window &optional delays)
+  "Schedule image preview linkification for visible Ghostel text in WINDOW.
+Optional DELAYS overrides
+`ai-code-backends-infra-ghostel-visible-image-linkify-delays'."
+  (when (and (window-live-p window)
+             (buffer-live-p (window-buffer window)))
+    (let ((buffer (window-buffer window)))
+      (when (ai-code-backends-infra-ghostel--ai-session-buffer-p buffer)
+        (with-current-buffer buffer
+          (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
+          (ai-code-backends-infra-ghostel--cancel-visible-image-linkify-timers
+           window)
+          (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
+            (let ((timers
+                   (mapcar
+                    (lambda (delay)
+                      (run-at-time
+                       delay nil
+                       #'ai-code-backends-infra-ghostel--linkify-visible-image-previews
+                       buffer window))
+                    (or delays
+                        ai-code-backends-infra-ghostel-visible-image-linkify-delays))))
+              (ai-code-backends-infra-ghostel--register-visible-image-linkify-timers
+               window timers))))))))
+
+(defun ai-code-backends-infra-ghostel-schedule-visible-image-linkify-for-buffer
+    (&optional buffer delays)
+  "Schedule visible image preview linkification for BUFFER's live windows.
+Optional DELAYS overrides the default visible image linkification delays."
+  (let ((buffer (or buffer (current-buffer))))
+    (when (buffer-live-p buffer)
+      (dolist (window (get-buffer-window-list buffer nil t))
+        (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+         window delays)))))
+
+(defun ai-code-backends-infra-ghostel--window-scroll (window _display-start)
+  "Schedule visible image preview linkification after WINDOW scrolls."
+  (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+   window
+   (list ai-code-backends-infra-ghostel-scroll-image-linkify-delay)))
+
+(defun ai-code-backends-infra-ghostel--after-readonly-command (&rest _args)
+  "Schedule visible image preview linkification after Ghostel mode changes."
+  (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+    (ai-code-backends-infra-ghostel-schedule-visible-image-linkify-for-buffer
+     (current-buffer))))
+
+(defun ai-code-backends-infra-ghostel--after-redispatch-scroll-event (event)
+  "Schedule visible image preview linkification after Ghostel scroll EVENT."
+  (when-let* ((window (ignore-errors (posn-window (event-start event))))
+              ((window-live-p window)))
+    (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+     window
+     (list ai-code-backends-infra-ghostel-scroll-image-linkify-delay))))
+
+(defun ai-code-backends-infra-ghostel--run-queued-link-detection-around
+    (original buffer)
+  "Run ORIGINAL Ghostel link detection in BUFFER and add image previews."
+  (let (start end)
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+          (setq start (and (boundp 'ghostel--plain-link-detection-begin)
+                           ghostel--plain-link-detection-begin)
+                end (and (boundp 'ghostel--plain-link-detection-end)
+                         ghostel--plain-link-detection-end)))))
+    (prog1 (funcall original buffer)
+      (when (and start end)
+        (ai-code-backends-infra-ghostel--linkify-image-preview-region
+         buffer start end)))))
+
+(defun ai-code-backends-infra-ghostel--install-image-preview-advice ()
+  "Install Ghostel advice used to add and refresh image previews."
+  (when (and (fboundp 'ghostel--run-queued-plain-link-detection)
+             (not (advice-member-p
+                   #'ai-code-backends-infra-ghostel--run-queued-link-detection-around
+                   'ghostel--run-queued-plain-link-detection)))
+    (advice-add 'ghostel--run-queued-plain-link-detection
+                :around
+                #'ai-code-backends-infra-ghostel--run-queued-link-detection-around))
+  (when (and (fboundp 'ghostel--redispatch-scroll-event)
+             (not (advice-member-p
+                   #'ai-code-backends-infra-ghostel--after-redispatch-scroll-event
+                   'ghostel--redispatch-scroll-event)))
+    (advice-add 'ghostel--redispatch-scroll-event
+                :after
+                #'ai-code-backends-infra-ghostel--after-redispatch-scroll-event))
+  (when (and (fboundp 'ghostel-copy-mode)
+             (not (advice-member-p
+                   #'ai-code-backends-infra-ghostel--after-readonly-command
+                   'ghostel-copy-mode)))
+    (advice-add 'ghostel-copy-mode
+                :after
+                #'ai-code-backends-infra-ghostel--after-readonly-command))
+  (when (and (fboundp 'ghostel-emacs-mode)
+             (not (advice-member-p
+                   #'ai-code-backends-infra-ghostel--after-readonly-command
+                   'ghostel-emacs-mode)))
+    (advice-add 'ghostel-emacs-mode
+                :after
+                #'ai-code-backends-infra-ghostel--after-readonly-command)))
+
+(defun ai-code-backends-infra-ghostel--effective-kitty-graphics-mediums ()
+  "Return Kitty graphics mediums for the current AI Code Ghostel session."
+  (delete-dups
+   (append (and (ai-code-backends-infra-ghostel--trusted-local-session-p)
+                ai-code-backends-infra-ghostel-kitty-graphics-mediums)
+           (and (boundp 'ghostel-kitty-graphics-mediums)
+                ghostel-kitty-graphics-mediums))))
+
+(defun ai-code-backends-infra-ghostel--configure-image-support ()
+  "Configure Ghostel image support for the current AI Code session."
+  (when (boundp 'ghostel-kitty-graphics-mediums)
+    (setq-local ghostel-kitty-graphics-mediums
+                (ai-code-backends-infra-ghostel--effective-kitty-graphics-mediums))))
+
 (defun ai-code-backends-infra-ghostel-send-string (string &optional paste)
   "Send STRING to the current Ghostel process.
 If PASTE is non-nil, send it as a pasted string."
@@ -168,7 +457,11 @@ Ghostel owns terminal-model resizing through its mode-local window hooks."
   (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
   (setq-local ghostel-set-title-function nil)
   (setq-local ghostel-kill-buffer-on-exit nil)
+  (ai-code-backends-infra-ghostel--configure-image-support)
   (ai-code-backends-infra-ghostel--install-lifecycle-hooks)
+  (ai-code-backends-infra-ghostel--install-image-preview-advice)
+  (add-hook 'window-scroll-functions
+            #'ai-code-backends-infra-ghostel--window-scroll nil t)
   (ai-code-backends-infra--configure-session-input-shortcuts)
   (ai-code-backends-infra--install-navigation-cursor-sync))
 
@@ -182,7 +475,10 @@ Ghostel owns terminal-model resizing through its mode-local window hooks."
       (cond
        ((not program) nil)
        ((fboundp 'ghostel-exec)
-        (let ((proc (ghostel-exec buffer program args)))
+        (let ((proc
+               (let ((ghostel-kitty-graphics-mediums
+                      (ai-code-backends-infra-ghostel--effective-kitty-graphics-mediums)))
+                 (ghostel-exec buffer program args))))
           ;; `ghostel-exec' enters `ghostel-mode', which resets local state.
           (ai-code-backends-infra--configure-ghostel-buffer)
           proc))
@@ -209,7 +505,7 @@ variables for the terminal process."
         (when (processp proc)
           (ignore-errors
             (set-process-query-on-exit-flag proc nil))
-          (when-let ((sentinel (ignore-errors (process-sentinel proc))))
+          (when-let* ((sentinel (ignore-errors (process-sentinel proc))))
             (ignore-errors
               (process-put proc
                            'ai-code-backends-infra--ghostel-sentinel
@@ -225,7 +521,10 @@ variables for the terminal process."
                    (with-current-buffer buffer
                      (when (ai-code-backends-infra--output-meaningful-p output)
                        (ai-code-backends-infra--note-meaningful-output))
-                     (ai-code-session-link--linkify-recent-output output))))))))
+                     (ai-code-session-link--schedule-linkify-recent-output
+                      buffer
+                      output
+                      ai-code-backends-infra-ghostel--linkify-redraw-delay))))))))
         (cons buffer proc)))))
 
 (provide 'ai-code-backends-infra-ghostel)

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -224,7 +224,7 @@ to t via their post-start-fn.")
   "Return a sequence that pushes visible content into scrollback.
 Move cursor to the last row, emit enough newlines to scroll all
 visible lines into the scrollback buffer, then cursor home."
-  (let ((height (or (when-let ((win (get-buffer-window (current-buffer) t)))
+  (let ((height (or (when-let* ((win (get-buffer-window (current-buffer) t)))
                       (window-body-height win))
                     50)))
     (concat "\033[" (number-to-string height) ";1H"
@@ -551,7 +551,7 @@ When BACKEND is nil, use `ai-code-backends-infra-terminal-backend'."
 
 (defun ai-code-backends-infra--session-buffer-p (buffer)
   "Check if BUFFER belongs to an AI session."
-  (when-let ((name (if (stringp buffer) buffer (buffer-name buffer))))
+  (when-let* ((name (if (stringp buffer) buffer (buffer-name buffer))))
     (string-match-p "\\`\\*.*\\[.*\\].*\\*\\'" name)))
 
 (defun ai-code-backends-infra--terminal-reflow-filter (original-fn &rest args)
@@ -641,7 +641,11 @@ buffer is in scroll/copy mode, working around bug #1422."
     ;; The buffer may have been created with different dimensions before
     ;; being displayed in this window.
     (when (and window (buffer-live-p buffer))
-      (ai-code-backends-infra--sync-terminal-dimensions buffer window))
+      (ai-code-backends-infra--sync-terminal-dimensions buffer window)
+      (with-current-buffer buffer
+        (when (eq ai-code-backends-infra--session-terminal-backend 'ghostel)
+          (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+           window))))
     window))
 
 (defun ai-code-backends-infra--fit-side-window-body-width (window)
@@ -658,7 +662,7 @@ the buffer has been displayed in its final window, which may differ
 from the window where it was initially created."
   (when (and buffer window (buffer-live-p buffer) (window-live-p window))
     (with-current-buffer buffer
-      (when-let ((proc (get-buffer-process buffer)))
+      (when-let* ((proc (get-buffer-process buffer)))
         (let ((backend (ai-code-backends-infra--current-terminal-backend))
               (windows (or (get-buffer-window-list buffer nil t)
                            (list window))))
@@ -736,7 +740,7 @@ use the branch name."
 
 (defun ai-code-backends-infra--remember-file-session-buffer (prefix source-buffer session-buffer)
   "Remember SESSION-BUFFER as attached session for SOURCE-BUFFER and PREFIX."
-  (when-let ((key (ai-code-backends-infra--file-session-map-key prefix source-buffer)))
+  (when-let* ((key (ai-code-backends-infra--file-session-map-key prefix source-buffer)))
     (if (and session-buffer (buffer-live-p session-buffer))
         (puthash key session-buffer ai-code-backends-infra--file-session-map)
       (remhash key ai-code-backends-infra--file-session-map))))
@@ -899,7 +903,7 @@ Return a cons of (base-name . instance-name) or nil."
 
 (defun ai-code-backends-infra--session-instance-name (buffer-name prefix)
   "Return instance name for BUFFER-NAME with PREFIX."
-  (when-let ((parsed (ai-code-backends-infra--parse-session-buffer-name buffer-name prefix)))
+  (when-let* ((parsed (ai-code-backends-infra--parse-session-buffer-name buffer-name prefix)))
     (ai-code-backends-infra--normalize-instance-name (cdr parsed))))
 
 (defun ai-code-backends-infra--find-session-buffers (prefix directory)
@@ -908,10 +912,10 @@ Return a cons of (base-name . instance-name) or nil."
         (target-directory (ai-code-backends-infra--normalize-session-directory directory)))
     (cl-remove-if-not
      (lambda (buf)
-       (when-let ((parsed (ai-code-backends-infra--parse-session-buffer-name
-                           (buffer-name buf)
-                           prefix)))
-         (if-let ((buffer-directory (ai-code-backends-infra--buffer-session-directory buf)))
+       (when-let* ((parsed (ai-code-backends-infra--parse-session-buffer-name
+                            (buffer-name buf)
+                            prefix)))
+         (if-let* ((buffer-directory (ai-code-backends-infra--buffer-session-directory buf)))
              (string= (ai-code-backends-infra--normalize-session-directory buffer-directory)
                       target-directory)
            (string= (car parsed) base))))
@@ -935,8 +939,8 @@ Return a cons of (base-name . instance-name) or nil."
 (defun ai-code-backends-infra--session-buffer-matches-directory-p (buffer directory)
   "Return non-nil when BUFFER is live and still belongs to DIRECTORY."
   (and (buffer-live-p buffer)
-       (when-let ((buffer-directory
-                   (ai-code-backends-infra--buffer-session-directory buffer)))
+       (when-let* ((buffer-directory
+                    (ai-code-backends-infra--buffer-session-directory buffer)))
          (string=
           (ai-code-backends-infra--normalize-session-directory buffer-directory)
           (ai-code-backends-infra--normalize-session-directory directory)))))
@@ -968,10 +972,10 @@ Returns the selected buffer or nil if none exist."
                                 buffers))
              (choices (delq nil
                             (mapcar (lambda (buf)
-                                      (when-let ((instance
-                                                  (ai-code-backends-infra--session-instance-name
-                                                   (buffer-name buf)
-                                                   prefix)))
+                                      (when-let* ((instance
+                                                   (ai-code-backends-infra--session-instance-name
+                                                    (buffer-name buf)
+                                                    prefix)))
                                         (cons instance buf)))
                                     ordered-buffers)))
              (candidates (mapcar #'car choices))
@@ -1065,7 +1069,7 @@ any error output left behind by the CLI."
                                  "default"))
          (key (ai-code-backends-infra--session-key directory resolved-instance)))
     (remhash key process-table))
-  (when-let ((buffer (get-buffer buffer-name)))
+  (when-let* ((buffer (get-buffer buffer-name)))
     (ai-code-backends-infra--forget-session-buffer prefix directory buffer)
     (ai-code-session-unregister buffer)
     (when (buffer-live-p buffer)
@@ -1237,7 +1241,7 @@ When :prepare-launch is present, it may return :command, :cleanup-fn, and
                           (ai-code-backends-infra--session-working-directory arg)
                         (ai-code-backends-infra--session-working-directory)))
          (command (plist-get resolved :command))
-         (launch (when-let ((prepare-launch (plist-get options :prepare-launch)))
+         (launch (when-let* ((prepare-launch (plist-get options :prepare-launch)))
                    (funcall prepare-launch working-dir command)))
          (launch-command (or (plist-get launch :command) command))
          (cleanup-fn (plist-get launch :cleanup-fn))
@@ -1466,7 +1470,7 @@ When PREFIX and WORKING-DIR are provided, select from multiple sessions."
                   working-dir
                   force-prompt
                   source-buffer)))
-    (if-let ((window (get-buffer-window buffer)))
+    (if-let* ((window (get-buffer-window buffer)))
         (select-window window)
       (ai-code-backends-infra--display-buffer-in-side-window buffer))))
 

--- a/ai-code-input.el
+++ b/ai-code-input.el
@@ -160,8 +160,8 @@ perform that action."
 
 (defun ai-code--speech-to-text-send-prompt (origin-buffer transcription)
   "Edit TRANSCRIPTION from ORIGIN-BUFFER and send the result to the AI session."
-  (when-let ((prompt (with-current-buffer origin-buffer
-                       (ai-code-read-string "Send to AI: " transcription))))
+  (when-let* ((prompt (with-current-buffer origin-buffer
+                        (ai-code-read-string "Send to AI: " transcription))))
     (require 'ai-code-prompt-mode)
     (ai-code--insert-prompt prompt)))
 
@@ -235,7 +235,7 @@ original buffer, send it to an AI coding session, or copy it to the clipboard."
 
 (defun ai-code--imenu-symbol-from-position (payload)
   "Extract a symbol name from PAYLOAD position as fallback."
-  (when-let ((pos (ai-code--imenu-item-position payload)))
+  (when-let* ((pos (ai-code--imenu-item-position payload)))
     (save-excursion
       (goto-char pos)
       (ai-code--extract-symbol-from-line
@@ -266,7 +266,7 @@ original buffer, send it to an AI coding session, or copy it to the clipboard."
               (payload (cdr item)))
           (if (ai-code--imenu-subalist-p payload)
               (setq result (append result (ai-code--flatten-imenu-index payload)))
-            (when-let ((symbol (ai-code--normalize-imenu-symbol-name name payload)))
+            (when-let* ((symbol (ai-code--normalize-imenu-symbol-name name payload)))
               (push symbol result))))))
     result))
 
@@ -313,7 +313,7 @@ original buffer, send it to an AI coding session, or copy it to the clipboard."
 (defun ai-code--hash-completion-target-file (&optional end-pos)
   "Return an absolute file path for @relative path ending at END-POS.
 END-POS defaults to the current '#' position."
-  (when-let ((git-root (ai-code--git-root)))
+  (when-let* ((git-root (ai-code--git-root)))
     (let* ((end (or end-pos (1- (point))))
            (start (save-excursion
                     (goto-char end)
@@ -442,7 +442,7 @@ END-POS defaults to the current '#' position."
          (file (and should-complete
                     (ai-code--hash-completion-target-file (point)))))
     (ai-code-backends-infra--terminal-send-string "#")
-    (when-let ((symbol (and file (ai-code--choose-symbol-from-file file))))
+    (when-let* ((symbol (and file (ai-code--choose-symbol-from-file file))))
       (when (not (string-empty-p symbol))
         (ai-code-backends-infra--terminal-send-backspace)
         (ai-code-backends-infra--terminal-send-string (concat "#" symbol))))))
@@ -527,7 +527,7 @@ END-POS defaults to the current '#' position."
 
 (defun ai-code--session-link-bounds-at-point ()
   "Return bounds of the clickable session link at point, or nil."
-  (if-let ((text (ai-code--session-link-property-at-point)))
+  (if-let* ((text (ai-code--session-link-property-at-point)))
       (let* ((prop-pos (if (get-text-property (point) 'ai-code-session-link)
                            (point)
                          (1- (point))))
@@ -555,7 +555,7 @@ END-POS defaults to the current '#' position."
 (defun ai-code--session-link-text-at-point ()
   "Return the clickable session link text at point, or nil."
   (or (ai-code--session-link-property-at-point)
-      (when-let ((bounds (ai-code--session-link-bounds-at-point)))
+      (when-let* ((bounds (ai-code--session-link-bounds-at-point)))
         (buffer-substring-no-properties (car bounds) (cdr bounds)))))
 
 (defun ai-code--parse-session-link (text)
@@ -625,14 +625,14 @@ END-POS defaults to the current '#' position."
 
 (defun ai-code--existing-absolute-session-path (filename)
   "Return an existing absolute local path for FILENAME, or nil."
-  (when-let ((normalized (ai-code-session-link--normalize-file filename)))
+  (when-let* ((normalized (ai-code-session-link--normalize-file filename)))
     (when (file-name-absolute-p normalized)
       (ai-code-session-link--resolve-existing-local-path normalized nil))))
 
 (defun ai-code--find-project-file (filename)
   "Locate FILENAME within the current project."
   (or (ai-code--existing-absolute-session-path filename)
-        (when-let ((candidates (ai-code--project-file-candidates filename)))
+        (when-let* ((candidates (ai-code--project-file-candidates filename)))
           (if (= (length candidates) 1)
               (car candidates)
             (ai-code--read-session-link-candidate
@@ -651,15 +651,22 @@ END-POS defaults to the current '#' position."
         (goto-char position)
         (ai-code-session-navigate-link-at-point)))))
 
-(defun ai-code--open-session-link-file (text link)
-  "Open the file described by LINK for session link TEXT."
+(defun ai-code--session-image-link-file-at-point (text)
+  "Return the resolved image file for session link TEXT at point."
+  (and text
+       (ai-code-session-link--image-preview-link-file text)))
+
+(defun ai-code--open-session-link-file (text link &optional resolved-file)
+  "Open the file described by LINK for session link TEXT.
+Optional RESOLVED-FILE is an existing absolute file path to open directly."
   (when-let* ((file (plist-get link :file))
-              (abs-file (ai-code--find-project-file file)))
+              (abs-file (or resolved-file
+                            (ai-code--find-project-file file))))
     (find-file-other-window abs-file)
-    (when-let ((line-start (plist-get link :line-start)))
+    (when-let* ((line-start (plist-get link :line-start)))
       (goto-char (point-min))
       (forward-line (1- line-start))
-      (when-let ((column-start (plist-get link :column-start)))
+      (when-let* ((column-start (plist-get link :column-start)))
         (when (> column-start 0)
           (move-to-column (1- column-start)))))
     (message "Navigated to %s" text)
@@ -670,15 +677,18 @@ END-POS defaults to the current '#' position."
   "Navigate to the file or URL session link at point."
   (interactive)
   (let* ((text (ai-code--session-link-text-at-point))
-         (link (and text (ai-code--parse-session-link text))))
+         (link (and text (ai-code--parse-session-link text)))
+         (image-file
+          (and link
+               (ai-code--session-image-link-file-at-point text))))
     (cond
      ((not link)
       (message "No code link found at point"))
-     ((when-let ((url (plist-get link :url)))
+     ((when-let* ((url (plist-get link :url)))
         (browse-url url)
         (message "Opened URL: %s" url)
         t))
-     ((ai-code--open-session-link-file text link))
+     ((ai-code--open-session-link-file text link image-file))
      (t
       (message "No code link found at point")))))
 

--- a/ai-code-session-link.el
+++ b/ai-code-session-link.el
@@ -9,8 +9,11 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'image)
 (require 'project)
+(require 'rx)
 (require 'subr-x)
+(require 'url-util)
 
 (declare-function ai-code-session-navigate-link-at-mouse "ai-code-input" (event))
 (declare-function ai-code-session-navigate-link-at-point "ai-code-input" ())
@@ -20,6 +23,9 @@
 (defvar ai-code-backends-infra--session-directory nil
   "Session working directory set by ai-code-backends-infra buffers.")
 
+(defvar ai-code-backends-infra--session-terminal-backend nil
+  "Terminal backend symbol set by ai-code-backends-infra buffers.")
+
 (defcustom ai-code-session-link-enabled t
   "When non-nil, make supported links clickable in AI session buffers.
 
@@ -27,6 +33,48 @@ Disable this if you prefer to avoid the extra linkification work on
 terminal output redraw."
   :type 'boolean
   :group 'ai-code)
+
+(defcustom ai-code-session-link-ghostel-image-preview-enabled t
+  "When non-nil, preview local image file links in Ghostel AI sessions.
+
+This only affects AI session buffers managed by the Ghostel terminal backend.
+It complements Ghostel's native Kitty graphics support by previewing image
+files when an AI CLI prints a local image path such as screenshot.png."
+  :type 'boolean
+  :group 'ai-code)
+
+(defcustom ai-code-session-link-ghostel-image-preview-max-bytes
+  (* 10 1024 1024)
+  "Maximum local image file size, in bytes, previewed in Ghostel sessions."
+  :type 'integer
+  :group 'ai-code)
+
+(defcustom ai-code-session-link-ghostel-image-preview-max-width nil
+  "Maximum displayed image width for Ghostel session previews, in pixels.
+When nil, previews fit the session window's body width.  Previews only ever
+scale down, so small images keep their native size either way.  Set an
+integer to impose a fixed hard cap instead."
+  :type '(choice (const :tag "Fit session window" nil)
+                 (integer :tag "Fixed pixel cap"))
+  :group 'ai-code)
+
+(defcustom ai-code-session-link-ghostel-image-preview-max-height nil
+  "Maximum displayed image height for Ghostel session previews, in pixels.
+When nil, preview height is not capped; the width cap controls default
+scaling and tall previews can be inspected by scrolling.  Set an integer to
+impose a fixed hard cap instead."
+  :type '(choice (const :tag "No height cap" nil)
+                 (integer :tag "Fixed pixel cap"))
+  :group 'ai-code)
+
+(defconst ai-code-session-link--visible-image-preview-max-line-width 2048
+  "Maximum candidate width inspected by strict visible image preview scanning.")
+
+(defconst ai-code-session-link--visible-image-preview-max-candidates 8
+  "Maximum image candidates inspected by one strict visible preview scan.")
+
+(defconst ai-code-session-link--visible-image-preview-prefix-max-lines 8
+  "Maximum previous terminal rows used to rebuild a wrapped image path.")
 
 (defvar ai-code-session-link--keymap
   (let ((map (make-sparse-keymap)))
@@ -44,8 +92,19 @@ terminal output redraw."
     map)
   "Keymap used for clickable session symbols.")
 
+(defvar ai-code-session-link--image-preview-keymap
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mouse-1] #'ai-code-session-link--ignore-image-preview-event)
+    (define-key map [mouse-2] #'ai-code-session-link--ignore-image-preview-event)
+    (define-key map (kbd "RET") #'ai-code-session-link--ignore-image-preview-event)
+    map)
+  "Keymap used to keep inline image previews from opening file links.")
+
 (defconst ai-code-session-link--linkify-min-tail-width 512
   "Minimum number of tail characters to rescan for session links.")
+
+(defconst ai-code-session-link--linkify-redraw-delay 0
+  "Seconds to wait before relinkifying recent terminal output.")
 
 (defconst ai-code-session-link--url-pattern-regexp
   "\\(https?://[^][(){}<>\"' \t\n]+\\)"
@@ -64,8 +123,30 @@ terminal output redraw."
   "Maximum number of symbol links to apply near one file link.")
 
 (defconst ai-code-session-link--path-base-regexp
-  "@?[[:alnum:]_./~-]*[./][[:alnum:]_./~-]+"
+  "@?\\(?:file:\\(?://localhost\\|//\\)?\\)?[[:alnum:]_./~%+-]*[./][[:alnum:]_./~%+-]+"
   "Regexp matching a local file-like or directory-like path.")
+
+(defconst ai-code-session-link--path-fragment-regexp
+  "[-[:alnum:]_./~%+:\\\\]+"
+  "Regexp matching one terminal row fragment of a local path.")
+
+(defconst ai-code-session-link--wrapped-path-max-lines 8
+  "Maximum number of terminal rows inspected for one wrapped path.")
+
+(defconst ai-code-session-link--file-suffix-regexp
+  (concat
+   "\\(?:"
+   "#L[0-9]+\\(?:-L?[0-9]+\\)?"
+   "\\|"
+   ":L[0-9]+\\(?:-L?[0-9]+\\)?"
+   "\\|"
+   ":[0-9]+:[0-9]+\\>"
+   "\\|"
+   ":[0-9]+-[0-9]+\\>"
+   "\\|"
+   ":[0-9]+\\>"
+   "\\)")
+  "Regexp matching the optional line or column suffix of a file link.")
 
 (defconst ai-code-session-link--symbol-identifier-regexp
   "[[:alpha:]_][[:alnum:]_*!?]*"
@@ -157,6 +238,87 @@ terminal output redraw."
     "xml" "yaml" "yml" "zsh")
   "Lowercase extensions accepted for basename file links.")
 
+(defconst ai-code-session-link--image-file-extensions
+  '("apng" "avif" "bmp" "gif" "heic" "heif" "jpeg" "jpg" "pbm" "pgm"
+    "png" "ppm" "svg" "tif" "tiff" "webp" "xbm" "xpm")
+  "Lowercase image extensions accepted for Ghostel session previews.")
+
+(defconst ai-code-session-link--file-url-prefix-regexp
+  "file:\\(?://localhost\\|//\\)?"
+  "Regexp matching local file URL prefixes accepted in session output.")
+
+(defconst ai-code-session-link--image-extension-regexp
+  (regexp-opt ai-code-session-link--image-file-extensions)
+  "Regexp matching image extensions accepted for Ghostel previews.")
+
+(defconst ai-code-session-link--wrapped-path-continuation-regexp
+  "\\(?:\n[ \t]*[-[:alnum:]_./~%+:\\\\]+\\)*"
+  "Regexp matching terminal-wrapped continuation segments of a path.
+Ghostel hard-wraps long lines, so a single file path can span several
+terminal rows (a common case for tools, such as Claude, that print bare
+paths rather than `file://' URLs).  Each continuation row is glued back
+together by `ai-code-session-link--normalize-file', which strips the
+embedded newline and leading indentation.")
+
+(defconst ai-code-session-link--file-url-image-regexp
+  (concat
+   "\\(" ai-code-session-link--file-url-prefix-regexp
+   "\\(?:[-[:alnum:]_./~%+:\\\\]+\\|\n[ \t]*[-[:alnum:]_./~%+:\\\\]+\\)+"
+   "\\.\\(?:"
+   ai-code-session-link--image-extension-regexp
+   "\\)\\)")
+  "Regexp matching file URL image references, including terminal wrapping.")
+
+(defconst ai-code-session-link--local-image-path-regexp
+  (concat
+   "\\(?:~\\|/\\|\\.\\.?/\\|[[:alnum:]_.~-]+/\\)"
+   "[^][(){}<>\"'\n\r]*"
+   ai-code-session-link--wrapped-path-continuation-regexp
+   "\\.\\(?:"
+   ai-code-session-link--image-extension-regexp
+   "\\)")
+  "Regexp matching local image paths that may contain spaces.
+Tolerates Ghostel hard-wrapping via
+`ai-code-session-link--wrapped-path-continuation-regexp'.")
+
+(defconst ai-code-session-link--wrapped-image-reference-regexp
+  (concat
+   "[^][(){}<>\"'\n\r]*"
+   ai-code-session-link--wrapped-path-continuation-regexp
+   "\\.\\(?:"
+   ai-code-session-link--image-extension-regexp
+   "\\)")
+  "Regexp matching image references inside an explicit wrapper.
+Tolerates Ghostel hard-wrapping via
+`ai-code-session-link--wrapped-path-continuation-regexp'.")
+
+(defconst ai-code-session-link--image-reference-patterns
+  (list
+   (list ai-code-session-link--file-url-image-regexp 1)
+   (list (concat "[\"'`]\\(" ai-code-session-link--wrapped-image-reference-regexp "\\)[\"'`]")
+         1)
+   (list (concat "[(<]\\(" ai-code-session-link--wrapped-image-reference-regexp "\\)[)>]")
+         1)
+   (list (concat "\\[\\[\\(file:[^]\n\r]*\\.\\(?:"
+                 ai-code-session-link--image-extension-regexp
+                 "\\)\\)\\(?:\\]\\[[^]\n\r]*\\)?\\]\\]")
+         1)
+   (list (concat "\\(?:^\\|[ \t:]\\)\\(" ai-code-session-link--local-image-path-regexp "\\)")
+         1))
+  "Patterns used to detect image file references with looser path syntax.")
+
+(defconst ai-code-session-link--reference-wrapper-left-regexp
+  (rx (+ (any "\"'`<([{")))
+  "Regexp matching wrapper characters before a session file reference.")
+
+(defconst ai-code-session-link--reference-wrapper-right-regexp
+  (rx (+ (any "\"'`>)}],.;:!?")))
+  "Regexp matching wrapper characters after a session file reference.")
+
+(defconst ai-code-session-link--unicode-trailing-punctuation-categories
+  '(Pe Pf Po)
+  "Unicode general categories accepted after image preview anchors.")
+
 (defvar-local ai-code-session-link--linkify-timer nil
   "Timer used to re-linkify recent terminal output after redraw settles.")
 
@@ -185,10 +347,32 @@ terminal output redraw."
   "Normalize session link FILENAME for project lookup."
   (when (stringp filename)
     (let* ((trimmed (string-trim filename))
-           (without-at (string-remove-prefix "@" trimmed))
-           (normalized (string-remove-prefix "file://" without-at)))
+           (unwrapped (replace-regexp-in-string "[\n\r][ \t]*" "" trimmed))
+           (without-wrappers
+            (string-trim
+             unwrapped
+             ai-code-session-link--reference-wrapper-left-regexp
+             ai-code-session-link--reference-wrapper-right-regexp))
+           (without-at (string-remove-prefix "@" without-wrappers))
+           (file-url-p (string-match-p "\\`file:" without-at))
+           (without-file-prefix
+            (replace-regexp-in-string
+             (concat "\\`" ai-code-session-link--file-url-prefix-regexp)
+             "" without-at))
+           (without-shell-escaped-spaces
+            (replace-regexp-in-string "\\\\ " " " without-file-prefix))
+           (normalized (if file-url-p
+                           (or (ignore-errors
+                                 (url-unhex-string without-shell-escaped-spaces))
+                               without-shell-escaped-spaces)
+                         without-shell-escaped-spaces)))
       (unless (string-empty-p normalized)
         normalized))))
+
+(defun ai-code-session-link--normalize-link-text (text)
+  "Normalize visible session link TEXT for stored navigation data."
+  (when (stringp text)
+    (replace-regexp-in-string "[\n\r][ \t]*" "" text)))
 
 (defun ai-code-session-link--cache-get-or-compute (cache key compute)
   "Return cached value from CACHE for KEY, or call COMPUTE and store it."
@@ -220,7 +404,7 @@ terminal output redraw."
      (expand-file-name root)
      (lambda ()
        (or (ignore-errors
-             (when-let ((project (project-current nil root)))
+             (when-let* ((project (project-current nil root)))
                (let ((project-root (expand-file-name (project-root project))))
                  (mapcar (lambda (file)
                            (if (file-name-absolute-p file)
@@ -261,7 +445,7 @@ Optional PROJECT-FILES supplies the project file list."
   "Return the current session project root directory with trailing slash."
   (let ((root (or ai-code-backends-infra--session-directory
                   (and (fboundp 'project-current)
-                       (when-let ((project (project-current nil default-directory)))
+                       (when-let* ((project (project-current nil default-directory)))
                          (expand-file-name (project-root project))))
                   default-directory)))
     (and root (file-name-as-directory (expand-file-name root)))))
@@ -278,7 +462,9 @@ Optional PROJECT-FILES supplies the project file list."
 
 (defun ai-code-session-link--resolve-existing-local-path (path root)
   "Resolve PATH to an existing local file or directory using ROOT."
-  (seq-find #'file-exists-p
+  (seq-find (lambda (candidate)
+              (and (not (file-remote-p candidate))
+                   (file-exists-p candidate)))
             (ai-code-session-link--local-path-candidates path root)))
 
 (defun ai-code-session-link--cheap-file-link-candidate-p (path &optional root)
@@ -286,7 +472,7 @@ Optional PROJECT-FILES supplies the project file list."
 Optional ROOT is the session project root used for bounded local existence
 checks.  Expensive project-wide resolution stays in
 `ai-code-session-link--resolve-session-file' on activation."
-  (when-let ((normalized (ai-code-session-link--normalize-file path)))
+  (when-let* ((normalized (ai-code-session-link--normalize-file path)))
     (let ((extension (file-name-extension normalized)))
       (or (ai-code-session-link--resolve-existing-local-path normalized root)
           (and (not (file-name-absolute-p normalized))
@@ -320,37 +506,351 @@ checks.  Expensive project-wide resolution stays in
                   (t nil))))))
       nil)))
 
+(defun ai-code-session-link--ghostel-session-p ()
+  "Return non-nil when the current buffer is a Ghostel-managed AI session."
+  (and (boundp 'ai-code-backends-infra--session-terminal-backend)
+       (eq ai-code-backends-infra--session-terminal-backend 'ghostel)))
+
+(defun ai-code-session-link--trusted-local-session-p ()
+  "Return non-nil when session file probing is safe for local preview."
+  (not (file-remote-p
+        (or ai-code-backends-infra--session-directory
+            default-directory))))
+
+(defun ai-code-session-link--image-preview-enabled-p ()
+  "Return non-nil when image previews should be applied in this buffer."
+  (and ai-code-session-link-ghostel-image-preview-enabled
+       (ai-code-session-link--ghostel-session-p)
+       (ai-code-session-link--trusted-local-session-p)
+       (display-images-p)))
+
+(defun ai-code-session-link--image-extension-p (file)
+  "Return non-nil when FILE has a known image file extension."
+  (when-let* ((extension (file-name-extension file)))
+    (member (downcase extension)
+            ai-code-session-link--image-file-extensions)))
+
+(defun ai-code-session-link--safe-local-image-file-p (file)
+  "Return non-nil when FILE is a local image safe enough to preview."
+  (and (stringp file)
+       (ai-code-session-link--image-extension-p file)
+       (not (file-remote-p file))
+       (file-regular-p file)
+       (file-readable-p file)
+       (let ((attrs (file-attributes file 'integer)))
+         (and attrs
+              (<= (file-attribute-size attrs)
+                  ai-code-session-link-ghostel-image-preview-max-bytes)))))
+
 (defun ai-code-session-link--parse-file-link-text (text)
   "Parse file-like session link TEXT into a plist."
-  (when (stringp text)
-    (catch 'parsed
-      (dolist (pattern ai-code-session-link--file-patterns)
-        (let ((regexp (concat "\\`" (car pattern) "\\'")))
-          (when (string-match regexp text)
-            (throw
-             'parsed
-             (list :file (match-string (nth 1 pattern) text)
-                   :line-start (when-let ((group (nth 2 pattern))
-                                          (line (match-string group text)))
-                                 (string-to-number line))
-                   :column-start (when-let ((group (nth 3 pattern))
-                                            (column (match-string group text)))
-                                   (string-to-number column))))))))))
+  (when-let* ((text (ai-code-session-link--normalize-link-text text)))
+    (if (or (string-match-p "\\`file:" text)
+            (when-let* ((normalized (ai-code-session-link--normalize-file text)))
+              (ai-code-session-link--image-extension-p normalized)))
+        (list :file text)
+      (catch 'parsed
+        (dolist (pattern ai-code-session-link--file-patterns)
+          (let ((regexp (concat "\\`" (car pattern) "\\'")))
+            (when (string-match regexp text)
+              (throw
+               'parsed
+               (list :file (match-string (nth 1 pattern) text)
+                     :line-start (when-let* ((group (nth 2 pattern))
+                                             (line (match-string group text)))
+                                   (string-to-number line))
+                     :column-start (when-let* ((group (nth 3 pattern))
+                                               (column (match-string group text)))
+                                     (string-to-number column)))))))))))
+
+(defun ai-code-session-link--image-preview-file (link-text)
+  "Return an absolute local image file resolved from LINK-TEXT, or nil."
+  (when-let* ((link (ai-code-session-link--parse-file-link-text link-text))
+              (file (plist-get link :file))
+              ((ai-code-session-link--image-extension-p file))
+              (abs-file (ai-code-session-link--resolve-session-file file))
+              ((ai-code-session-link--safe-local-image-file-p abs-file)))
+    abs-file))
+
+(defun ai-code-session-link--delete-image-preview-overlays (start end)
+  "Delete image preview overlays touching START through END."
+  (let* ((line-start (save-excursion
+                       (goto-char start)
+                       (line-beginning-position)))
+         (line-end (save-excursion
+                     (goto-char end)
+                     (line-end-position)))
+         (scan-end (min (point-max) (1+ line-end))))
+    (dolist (overlay (delete-dups
+                      (append (overlays-in line-start scan-end)
+                              (overlays-at line-start)
+                              (overlays-at start)
+                              (overlays-at end)
+                              (overlays-at line-end)
+                              (overlays-at scan-end))))
+      (when (overlay-get overlay 'ai-code-session-image-preview)
+        (delete-overlay overlay)))))
+
+(defun ai-code-session-link--image-preview-indent (match-start)
+  "Return indentation for an image preview after MATCH-START's line.
+The preview aligns with the line's leading prompt gutter, not with column zero."
+  (save-excursion
+    (goto-char match-start)
+    (let ((line-start (line-beginning-position))
+          (line-end (line-end-position)))
+      (goto-char line-start)
+      (skip-chars-forward " \t" line-end)
+      (buffer-substring-no-properties line-start (point)))))
+
+(defun ai-code-session-link--image-preview-string (image file indent)
+  "Return an after-string preview for IMAGE loaded from FILE.
+INDENT is inserted before the image on the preview line."
+  (concat
+   "\n"
+   indent
+   (propertize
+    " "
+    'display image
+    'help-echo (format "Image preview: %s" file)
+    'keymap ai-code-session-link--image-preview-keymap
+    'follow-link nil)
+   "\n"))
+
+(defun ai-code-session-link--unicode-trailing-punctuation-p (char)
+  "Return non-nil when CHAR is non-ASCII trailing Unicode punctuation."
+  (and (characterp char)
+       (> char 127)
+       (memq (get-char-code-property char 'general-category)
+             ai-code-session-link--unicode-trailing-punctuation-categories)))
+
+(defun ai-code-session-link--image-preview-anchor-end (match-end)
+  "Return the preview overlay end after display suffixes at MATCH-END."
+  (save-excursion
+    (goto-char match-end)
+    (let ((line-end (line-end-position))
+          next)
+      (when (looking-at "\\]\\[[^]\n\r]*\\]\\]")
+        (goto-char (match-end 0)))
+      (while (and
+              (< (point) line-end)
+              (setq next
+                    (cond
+                     ((looking-at
+                       ai-code-session-link--reference-wrapper-right-regexp)
+                      (match-end 0))
+                     ((ai-code-session-link--unicode-trailing-punctuation-p
+                       (char-after))
+                      (1+ (point))))))
+        (goto-char next))
+      (point))))
+
+(defun ai-code-session-link--ignore-image-preview-event (&optional _event)
+  "Ignore mouse or keyboard EVENT on an inline image preview."
+  (interactive)
+  nil)
+
+(defun ai-code-session-link--image-preview-link-file (link-text)
+  "Return the local image file for previewable LINK-TEXT, or nil."
+  (when (ai-code-session-link--image-preview-enabled-p)
+    (ai-code-session-link--image-preview-file link-text)))
+
+(defun ai-code-session-link--live-image-preview-overlay-p (overlay)
+  "Return non-nil when OVERLAY is still anchored to its image link text."
+  (and (overlayp overlay)
+       (eq (overlay-buffer overlay) (current-buffer))
+       (overlay-get overlay 'ai-code-session-image-preview)
+       (< (overlay-start overlay) (overlay-end overlay))
+       (let ((link-text (overlay-get overlay 'ai-code-session-image-link-text))
+             (display-text
+              (or (overlay-get overlay 'ai-code-session-image-display-text)
+                  (overlay-get overlay 'ai-code-session-image-link-text))))
+         (and link-text
+              display-text
+              (get-text-property (overlay-start overlay)
+                                 'ai-code-session-link)
+              (equal (buffer-substring-no-properties
+                      (overlay-start overlay) (overlay-end overlay))
+                     display-text)))))
+
+(defun ai-code-session-link--live-image-preview-overlays-in-region (start end)
+  "Return live image preview overlays between START and END."
+  (cl-remove-if-not
+   #'ai-code-session-link--live-image-preview-overlay-p
+   (overlays-in start end)))
+
+(defun ai-code-session-link--image-preview-overlay-present-p
+    (start end display-text)
+  "Return non-nil when START to END already has a preview for DISPLAY-TEXT."
+  (cl-some
+   (lambda (overlay)
+     (and (ai-code-session-link--live-image-preview-overlay-p overlay)
+          (= (overlay-start overlay) start)
+          (<= end (overlay-end overlay))
+          (let ((overlay-link
+                 (overlay-get overlay 'ai-code-session-image-link-text))
+                (overlay-display
+                 (overlay-get overlay 'ai-code-session-image-display-text)))
+            (or (equal display-text overlay-link)
+                (equal display-text overlay-display)))))
+   (overlays-in start end)))
+
+(defun ai-code-session-link--text-may-contain-image-reference-p (text)
+  "Return non-nil when TEXT may contain an image reference."
+  (and (stringp text)
+       (string-match-p
+        (concat "\\(?:file:\\|\\.\\(?:" ai-code-session-link--image-extension-regexp "\\)\\)")
+        text)))
+
+(defun ai-code-session-link--image-preview-refresh-needed-p (start end)
+  "Return non-nil when image previews between START and END need refreshing."
+  (catch 'missing-preview
+    (let ((ai-code-session-link--project-files-cache
+           (ai-code-session-link--buffer-project-files-cache))
+          (ai-code-session-link--resolved-path-cache
+           (make-hash-table :test 'equal)))
+      (dolist (file-link (ai-code-session-link--collect-file-links start end))
+        (let ((link-start (plist-get file-link :start))
+              (link-end (plist-get file-link :end))
+              (link-text (plist-get file-link :text)))
+          (when (and (ai-code-session-link--image-preview-link-file link-text)
+                     (not (ai-code-session-link--image-preview-overlay-present-p
+                           link-start link-end link-text)))
+            (throw 'missing-preview t)))))
+    nil))
+
+(defun ai-code-session-link--image-preview-format-hint (file)
+  "Return an image MIME-style data hint for FILE, or nil."
+  (when-let* ((extension (file-name-extension file)))
+    (intern (format "image/%s"
+                    (pcase (downcase extension)
+                      ("jpg" "jpeg")
+                      ("tif" "tiff")
+                      (other other))))))
+
+(defun ai-code-session-link--image-preview-data (file)
+  "Return unibyte image data read from FILE."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally file)
+    (buffer-string)))
+
+(defconst ai-code-session-link--image-preview-fallback-max-width 960
+  "Width cap used when no window is available to fit the preview to.")
+
+(defun ai-code-session-link--image-preview-max-dimensions (indent)
+  "Return a (MAX-WIDTH . MAX-HEIGHT) pixel cap for an image preview.
+An explicit integer custom is used verbatim as a hard cap.  When the custom
+is nil the preview fits the session window's body width, reduced by INDENT
+so the image never overflows into a horizontal scroll.  Height is uncapped by
+default so large screenshots can use the available width and be inspected by
+scrolling.  These are upper bounds only: `create-image' scales large images
+down to fit but never enlarges a small one.  A fixed width fallback applies
+when no window shows the buffer."
+  (let* ((window (get-buffer-window (current-buffer) t))
+         (char-width (frame-char-width (if window
+                                           (window-frame window)
+                                         (selected-frame))))
+         (indent-pixels (* (string-width (or indent "")) char-width)))
+    (cons
+     (cond
+      ((integerp ai-code-session-link-ghostel-image-preview-max-width)
+       ai-code-session-link-ghostel-image-preview-max-width)
+      (window
+       (max 1 (- (window-body-width window t) indent-pixels char-width)))
+      (t ai-code-session-link--image-preview-fallback-max-width))
+     (and (integerp ai-code-session-link-ghostel-image-preview-max-height)
+          ai-code-session-link-ghostel-image-preview-max-height))))
+
+(defun ai-code-session-link--create-image-preview (file max-width max-height)
+  "Create a data-backed preview image for FILE.
+MAX-WIDTH and MAX-HEIGHT are pixel caps passed to `create-image', which only
+scales down, so a smaller image keeps its native size.  A nil cap leaves that
+dimension unbounded.
+
+Using image data instead of a file-backed image spec keeps inline previews
+stable when `image-mode' opens and flushes the same image file."
+  (let* ((data (ai-code-session-link--image-preview-data file))
+         (data-p (or (ai-code-session-link--image-preview-format-hint file)
+                     t))
+         (type (ignore-errors (image-type data nil data-p))))
+    (ignore-errors
+      (apply #'create-image
+             data type data-p
+             (append (when max-width (list :max-width max-width))
+                     (when max-height (list :max-height max-height)))))))
+
+(defun ai-code-session-link--apply-image-preview (match-start match-end link-text)
+  "Display an image preview for LINK-TEXT after MATCH-START through MATCH-END."
+  (when (ai-code-session-link--image-preview-enabled-p)
+    (when-let* ((file (ai-code-session-link--image-preview-file link-text)))
+      (ai-code-session-link--apply-image-preview-for-file
+       match-start match-end link-text file))))
+
+(defun ai-code-session-link--apply-image-preview-for-file
+    (match-start match-end link-text file &optional display-text)
+  "Display FILE preview for LINK-TEXT after MATCH-START through MATCH-END."
+  (when (ai-code-session-link--image-preview-enabled-p)
+    (let* ((anchor-end
+            (ai-code-session-link--image-preview-anchor-end match-end))
+           (display-text
+            (or display-text
+                (buffer-substring-no-properties match-start match-end)))
+           (display-text
+            (if (> anchor-end match-end)
+                (concat display-text
+                        (buffer-substring-no-properties match-end anchor-end))
+              display-text))
+           (indent (ai-code-session-link--image-preview-indent match-start))
+           (dimensions (ai-code-session-link--image-preview-max-dimensions indent))
+           (image (ai-code-session-link--create-image-preview
+                   file (car dimensions) (cdr dimensions))))
+      (when image
+        (let ((overlay (make-overlay match-start anchor-end nil nil nil)))
+          (overlay-put overlay 'ai-code-session-image-preview t)
+          (overlay-put overlay 'ai-code-session-image-file file)
+          (overlay-put overlay 'ai-code-session-image-link-text link-text)
+          (overlay-put overlay 'ai-code-session-image-display-text
+                       (or display-text link-text))
+          (overlay-put overlay 'after-string
+                       (ai-code-session-link--image-preview-string
+                        image file indent))
+          overlay)))))
 
 (defun ai-code-session-link--apply-properties (start end &optional text help-echo)
   "Apply session link properties from START to END.
 Optional TEXT overrides the stored link text.
 Optional HELP-ECHO overrides the hover help text."
-  (add-text-properties
-   start end
-   (list 'ai-code-session-link (or text
-                                   (buffer-substring-no-properties start end))
-         'mouse-face 'highlight
-         'help-echo help-echo
-         'keymap ai-code-session-link--keymap
-         'follow-link t
-         'font-lock-face 'link
-         'face 'link)))
+  (let ((link-text
+         (ai-code-session-link--normalize-link-text
+          (or text (buffer-substring-no-properties start end)))))
+    (ai-code-session-link--apply-link-properties-to-visible-text
+     start end
+     (list 'ai-code-session-link link-text
+           'mouse-face 'highlight
+           'help-echo help-echo
+           'keymap ai-code-session-link--keymap
+           'follow-link t
+           'font-lock-face 'link
+           'face 'link))))
+
+(defun ai-code-session-link--apply-link-properties-to-visible-text
+    (start end properties)
+  "Apply PROPERTIES from START to END, skipping wrapped-line indentation."
+  (save-excursion
+    (goto-char start)
+    (let ((segment-start start)
+          segment-end)
+      (while (< segment-start end)
+        (goto-char segment-start)
+        (skip-chars-forward " \t" (min end (line-end-position)))
+        (setq segment-start (point)
+              segment-end (min end (line-end-position)))
+        (when (< segment-start segment-end)
+          (add-text-properties segment-start segment-end properties))
+        (setq segment-start
+              (if (< segment-end end)
+                  (1+ segment-end)
+                end))))))
 
 (defun ai-code-session-link--apply-symbol-properties (start end symbol file-link)
   "Apply clickable SYMBOL properties from START to END using FILE-LINK."
@@ -487,26 +987,170 @@ Optional NEXT-FILE-START caps the scan boundary."
                  symbol-start symbol-end candidate file-link)
                 (setq link-count (1+ link-count))))))))))
 
+(defun ai-code-session-link--sort-and-prune-file-links (file-links)
+  "Return FILE-LINKS ordered by start, with contained links removed."
+  (let ((sorted
+         (sort file-links
+               (lambda (left right)
+                 (let ((left-start (plist-get left :start))
+                       (right-start (plist-get right :start))
+                       (left-end (plist-get left :end))
+                       (right-end (plist-get right :end)))
+                   (if (= left-start right-start)
+                       (> left-end right-end)
+                     (< left-start right-start)))))))
+    (let (kept)
+      (dolist (link sorted)
+        (let ((link-start (plist-get link :start))
+              (link-end (plist-get link :end)))
+          (unless (cl-some
+                   (lambda (kept-link)
+                     (and (<= (plist-get kept-link :start) link-start)
+                          (<= link-end (plist-get kept-link :end))))
+                   kept)
+            (push link kept))))
+      (nreverse kept))))
+
+(defun ai-code-session-link--blank-between-p (start end)
+  "Return non-nil when buffer text between START and END is blank."
+  (save-excursion
+    (goto-char start)
+    (skip-chars-forward " \t" end)
+    (>= (point) end)))
+
+(defun ai-code-session-link--line-path-fragment-bounds (start end)
+  "Return path fragment bounds between START and END after indentation."
+  (save-excursion
+    (goto-char start)
+    (skip-chars-forward " \t" end)
+    (let ((fragment-start (point)))
+      (when (looking-at ai-code-session-link--path-fragment-regexp)
+        (let ((fragment-end (min (match-end 0) end)))
+          (when (< fragment-start fragment-end)
+            (cons fragment-start fragment-end)))))))
+
+(defun ai-code-session-link--file-suffix-end-at (position limit)
+  "Return end of a file suffix at POSITION, bounded by LIMIT."
+  (save-excursion
+    (goto-char position)
+    (when (looking-at ai-code-session-link--file-suffix-regexp)
+      (let ((suffix-end (match-end 0)))
+        (and (<= suffix-end limit) suffix-end)))))
+
+(defun ai-code-session-link--file-link-end-at (base-end line-end)
+  "Return file link end from BASE-END, including a suffix before LINE-END."
+  (or (ai-code-session-link--file-suffix-end-at base-end line-end)
+      base-end))
+
+(defun ai-code-session-link--wrapped-file-link-candidate-p (text root)
+  "Return non-nil when wrapped link TEXT resolves to a local file for ROOT."
+  (when-let* ((parsed (ai-code-session-link--parse-file-link-text text))
+              (file (plist-get parsed :file))
+              (normalized (ai-code-session-link--normalize-file file)))
+    (ai-code-session-link--resolve-existing-local-path normalized root)))
+
+(defun ai-code-session-link--wrapped-file-link-at
+    (match-start match-end scan-end root)
+  "Return a wrapped file link candidate starting at MATCH-START.
+MATCH-END is the end of the first-row path match.  SCAN-END bounds the
+search, and ROOT is the session project root."
+  (save-excursion
+    (goto-char match-start)
+    (let ((first-line-end (min scan-end (line-end-position)))
+          (current-line-end nil)
+          (best-link nil)
+          (continued-lines 0)
+          (scan t))
+      (setq current-line-end first-line-end)
+      (when (ai-code-session-link--blank-between-p match-end first-line-end)
+        (while (and scan
+                    (< continued-lines ai-code-session-link--wrapped-path-max-lines)
+                    (< current-line-end scan-end)
+                    (eq (char-after current-line-end) ?\n))
+          (let* ((next-line-start (1+ current-line-end))
+                 (next-line-end
+                  (save-excursion
+                    (goto-char next-line-start)
+                    (min scan-end (line-end-position))))
+                 (fragment
+                  (ai-code-session-link--line-path-fragment-bounds
+                   next-line-start next-line-end)))
+            (if (not fragment)
+                (setq scan nil)
+              (let* ((base-end (cdr fragment))
+                     (link-end
+                      (ai-code-session-link--file-link-end-at
+                       base-end next-line-end)))
+                (if (not (ai-code-session-link--blank-between-p
+                          link-end next-line-end))
+                    (setq scan nil)
+                  (cl-incf continued-lines)
+                  (let ((link-text
+                         (ai-code-session-link--normalize-link-text
+                          (buffer-substring-no-properties
+                           match-start link-end))))
+                    (when (ai-code-session-link--wrapped-file-link-candidate-p
+                           link-text root)
+                      (setq best-link
+                            (list :start match-start
+                                  :end link-end
+                                  :text link-text))))
+                  (setq current-line-end next-line-end)))))))
+      best-link)))
+
+(defun ai-code-session-link--collect-wrapped-file-links (start end root)
+  "Return hard-wrapped file link matches between START and END for ROOT."
+  (let (file-links)
+    (save-excursion
+      (goto-char start)
+      (while (re-search-forward ai-code-session-link--path-base-regexp end t)
+        (when-let* ((file-link
+                     (ai-code-session-link--wrapped-file-link-at
+                      (match-beginning 0)
+                      (match-end 0)
+                      end
+                      root)))
+          (push file-link file-links))))
+    (nreverse file-links)))
+
 (defun ai-code-session-link--collect-file-links (start end)
   "Return file link matches between START and END without eager resolution."
   (let ((root (ai-code-session-link--project-root-for-paths))
         (seen-starts (make-hash-table :test 'eql))
         file-links)
-    (save-excursion
-      (dolist (pattern ai-code-session-link--file-patterns)
-        (goto-char start)
-        (while (re-search-forward (car pattern) end t)
-          (let ((match-start (match-beginning 0))
-                (match-end (match-end 0)))
-            (unless (gethash match-start seen-starts)
-              (let ((path (match-string-no-properties (nth 1 pattern))))
-                (when (ai-code-session-link--cheap-file-link-candidate-p path root)
-                  (puthash match-start t seen-starts)
-                  (push (list :start match-start
-                              :end match-end
-                              :text (buffer-substring-no-properties match-start match-end))
-                        file-links))))))))
-    (nreverse file-links)))
+    (setq file-links
+          (ai-code-session-link--collect-wrapped-file-links start end root))
+    (cl-labels
+        ((add-link
+          (match-start match-end link-text &optional candidate-text)
+          (unless (gethash match-start seen-starts)
+            (when (ai-code-session-link--cheap-file-link-candidate-p
+                   (or candidate-text link-text) root)
+              (puthash match-start t seen-starts)
+              (push (list :start match-start
+                          :end match-end
+                          :text link-text)
+                    file-links)))))
+      (save-excursion
+        (dolist (pattern ai-code-session-link--image-reference-patterns)
+          (goto-char start)
+          (while (re-search-forward (car pattern) end t)
+            (let* ((capture (cadr pattern))
+                   (match-start (match-beginning capture))
+                   (match-end (match-end capture))
+                   (link-text (match-string-no-properties capture)))
+              (add-link match-start match-end link-text))))
+        (dolist (pattern ai-code-session-link--file-patterns)
+          (goto-char start)
+          (while (re-search-forward (car pattern) end t)
+            (let ((match-start (match-beginning 0))
+                  (match-end (match-end 0))
+                  (path (match-string-no-properties (nth 1 pattern))))
+              (add-link
+               match-start match-end
+               (buffer-substring-no-properties match-start match-end)
+               path))))))
+    (ai-code-session-link--sort-and-prune-file-links file-links)))
 
 (defun ai-code-session-link--linkify-url-region (start end)
   "Apply URL session links between START and END."
@@ -522,23 +1166,225 @@ Optional NEXT-FILE-START caps the scan boundary."
 
 (defun ai-code-session-link--linkify-file-region (start end)
   "Apply file session links between START and END."
-  (let ((ai-code-session-link--project-files-cache
-         (ai-code-session-link--buffer-project-files-cache))
-        (ai-code-session-link--resolved-path-cache (make-hash-table :test 'equal)))
-    (let ((file-links (ai-code-session-link--collect-file-links start end)))
-      (while file-links
-        (let* ((file-link (car file-links))
-               (next-file-link (cadr file-links))
-               (match-start (plist-get file-link :start))
-               (match-end (plist-get file-link :end))
-               (link-text (plist-get file-link :text)))
-          (unless (get-text-property match-start 'ai-code-session-link)
-            (ai-code-session-link--apply-properties
-             match-start match-end link-text "mouse-1: Visit file")
-            (ai-code-session-link--linkify-symbols-near-file
-             link-text match-end end
-             (and next-file-link (plist-get next-file-link :start))))
-          (setq file-links (cdr file-links)))))))
+  (let ((inhibit-read-only t)
+        (inhibit-modification-hooks t))
+    (ai-code-session-link--delete-image-preview-overlays start end)
+    (let ((ai-code-session-link--project-files-cache
+           (ai-code-session-link--buffer-project-files-cache))
+          (ai-code-session-link--resolved-path-cache
+           (make-hash-table :test 'equal)))
+      (let ((file-links (ai-code-session-link--collect-file-links start end)))
+        (while file-links
+          (let* ((file-link (car file-links))
+                 (next-file-link (cadr file-links))
+                 (match-start (plist-get file-link :start))
+                 (match-end (plist-get file-link :end))
+                 (link-text (plist-get file-link :text))
+                 (image-link-file
+                  (ai-code-session-link--image-preview-link-file link-text)))
+            (if image-link-file
+                (ai-code-session-link--apply-properties
+                 match-start match-end link-text
+                 "mouse-1: Visit image file")
+              (unless (get-text-property match-start 'ai-code-session-link)
+                (ai-code-session-link--apply-properties
+                 match-start match-end link-text "mouse-1: Visit file")
+                (ai-code-session-link--linkify-symbols-near-file
+                 link-text match-end end
+                 (and next-file-link (plist-get next-file-link :start)))))
+            (ai-code-session-link--apply-image-preview
+             match-start match-end link-text)
+            (setq file-links (cdr file-links))))))))
+
+(defun ai-code-session-link--strict-image-candidate-bounds (match-start match-end)
+  "Return strict local image path bounds around MATCH-START and MATCH-END."
+  (let ((start match-start)
+        (end match-end)
+        (min-start (line-beginning-position)))
+    (while (and (> start min-start)
+                (not (memq (char-before start)
+                           '(?\s ?\t ?\n ?\r ?\" ?' ?` ?< ?> ?\( ?\)
+                             ?\[ ?\] ?{ ?}))))
+      (setq start (1- start)))
+    (when (and (< start end)
+               (<= (- end start)
+                   ai-code-session-link--visible-image-preview-max-line-width))
+      (cons start end))))
+
+(defun ai-code-session-link--image-preview-existing-local-file (link-text)
+  "Return existing local image file for LINK-TEXT without project scanning."
+  (when-let* ((link (ai-code-session-link--parse-file-link-text link-text))
+              (file (plist-get link :file))
+              (normalized (ai-code-session-link--normalize-file file))
+              ((ai-code-session-link--image-extension-p normalized))
+              (root (ai-code-session-link--project-root-for-paths))
+              (abs-file
+               (ai-code-session-link--resolve-existing-local-path
+                normalized root))
+              ((ai-code-session-link--safe-local-image-file-p abs-file)))
+    abs-file))
+
+(defun ai-code-session-link--strict-path-continuation-line-p (line)
+  "Return non-nil when LINE is safe to treat as a wrapped path fragment."
+  (and (stringp line)
+       (not (string-empty-p line))
+       (<= (length line)
+           ai-code-session-link--visible-image-preview-max-line-width)
+       (string-match-p "\\`[-[:alnum:]_./~%+:\\\\]+\\'" line)))
+
+(defun ai-code-session-link--strict-absolute-path-suffix (line)
+  "Return an absolute path suffix from LINE, or nil."
+  (when (and (stringp line)
+             (string-match
+              "\\(?:\\`\\|[ \t]\\)\\(/[^] \t\n\r\"'`<>(){}[]+\\)\\'"
+              line))
+    (match-string 1 line)))
+
+(defun ai-code-session-link--strict-previous-line-prefix (position)
+  "Return a safe wrapped path prefix before POSITION, or nil."
+  (cdr (ai-code-session-link--strict-previous-line-prefix-info position)))
+
+(defun ai-code-session-link--strict-previous-line-prefix-info (position)
+  "Return a (START . PREFIX) pair before POSITION, or nil."
+  (save-excursion
+    (goto-char position)
+    (let ((suffix "")
+          (lines 0)
+          result
+          stop)
+      (while (and (not result)
+                  (not stop)
+                  (< lines
+                     ai-code-session-link--visible-image-preview-prefix-max-lines)
+                  (not (bobp)))
+        (forward-line -1)
+        (setq lines (1+ lines))
+        (let* ((raw-line
+                (buffer-substring-no-properties
+                 (line-beginning-position)
+                 (line-end-position)))
+               (line (string-trim raw-line))
+               (content-start
+                (+ (line-beginning-position)
+                   (or (string-match-p "[^ \t]" raw-line)
+                       (length raw-line))))
+               (too-long
+                (> (+ (length line) (length suffix))
+                   ai-code-session-link--visible-image-preview-max-line-width)))
+          (cond
+           (too-long
+            (setq stop t))
+           ((string-match "file:" line)
+            (setq result
+                  (cons (+ content-start (match-beginning 0))
+                        (concat (substring line (match-beginning 0))
+                                suffix))))
+           ((string-match
+             "\\(?:\\`\\|[ \t]\\)\\(/[^] \t\n\r\"'`<>(){}[]+\\)\\'"
+             line)
+            (setq result
+                  (cons (+ content-start (match-beginning 1))
+                        (concat (match-string 1 line) suffix))))
+           ((and (ai-code-session-link--strict-path-continuation-line-p line)
+                 (or suffix
+                     (string-match-p "[/-]\\'" line)
+                     (string-match-p "/" line)))
+            (setq suffix (concat line suffix)))
+           (t
+            (setq stop t)))))
+      result)))
+
+(defun ai-code-session-link--strict-image-candidates
+    (start end link-text)
+  "Return strict image candidates for LINK-TEXT between START and END."
+  (let* ((trimmed (string-trim link-text))
+         (normalized (ai-code-session-link--normalize-file trimmed))
+         (prefix-info
+          (and normalized
+               (not (file-name-absolute-p normalized))
+               (not (string-prefix-p "file:" normalized))
+               (ai-code-session-link--strict-previous-line-prefix-info start)))
+         (current-candidate
+          (list :start start
+                :end end
+                :link-text trimmed
+                :display-text link-text))
+         candidates)
+    (when prefix-info
+      (let* ((candidate-start (car prefix-info))
+             (candidate-text (concat (cdr prefix-info) trimmed))
+             (display-text
+              (buffer-substring-no-properties candidate-start end)))
+        (push (list :start candidate-start
+                    :end end
+                    :link-text candidate-text
+                    :display-text display-text)
+              candidates)))
+    (append (nreverse candidates) (list current-candidate))))
+
+(defun ai-code-session-link--strict-image-candidate-texts (start link-text)
+  "Return strict image candidate texts for LINK-TEXT at START."
+  (let* ((trimmed (string-trim link-text))
+         (normalized (ai-code-session-link--normalize-file trimmed))
+         (prefix (and normalized
+                      (not (file-name-absolute-p normalized))
+                      (not (string-prefix-p "file:" normalized))
+                      (ai-code-session-link--strict-previous-line-prefix start))))
+    (let ((candidates (list trimmed)))
+      (when prefix
+        (push (concat prefix trimmed) candidates))
+      (delete-dups
+       (delq nil
+             (nreverse candidates))))))
+
+(defun ai-code-session-link--linkify-strict-image-preview-region (start end)
+  "Apply image previews between START and END using strict local path parsing.
+This avoids broad path regexps and project scans, making it suitable for
+visible-window recovery in large terminal scrollback."
+  (when (ai-code-session-link--image-preview-enabled-p)
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t))
+      (ai-code-session-link--delete-image-preview-overlays start end)
+      (save-excursion
+        (let ((case-fold-search t)
+              (candidate-count 0)
+              (extension-regexp
+               (concat "\\.\\(?:" ai-code-session-link--image-extension-regexp "\\)")))
+          (goto-char start)
+          (while (and (< candidate-count
+                         ai-code-session-link--visible-image-preview-max-candidates)
+                      (re-search-forward extension-regexp end t))
+            (setq candidate-count (1+ candidate-count))
+            (let* ((bounds
+                    (ai-code-session-link--strict-image-candidate-bounds
+                     (match-beginning 0)
+                     (match-end 0)))
+                   (match-start (car-safe bounds))
+                   (match-end (cdr-safe bounds))
+                   (link-text
+                    (and bounds
+                         (buffer-substring-no-properties match-start match-end))))
+              (when link-text
+                (catch 'previewed
+                  (dolist (candidate
+                           (ai-code-session-link--strict-image-candidates
+                            match-start match-end link-text))
+                    (when-let* ((link-text (plist-get candidate :link-text))
+                                (file
+                                 (ai-code-session-link--image-preview-existing-local-file
+                                  link-text)))
+                      (ai-code-session-link--apply-properties
+                       (plist-get candidate :start)
+                       (plist-get candidate :end)
+                       link-text
+                       "mouse-1: Visit image file")
+                      (ai-code-session-link--apply-image-preview-for-file
+                       (plist-get candidate :start)
+                       (plist-get candidate :end)
+                       link-text
+                       file
+                       (plist-get candidate :display-text))
+                      (throw 'previewed t))))))))))))
 
 (defun ai-code-session-link--property-at-point (property)
   "Return PROPERTY at point or immediately before point."
@@ -564,16 +1410,16 @@ Optional NEXT-FILE-START caps the scan boundary."
               (abs-file (ai-code-session-link--resolve-session-file file)))
     (find-file-other-window abs-file)
     (goto-char (point-min))
-    (when-let ((line-start (plist-get link :line-start)))
+    (when-let* ((line-start (plist-get link :line-start)))
       (forward-line (1- line-start)))
-    (when-let ((column-start (plist-get link :column-start)))
+    (when-let* ((column-start (plist-get link :column-start)))
       (when (> column-start 0)
         (move-to-column (1- column-start))))
     t))
 
 (defun ai-code-session-link--try-xref-definition (symbol)
   "Try xref lookup for SYMBOL in the current buffer."
-  (when-let ((lookup (ai-code-session-link--primary-symbol-search-term symbol)))
+  (when-let* ((lookup (ai-code-session-link--primary-symbol-search-term symbol)))
     (when (fboundp 'xref-find-definitions)
       (condition-case nil
           (progn
@@ -583,7 +1429,7 @@ Optional NEXT-FILE-START caps the scan boundary."
 
 (defun ai-code-session-link--try-helm-gtags-definition (symbol)
   "Try helm-gtags lookup for SYMBOL in the current buffer."
-  (when-let ((lookup (ai-code-session-link--primary-symbol-search-term symbol)))
+  (when-let* ((lookup (ai-code-session-link--primary-symbol-search-term symbol)))
     (when (fboundp 'helm-gtags-find-tag)
       (condition-case nil
           (progn
@@ -635,7 +1481,8 @@ Optional NEXT-FILE-START caps the scan boundary."
   "Make supported URLs and in-project file references clickable from START to END."
   (when (and ai-code-session-link-enabled
              (< start end))
-    (let ((inhibit-read-only t))
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t))
       (save-excursion
         (save-restriction
           (widen)
@@ -643,7 +1490,13 @@ Optional NEXT-FILE-START caps the scan boundary."
                 end (min (point-max) end))
           (let ((bounds (cons start end))
                 (region-text (buffer-substring-no-properties start end)))
-            (unless (ai-code-session-link--unchanged-region-p bounds region-text)
+            (if (ai-code-session-link--unchanged-region-p bounds region-text)
+                (when (and (ai-code-session-link--image-preview-enabled-p)
+                           (ai-code-session-link--text-may-contain-image-reference-p
+                            region-text)
+                           (ai-code-session-link--image-preview-refresh-needed-p
+                            start end))
+                  (ai-code-session-link--linkify-file-region start end))
               (let ((pos start))
                 (while (< pos end)
                   (let ((next (or (next-single-property-change
@@ -705,8 +1558,9 @@ Optional NEXT-FILE-START caps the scan boundary."
          (max (point-min) (- end tail-width))
          end)))))
 
-(defun ai-code-session-link--schedule-linkify-recent-output (buffer output)
-  "Linkify recent OUTPUT in BUFFER after terminal redraw settles."
+(defun ai-code-session-link--schedule-linkify-recent-output (buffer output &optional delay)
+  "Linkify recent OUTPUT in BUFFER after terminal redraw settles.
+Optional DELAY overrides the default redraw delay in seconds."
   (when (ai-code-session-link--should-linkify-recent-output-p buffer output)
     (with-current-buffer buffer
       (setq ai-code-session-link--pending-tail-width
@@ -715,7 +1569,7 @@ Optional NEXT-FILE-START caps the scan boundary."
       (unless ai-code-session-link--linkify-timer
         (setq ai-code-session-link--linkify-timer
               (run-at-time
-               0 nil
+               (or delay ai-code-session-link--linkify-redraw-delay) nil
                (lambda (buf)
                  (when (buffer-live-p buf)
                    (with-current-buffer buf

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -17,6 +17,9 @@
 (defvar ghostel-progress-function)
 (defvar ghostel-set-title-function)
 (defvar ghostel-kill-buffer-on-exit)
+(defvar ghostel-kitty-graphics-mediums)
+(defvar ghostel--plain-link-detection-begin)
+(defvar ghostel--plain-link-detection-end)
 (defvar ai-code-backends-infra--session-directory)
 
 (ert-deftest test-ai-code-backends-infra-ghostel-create-session-restores-ai-state ()
@@ -78,6 +81,292 @@
                 #'ai-code-backends-infra-ghostel--progress))
     (should (eq ai-code-backends-infra-ghostel--progress-function
                 #'ignore))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-configures-visible-image-hook ()
+  "Ghostel AI session configuration should install visible image recovery."
+  (with-temp-buffer
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+               (lambda () nil))
+              ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+               (lambda () nil)))
+      (ai-code-backends-infra--configure-ghostel-buffer))
+    (should (memq #'ai-code-backends-infra-ghostel--window-scroll
+                  window-scroll-functions))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-configures-image-mediums ()
+  "Ghostel AI session configuration should enable local image mediums."
+  (with-temp-buffer
+    (let ((ai-code-backends-infra-ghostel-kitty-graphics-mediums
+           '(file temp-file))
+          (original-bound (boundp 'ghostel-kitty-graphics-mediums))
+          (original-value (and (boundp 'ghostel-kitty-graphics-mediums)
+                               ghostel-kitty-graphics-mediums)))
+      (unwind-protect
+          (progn
+            (setq ghostel-kitty-graphics-mediums '(shared-mem))
+            (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+                       (lambda () nil))
+                      ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+                       (lambda () nil)))
+              (ai-code-backends-infra--configure-ghostel-buffer))
+            (should (equal ghostel-kitty-graphics-mediums
+                           '(file temp-file shared-mem))))
+        (if original-bound
+            (setq ghostel-kitty-graphics-mediums original-value)
+          (makunbound 'ghostel-kitty-graphics-mediums))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-remote-keeps-user-image-mediums ()
+  "Remote Ghostel sessions should not add AI Code local image mediums."
+  (with-temp-buffer
+    (let ((ai-code-backends-infra-ghostel-kitty-graphics-mediums
+           '(file temp-file))
+          (original-bound (boundp 'ghostel-kitty-graphics-mediums))
+          (original-value (and (boundp 'ghostel-kitty-graphics-mediums)
+                               ghostel-kitty-graphics-mediums)))
+      (unwind-protect
+          (progn
+            (setq ghostel-kitty-graphics-mediums '(shared-mem))
+            (setq-local ai-code-backends-infra--session-directory
+                        "/ssh:example:/repo/")
+            (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+                       (lambda () nil))
+                      ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+                       (lambda () nil)))
+              (ai-code-backends-infra--configure-ghostel-buffer))
+            (should (equal ghostel-kitty-graphics-mediums '(shared-mem))))
+        (if original-bound
+            (setq ghostel-kitty-graphics-mediums original-value)
+          (makunbound 'ghostel-kitty-graphics-mediums))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-restores-image-preview ()
+  "Visible Ghostel image linkification should restore inline image previews."
+  (let* ((root (make-temp-file "ai-code-ghostel-history-image-" t))
+         (image-file (expand-file-name "history.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (list :image file :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "Restored history\n")
+              (insert "history.png\n")
+              (ai-code-session-link--linkify-strict-image-preview-region
+               (point-min) (point-max))
+              (should
+               (= (length
+                   (cl-remove-if-not
+                    (lambda (overlay)
+                      (overlay-get overlay 'ai-code-session-image-preview))
+                    (overlays-in (point-min) (point-max))))
+                  1)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-schedules-visible-linkify ()
+  "Visible image linkification should schedule bounded window scans."
+  (let (scheduled)
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (let ((ai-code-backends-infra-ghostel-visible-image-linkify-delays
+             '(0.1 0.5)))
+        (cl-letf (((symbol-function 'run-at-time)
+                   (lambda (delay _repeat function &rest args)
+                     (push (list delay function args) scheduled)
+                     'mock-timer)))
+          (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+           (selected-window))
+          (should (equal (mapcar #'car (reverse scheduled))
+                         '(0.1 0.5))))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-schedules-visible-linkify-per-window ()
+  "Visible image linkification timers should be isolated per window."
+  (let ((buffer (generate-new-buffer " *ai-code-ghostel-window-timers*"))
+        (owners (make-hash-table :test 'eq))
+        cancelled
+        right-window)
+    (unwind-protect
+        (let ((window-min-width 1))
+          (delete-other-windows)
+          (setq right-window (split-window-right))
+          (set-window-buffer (selected-window) buffer)
+          (set-window-buffer right-window buffer)
+          (with-current-buffer buffer
+            (setq-local ai-code-backends-infra--session-terminal-backend
+                        'ghostel)
+            (cl-letf (((symbol-function 'run-at-time)
+                       (lambda (_delay _repeat _function &rest args)
+                         (let ((timer (timer-create)))
+                           (puthash timer (cadr args) owners)
+                           timer)))
+                      ((symbol-function 'cancel-timer)
+                       (lambda (timer)
+                         (push (gethash timer owners) cancelled))))
+              (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+               (selected-window)
+               '(0.1))
+              (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+               right-window
+               '(0.2))
+              (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+               (selected-window)
+               '(0.3))
+              (should (equal cancelled (list (selected-window))))
+              (should (assq (selected-window)
+                            ai-code-backends-infra-ghostel--visible-image-linkify-timers))
+              (should (assq right-window
+                            ai-code-backends-infra-ghostel--visible-image-linkify-timers)))))
+      (when (window-live-p right-window)
+        (delete-window right-window))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-is-bounded ()
+  "Visible image linkification should not scan the full scrollback."
+  (let (linkified)
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (insert (make-string 1000 ?x))
+      (goto-char (point-min))
+      (set-window-start (selected-window) (point-min) t)
+      (let ((ai-code-backends-infra-ghostel-visible-image-linkify-max-chars
+             100))
+        (cl-letf (((symbol-function
+                    'ai-code-session-link--linkify-strict-image-preview-region)
+                   (lambda (start end)
+                     (setq linkified (cons start end)))))
+          (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+           (current-buffer)
+           (selected-window))
+          (should linkified)
+          (should (<= (- (cdr linkified) (car linkified)) 100)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-retries-same-region ()
+  "Visible image linkification should retry delayed scans for the same text."
+  (let ((scan-count 0))
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (insert "history.png\n")
+      (goto-char (point-min))
+      (set-window-start (selected-window) (point-min) t)
+      (cl-letf (((symbol-function
+                  'ai-code-session-link--linkify-strict-image-preview-region)
+                 (lambda (_start _end)
+                   (setq scan-count (1+ scan-count)))))
+        (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+         (current-buffer)
+         (selected-window))
+        (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+         (current-buffer)
+         (selected-window))
+        (should (= scan-count 2))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-remote-linkify-skips-file-stats ()
+  "Remote Ghostel image recovery should not inspect remote file paths."
+  (let (path-resolution-called strict-linkify-called)
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local ai-code-backends-infra--session-directory
+                  "/ssh:example:/repo/")
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (insert "remote.png\n")
+      (goto-char (point-min))
+      (set-window-start (selected-window) (point-min) t)
+      (cl-letf (((symbol-function
+                  'ai-code-session-link--resolve-existing-local-path)
+                 (lambda (&rest _args)
+                   (setq path-resolution-called t)
+                   nil))
+                ((symbol-function
+                  'ai-code-session-link--linkify-strict-image-preview-region)
+                 (lambda (&rest _args)
+                   (setq strict-linkify-called t)
+                   (ai-code-session-link--resolve-existing-local-path
+                    "remote.png"
+                    "/ssh:example:/repo/"))))
+        (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+         (current-buffer)
+         (selected-window))
+        (ai-code-backends-infra-ghostel--linkify-image-preview-region
+         (current-buffer)
+         (point-min)
+         (point-max))
+        (should-not strict-linkify-called)
+        (should-not path-resolution-called)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-redraw-linkify-is-bounded ()
+  "Ghostel redraw linkification should use the queued link-detection region."
+  (let (linkified original-called)
+    (with-temp-buffer
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (setq-local ghostel--plain-link-detection-begin 4)
+      (setq-local ghostel--plain-link-detection-end 900)
+      (insert (make-string 1000 ?x))
+      (let ((ai-code-backends-infra-ghostel-visible-image-linkify-max-chars
+             100))
+        (cl-letf (((symbol-function
+                    'ai-code-session-link--linkify-strict-image-preview-region)
+                   (lambda (start end)
+                     (setq linkified (cons start end)))))
+          (ai-code-backends-infra-ghostel--run-queued-link-detection-around
+           (lambda (_buffer)
+             (setq original-called t))
+           (current-buffer))
+          (should original-called)
+          (should linkified)
+          (should (<= (- (cdr linkified) (car linkified)) 100)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-readonly-entry-schedules-visible-linkify ()
+  "Ghostel copy/emacs mode entry should schedule visible image recovery."
+  (let (scheduled)
+    (with-temp-buffer
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (cl-letf (((symbol-function
+                  'ai-code-backends-infra-ghostel-schedule-visible-image-linkify-for-buffer)
+                 (lambda (&optional buffer delays)
+                   (setq scheduled (list buffer delays)))))
+        (ai-code-backends-infra-ghostel--after-readonly-command)
+        (should (equal scheduled (list (current-buffer) nil)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-start-process-binds-image-mediums-before-exec ()
+  "Ghostel startup should pass image mediums to `ghostel-exec' before init."
+  (with-temp-buffer
+    (let ((ai-code-backends-infra-ghostel-kitty-graphics-mediums
+           '(file temp-file))
+          (mediums-seen nil)
+          (original-bound (boundp 'ghostel-kitty-graphics-mediums))
+          (original-value (and (boundp 'ghostel-kitty-graphics-mediums)
+                               ghostel-kitty-graphics-mediums)))
+      (unwind-protect
+          (progn
+            (setq ghostel-kitty-graphics-mediums nil)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+                       (lambda () nil))
+                      ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+                       (lambda () nil))
+                      ((symbol-function 'ghostel-exec)
+                       (lambda (_buffer _program _args)
+                         (setq mediums-seen ghostel-kitty-graphics-mediums)
+                         nil)))
+              (ai-code-backends-infra--start-ghostel-process
+               (current-buffer) "codex --foo"))
+            (should (equal mediums-seen '(file temp-file)))
+            (should (equal ghostel-kitty-graphics-mediums '(file temp-file))))
+        (if original-bound
+            (setq ghostel-kitty-graphics-mediums original-value)
+          (makunbound 'ghostel-kitty-graphics-mediums))))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-command-lifecycle-updates-session-metadata ()
   "OSC 133 command hooks should write structured session metadata."

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -707,6 +707,29 @@ The prefix argument should also force instance-name prompting."
         (funcall (cdr (assq 'window-width captured-entry)) 'fake-window)
         (should (equal resize-call '(fake-window 4 t)))))))
 
+(ert-deftest test-ai-code-backends-infra-display-buffer-linkifies-visible-ghostel-images ()
+  "Displaying a Ghostel session should scan only visible text for images."
+  (let ((ai-code-backends-infra-use-side-window nil)
+        (ai-code-backends-infra-focus-on-open nil)
+        displayed-buffer
+        display-linkified-window)
+    (with-temp-buffer
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (cl-letf (((symbol-function 'display-buffer)
+                 (lambda (buffer &rest _args)
+                   (setq displayed-buffer buffer)
+                   (selected-window)))
+                ((symbol-function 'ai-code-backends-infra--sync-terminal-dimensions)
+                 (lambda (&rest _args) nil))
+                ((symbol-function
+                  'ai-code-backends-infra-ghostel-schedule-visible-image-linkify)
+                 (lambda (window)
+                   (setq display-linkified-window window))))
+        (ai-code-backends-infra--display-buffer-in-side-window
+         (current-buffer))
+        (should (eq displayed-buffer (current-buffer)))
+        (should (eq display-linkified-window (selected-window)))))))
+
 (ert-deftest test-ai-code-backends-infra-terminal-reflow-filter-ignores-non-ai-vterm-buffer ()
   "The reflow filter should pass through non-session vterm buffers."
   (with-temp-buffer
@@ -1437,7 +1460,7 @@ The prefix argument should also force instance-name prompting."
        saved-default))))
 
 (ert-deftest test-ai-code-backends-infra-create-terminal-session-ghostel-wraps-output-filter ()
-  "Ghostel session creation should track meaningful output and linkify output."
+  "Ghostel session creation should track output and schedule linkification."
   (let* ((buffer-name "*test-ai-code-ghostel-output*")
          (buffer (get-buffer-create buffer-name))
          (proc (make-process :name "ai-code-ghostel-output"
@@ -1446,13 +1469,13 @@ The prefix argument should also force instance-name prompting."
                              :noquery t))
          (orig-outputs nil)
          (meaningful-outputs nil)
-         (linkify-outputs nil)
+         (scheduled-outputs nil)
          (ai-code-backends-infra-terminal-backend 'ghostel)
          (note-advice (lambda (&rest _args)
                         (push 'noted meaningful-outputs)))
-         (linkify-advice (lambda (orig-fun output)
-                           (push output linkify-outputs)
-                           (funcall orig-fun output))))
+         (schedule-advice (lambda (_orig-fun target-buffer output &optional delay)
+                            (push (list target-buffer output delay)
+                                  scheduled-outputs))))
     (unwind-protect
         (progn
           (set-process-filter
@@ -1461,8 +1484,8 @@ The prefix argument should also force instance-name prompting."
              (push output orig-outputs)))
           (advice-add 'ai-code-backends-infra--note-meaningful-output
                       :before note-advice)
-          (advice-add 'ai-code-session-link--linkify-recent-output
-                      :around linkify-advice)
+          (advice-add 'ai-code-session-link--schedule-linkify-recent-output
+                      :around schedule-advice)
           (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-ensure-backend)
                      (lambda () nil))
                     ((symbol-function 'ghostel-exec)
@@ -1478,9 +1501,11 @@ The prefix argument should also force instance-name prompting."
           (funcall (process-filter proc) proc "src/foo.el:12\n")
           (should (equal orig-outputs '("src/foo.el:12\n")))
           (should (equal meaningful-outputs '(noted)))
-          (should (equal linkify-outputs '("src/foo.el:12\n"))))
+          (should (equal scheduled-outputs
+                         (list (list buffer "src/foo.el:12\n" 0.05)))))
       (advice-remove 'ai-code-backends-infra--note-meaningful-output note-advice)
-      (advice-remove 'ai-code-session-link--linkify-recent-output linkify-advice)
+      (advice-remove 'ai-code-session-link--schedule-linkify-recent-output
+                     schedule-advice)
       (when (process-live-p proc)
         (delete-process proc))
       (when (buffer-live-p buffer)
@@ -1492,7 +1517,7 @@ The prefix argument should also force instance-name prompting."
          (buffer (get-buffer-create buffer-name))
          (orig-filter-called nil)
          (note-called nil)
-         (linkify-called nil)
+         (schedule-called nil)
          (wrapped-filter nil)
          (ai-code-backends-infra-terminal-backend 'ghostel))
     (unwind-protect
@@ -1523,9 +1548,9 @@ The prefix argument should also force instance-name prompting."
                     ((symbol-function 'ai-code-backends-infra--note-meaningful-output)
                      (lambda (&rest _args)
                        (setq note-called t)))
-                    ((symbol-function 'ai-code-session-link--linkify-recent-output)
+                    ((symbol-function 'ai-code-session-link--schedule-linkify-recent-output)
                      (lambda (&rest _args)
-                       (setq linkify-called t))))
+                       (setq schedule-called t))))
             (ai-code-backends-infra--create-terminal-session
              buffer-name
              default-directory
@@ -1540,7 +1565,7 @@ The prefix argument should also force instance-name prompting."
              (error t)))
           (should-not orig-filter-called)
           (should-not note-called)
-          (should-not linkify-called))
+          (should-not schedule-called))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 

--- a/test/test_ai-code-input.el
+++ b/test/test_ai-code-input.el
@@ -1125,6 +1125,76 @@
     (when (buffer-live-p opened-buffer)
       (kill-buffer opened-buffer))))
 
+(ert-deftest ai-code-test-session-navigate-link-at-point-keeps-ghostel-image-after-open ()
+  "Image session links in Ghostel should open files and keep inline previews."
+  (let* ((root (make-temp-file "ai-code-session-link-image-nav-" t))
+         (image-file (expand-file-name "screenshot.png" root))
+         opened-file
+         opened-buffer
+         session-buffer
+         navigation-timer-called)
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (list :image file :args args)))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (file)
+                       (setq opened-file file)
+                       (setq opened-buffer
+                             (get-buffer-create " *ai-code-opened-image*"))
+                       (set-buffer opened-buffer)
+                       opened-buffer))
+                    ((symbol-function 'run-at-time)
+                     (lambda (&rest _args)
+                       (setq navigation-timer-called t)))
+                    ((symbol-function 'message)
+                     (lambda (&rest _args) nil)))
+            (with-temp-buffer
+              (setq session-buffer (current-buffer))
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "Saved screenshot.png\n")
+              (ai-code-session-link--linkify-session-region
+               (point-min) (point-max))
+              (goto-char (point-min))
+              (search-forward "screenshot.png")
+              (ai-code-session-navigate-link-at-point)
+              (should (equal opened-file image-file))
+              (should-not navigation-timer-called)
+              (with-current-buffer session-buffer
+                (should
+                 (= (length
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max))))
+                    1)))
+              (setq opened-file nil)
+              (with-current-buffer session-buffer
+                (goto-char (point-min))
+                (search-forward "screenshot.png")
+                (end-of-line)
+                (ai-code-session-navigate-link-at-point))
+              (should (equal opened-file image-file))
+              (should-not navigation-timer-called)
+              (with-current-buffer session-buffer
+                (should
+                 (= (length
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max))))
+                    1))))))
+      (when (get-buffer " *ai-code-opened-image*")
+        (kill-buffer " *ai-code-opened-image*"))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
 (ert-deftest ai-code-test-parse-session-link-file-with-line-and-column ()
   "Session link parsing should keep file, line, and column metadata."
   (should (equal (ai-code--parse-session-link "src/Foo.java:42:8")
@@ -1385,4 +1455,3 @@
 
 (provide 'test_ai-code-input)
 ;;; test_ai-code-input.el ends here
-

--- a/test/test_ai-code-session-link.el
+++ b/test/test_ai-code-session-link.el
@@ -13,6 +13,7 @@
 (require 'ai-code-session-link)
 
 (defvar ai-code-backends-infra--session-directory)
+(defvar ai-code-backends-infra--session-terminal-backend)
 
 (ert-deftest ai-code-session-link-test-toggle-defaults-enabled ()
   "Session linkification should be enabled by default."
@@ -25,6 +26,19 @@
                  "src/Foo.java"))
   (should (equal (ai-code-session-link--normalize-file "file:///tmp/project/Foo.java")
                  "/tmp/project/Foo.java"))
+  (should (equal (ai-code-session-link--normalize-file "file://localhost/tmp/project/Foo.java")
+                 "/tmp/project/Foo.java"))
+  (should (equal (ai-code-session-link--normalize-file "file:/tmp/project/Foo.java")
+                 "/tmp/project/Foo.java"))
+  (should (equal (ai-code-session-link--normalize-file
+                  "file:///tmp/project/image-\nwrapped.png")
+                 "/tmp/project/image-wrapped.png"))
+  (should (equal (ai-code-session-link--normalize-file
+                  "<file:///tmp/project/My%20Image.png>")
+                 "/tmp/project/My Image.png"))
+  (should (equal (ai-code-session-link--normalize-file
+                  "./screens/My\\ Image.png")
+                 "./screens/My Image.png"))
   (should-not (ai-code-session-link--normalize-file "   ")))
 
 (ert-deftest ai-code-session-link-test-project-files-expands-relative-project-entries ()
@@ -797,6 +811,741 @@
                "src/FileABC.java:42")
               (should-not ai-code-session-link--linkify-timer)
               (should (zerop ai-code-session-link--pending-tail-width)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-adds-overlay ()
+  "Ghostel sessions should preview local image file links."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-" t))
+         (image-file (expand-file-name "screenshot.png" root))
+         (created-image nil))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (setq created-image (cons data args))
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "Saved screenshot.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (goto-char (point-min))
+              (search-forward "screenshot.png")
+              (let* ((link-start (match-beginning 0))
+                     (link-end (match-end 0))
+                     (preview-overlays
+                      (cl-remove-if-not
+                       (lambda (overlay)
+                         (overlay-get overlay 'ai-code-session-image-preview))
+                       (overlays-in (point-min) (point-max)))))
+                (should (equal (get-text-property (match-beginning 0)
+                                                  'ai-code-session-link)
+                               "screenshot.png"))
+                (should (= (length preview-overlays) 1))
+                (should (equal (overlay-get (car preview-overlays)
+                                            'ai-code-session-image-file)
+                               image-file))
+                (should (= (overlay-start (car preview-overlays))
+                           link-start))
+                (should (= (overlay-end (car preview-overlays))
+                           link-end))
+                (should (equal (car created-image) "fake image bytes"))
+                (should-not (equal (car created-image) image-file))
+                (should (nth 2 created-image))
+                (should (member :max-width created-image))
+                (should-not (member :max-height created-image))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-unicode-trailing-punctuation-categories ()
+  "Image preview suffix detection should use Unicode punctuation categories."
+  (should (ai-code-session-link--unicode-trailing-punctuation-p ?\u3002))
+  (should (ai-code-session-link--unicode-trailing-punctuation-p ?\u061f))
+  (should (ai-code-session-link--unicode-trailing-punctuation-p ?\uff09))
+  (should-not (ai-code-session-link--unicode-trailing-punctuation-p ?/))
+  (should-not (ai-code-session-link--unicode-trailing-punctuation-p ?a)))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-follows-trailing-punctuation ()
+  "Image previews should appear after sentence punctuation following a path."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-punctuation-" t))
+         (image-file (expand-file-name "screenshot.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (list :image data :args args))))
+            (dolist (suffix (list "." (string ?\u3002)))
+              (with-temp-buffer
+                (setq-local ai-code-backends-infra--session-directory root)
+                (setq-local ai-code-backends-infra--session-terminal-backend
+                            'ghostel)
+                (insert "Saved " image-file suffix "\n")
+                (ai-code-session-link--linkify-session-region
+                 (point-min) (point-max))
+                (goto-char (point-min))
+                (search-forward image-file)
+                (let* ((link-start (match-beginning 0))
+                       (link-end (match-end 0))
+                       (preview-overlays
+                        (cl-remove-if-not
+                         (lambda (overlay)
+                           (overlay-get overlay 'ai-code-session-image-preview))
+                         (overlays-in (point-min) (point-max))))
+                       (overlay (car preview-overlays)))
+                  (should (= (length preview-overlays) 1))
+                  (should (= (overlay-start overlay) link-start))
+                  (should (= (overlay-end overlay) (1+ link-end)))
+                  (should (equal (overlay-get
+                                  overlay
+                                  'ai-code-session-image-display-text)
+                                 (concat image-file suffix)))
+                  (should (equal (overlay-get
+                                  overlay
+                                  'ai-code-session-image-link-text)
+                                 image-file))
+                  (should-not
+                   (ai-code-session-link--image-preview-refresh-needed-p
+                    (point-min) (point-max))))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-remote-ghostel-generic-linkify-skips-file-stats ()
+  "Remote Ghostel generic linkification should not stat TRAMP candidates."
+  (let ((remote-root "/mock-remote/tmp/project/")
+        (file-exists-called nil)
+        (create-image-called nil))
+    (cl-letf (((symbol-function 'display-images-p)
+               (lambda (&optional _display) t))
+              ((symbol-function 'file-remote-p)
+               (lambda (file &rest _args)
+                 (and (stringp file)
+                      (string-prefix-p "/mock-remote/" file))))
+              ((symbol-function 'file-exists-p)
+               (lambda (_file)
+                 (setq file-exists-called t)
+                 nil))
+              ((symbol-function 'create-image)
+               (lambda (&rest _args)
+                 (setq create-image-called t)
+                 'image)))
+      (with-temp-buffer
+        (setq-local ai-code-backends-infra--session-directory
+                    remote-root)
+        (setq-local ai-code-backends-infra--session-terminal-backend
+                    'ghostel)
+        (setq-local default-directory remote-root)
+        (insert "Saved ./remote.png\n")
+        (ai-code-session-link--linkify-session-region
+         (point-min) (point-max))
+        (should-not file-exists-called)
+        (should-not create-image-called)
+        (should-not
+         (cl-some
+          (lambda (overlay)
+            (overlay-get overlay 'ai-code-session-image-preview))
+          (overlays-in (point-min) (point-max))))))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-wrapped-bare-path ()
+  "A bare local image path hard-wrapped across terminal rows should preview.
+Tools such as Claude print bare paths (no `file://' prefix); when the path
+is long enough Ghostel wraps it, splitting the token across rows.  The
+detection regexp must stitch those rows back together."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-wrap-" t))
+         (image-file
+          (expand-file-name
+           "a-very-long-wrapped-screenshot-name-for-terminal-testing.png"
+           root))
+         (split (/ (length image-file) 2))
+         (head (substring image-file 0 split))
+         (tail (substring image-file split))
+         (created-image nil))
+    ;; Guard against an accidental split inside a space run; the temp path
+    ;; has none, but keep the invariant explicit for future readers.
+    (should-not (string-match-p "[ \t]" image-file))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (setq created-image (cons data args))
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              ;; Mimic a Ghostel hard wrap: the path breaks mid-token and the
+              ;; continuation row carries a leading render gutter.
+              (insert (format "Wrote %s\n    %s\n" head tail))
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (let ((preview-overlays
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max)))))
+                (should (= (length preview-overlays) 1))
+                (should (equal (overlay-get (car preview-overlays)
+                                            'ai-code-session-image-file)
+                               image-file))
+                (should (equal (car created-image) "fake image bytes"))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-keeps-line-gutter ()
+  "Image previews should align with the image path line's leading gutter."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-indent-" t))
+         (image-file (expand-file-name "screenshot.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (list :image file :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "    | /tmp/nope.txt\n")
+              (insert "    | screenshot.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (let* ((preview-overlays
+                      (cl-remove-if-not
+                       (lambda (overlay)
+                         (overlay-get overlay 'ai-code-session-image-preview))
+                       (overlays-in (point-min) (point-max))))
+                     (after-string (overlay-get (car preview-overlays)
+                                                'after-string)))
+                (should (= (length preview-overlays) 1))
+                (should (string-prefix-p "\n    " after-string))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-absorbs-clicks ()
+  "Clicking the inline image preview should not open the file link."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-click-" t))
+         (image-file (expand-file-name "screenshot.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (list :image file :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "Saved screenshot.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (let* ((preview-overlays
+                      (cl-remove-if-not
+                       (lambda (overlay)
+                         (overlay-get overlay 'ai-code-session-image-preview))
+                       (overlays-in (point-min) (point-max))))
+                     (overlay (car preview-overlays))
+                     (after-string (overlay-get overlay 'after-string))
+                     (image-index (cl-position-if
+                                   (lambda (index)
+                                     (get-text-property index 'display after-string))
+                                   (number-sequence 0 (1- (length after-string)))))
+                     (preview-keymap
+                      (and image-index
+                           (get-text-property image-index 'keymap after-string))))
+                (should (= (length preview-overlays) 1))
+                (goto-char (point-min))
+                (search-forward "screenshot.png")
+                (should (eq (lookup-key (get-text-property (match-beginning 0)
+                                                           'keymap)
+                                        [mouse-1])
+                            'ai-code-session-navigate-link-at-mouse))
+                (should preview-keymap)
+                (should (eq (lookup-key preview-keymap [mouse-1])
+                            'ai-code-session-link--ignore-image-preview-event))
+                (should-not (eq (lookup-key preview-keymap [mouse-1])
+                                'ai-code-session-navigate-link-at-mouse))
+                (should-not (overlay-get overlay 'keymap))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-recreates-missing-overlay ()
+  "Image previews should be recreated when link text is already linked."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-recreate-" t))
+         (image-file (expand-file-name "screenshot.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (list :image file :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "Saved screenshot.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (dolist (overlay (overlays-in (point-min) (point-max)))
+                (when (overlay-get overlay 'ai-code-session-image-preview)
+                  (delete-overlay overlay)))
+              (goto-char (point-min))
+              (search-forward "screenshot.png")
+              (should (get-text-property (match-beginning 0)
+                                         'ai-code-session-link))
+              (ai-code-session-link--linkify-file-region (point-min) (point-max))
+              (should
+               (= (length
+                   (cl-remove-if-not
+                    (lambda (overlay)
+                      (overlay-get overlay 'ai-code-session-image-preview))
+                    (overlays-in (point-min) (point-max))))
+                  1)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-refreshes-unchanged-history ()
+  "Image previews should refresh for unchanged Ghostel history text."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-history-" t))
+         (image-file (expand-file-name "history.png" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (with-temp-buffer
+            (setq-local ai-code-backends-infra--session-directory root)
+            (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+            (insert "Saved history.png\n")
+            (cl-letf (((symbol-function 'display-images-p)
+                       (lambda (&optional _display) nil)))
+              (ai-code-session-link--linkify-session-region (point-min) (point-max)))
+            (goto-char (point-min))
+            (search-forward "history.png")
+            (should (get-text-property (match-beginning 0)
+                                       'ai-code-session-link))
+            (should-not
+             (cl-some
+              (lambda (overlay)
+                (overlay-get overlay 'ai-code-session-image-preview))
+              (overlays-in (point-min) (point-max))))
+            (cl-letf (((symbol-function 'display-images-p)
+                       (lambda (&optional _display) t))
+                      ((symbol-function 'create-image)
+                       (lambda (file &rest args)
+                         (list :image file :args args))))
+              (ai-code-session-link--linkify-session-region (point-min) (point-max)))
+            (should
+             (= (length
+                 (cl-remove-if-not
+                  (lambda (overlay)
+                    (overlay-get overlay 'ai-code-session-image-preview))
+                  (overlays-in (point-min) (point-max))))
+                1))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-keeps-repeated-history-stable ()
+  "Unchanged Ghostel history should not duplicate live image previews."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-repeat-" t))
+         (image-file (expand-file-name "history.png" root))
+         (create-count 0))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (file &rest args)
+                       (setq create-count (1+ create-count))
+                       (list :image file :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "Saved history.png\n")
+              (ai-code-session-link--linkify-session-region
+               (point-min) (point-max))
+              (should (= create-count 1))
+              (ai-code-session-link--linkify-session-region
+               (point-min) (point-max))
+              (should (= create-count 1))
+              (should
+               (= (length
+                   (cl-remove-if-not
+                    (lambda (overlay)
+                      (overlay-get overlay 'ai-code-session-image-preview))
+                    (overlays-in (point-min) (point-max))))
+                  1)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-strict-visible-scan ()
+  "Strict visible image scanning should preview local images without project scans."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-visible-" t))
+         (image-file (expand-file-name "visible.png" root))
+         project-scan-count)
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (list :image data :args args)))
+                    ((symbol-function 'ai-code-session-link--project-files)
+                     (lambda (&rest _args)
+                       (setq project-scan-count (1+ (or project-scan-count 0)))
+                       nil)))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "Saved to: " image-file "\n")
+              (setq buffer-read-only t)
+              (ai-code-session-link--linkify-strict-image-preview-region
+               (point-min) (point-max))
+              (should-not project-scan-count)
+              (should
+               (= (length
+                   (cl-remove-if-not
+                    (lambda (overlay)
+                      (overlay-get overlay 'ai-code-session-image-preview))
+                    (overlays-in (point-min) (point-max))))
+                  1)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-strict-visible-wrap ()
+  "Strict visible image scanning should handle simple wrapped file URLs."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-visible-wrap-" t))
+         (dir (expand-file-name "generated_images/session" root))
+         (image-file (expand-file-name "ig_wrapped_image.png" dir))
+         (split-index (- (length image-file)
+                         (length (file-name-nondirectory image-file)))))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "file://")
+              (insert (substring image-file 0 split-index))
+              (insert "\n  ")
+              (let ((segment-start (point)))
+                (insert (substring image-file split-index))
+                (insert "\n")
+                (setq buffer-read-only t)
+                (ai-code-session-link--linkify-strict-image-preview-region
+                 (point-min) (point-max))
+                (let ((preview-overlays
+                       (cl-remove-if-not
+                        (lambda (overlay)
+                          (overlay-get overlay 'ai-code-session-image-preview))
+                        (overlays-in (point-min) (point-max)))))
+                  (should (= (length preview-overlays) 1))
+                  (should (equal (get-text-property
+                                  segment-start
+                                  'ai-code-session-link)
+                                 (concat "file://" image-file)))
+                  (should (equal (overlay-get (car preview-overlays)
+                                              'ai-code-session-image-file)
+                                 image-file)))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-file-url-wrap ()
+  "Ghostel image previews should handle terminal-wrapped file:// URLs."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-url-" t))
+         (dir (expand-file-name "generated_images/019f3849-01c6-70d2-9306-f19721bfa0f4" root))
+         (image-file (expand-file-name
+                      "ig_0316e59b09ff2b45016a4be031a5b8819ab73e1af52a3e7bd2.png"
+                      dir))
+         (split-index (- (length image-file)
+                         (length (file-name-nondirectory image-file))))
+         (create-image-data nil))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (setq create-image-data data)
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "  file://")
+              (insert (substring image-file 0 split-index))
+              (insert "\n")
+              (insert "    ")
+              (insert (substring image-file split-index))
+              (insert "\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (let ((preview-overlays
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max)))))
+                (should (= (length preview-overlays) 1))
+                (should (equal create-image-data "fake image bytes"))
+                (should (equal (overlay-get (car preview-overlays)
+                                            'ai-code-session-image-file)
+                               image-file))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-strict-visible-wrap-bare-path ()
+  "Strict visible scanning should rejoin a wrapped BARE absolute path.
+Regression: `ai-code-session-link--strict-previous-line-prefix' used a
+malformed negated character class (a `]' escaped with a backslash) that
+closed the class early, so it only matched lines ending in a literal `]'.
+Bare wrapped paths -- as printed by tools such as Claude, which omit the
+`file://' prefix -- were therefore never recovered from the previous row."
+  (let* ((root (make-temp-file
+                "ai-code-session-image-preview-visible-wrap-bare-" t))
+         (dir (expand-file-name
+               "generated/2d806356-90b2-4e71-82fa-30359ee62190" root))
+         (image-file (expand-file-name "ghostel-wrapped-bare-image.png" dir))
+         ;; Break right before the file name so the continuation row is a
+         ;; relative fragment (no leading slash) -- this is what forces the
+         ;; previous-line prefix recovery path (the buggy branch).
+         (split-index (- (length image-file)
+                         (length (file-name-nondirectory image-file)))))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              ;; Bare path (no file:// prefix) hard-wrapped across two rows,
+              ;; each carrying a leading render gutter.
+              (insert "  ")
+              (insert (substring image-file 0 split-index))
+              (insert "\n    ")
+              (insert (substring image-file split-index))
+              (insert "\n")
+              (setq buffer-read-only t)
+              (ai-code-session-link--linkify-strict-image-preview-region
+               (point-min) (point-max))
+              (let ((preview-overlays
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max)))))
+                (should (= (length preview-overlays) 1))
+                (should (equal (overlay-get (car preview-overlays)
+                                            'ai-code-session-image-file)
+                               image-file))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-strict-visible-wrap-three-rows ()
+  "Strict visible scanning should rejoin bare paths wrapped over three rows."
+  (let* ((root (make-temp-file
+                "ai-code-session-image-preview-visible-wrap-three-" t))
+         (dir (expand-file-name "sloth-layout-check" root))
+         (image-file (expand-file-name "sloth-window-after-53660.png" dir))
+         (needle "sloth-layout-check/sloth-window-after-53660.png")
+         (needle-start (string-match (regexp-quote needle) image-file))
+         (path-prefix (substring image-file 0 needle-start)))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "  ")
+              (insert path-prefix)
+              (insert "sloth-layout-\n    check/sloth-window-after-\n    53660.png\n")
+              (setq buffer-read-only t)
+              (ai-code-session-link--linkify-strict-image-preview-region
+               (point-min) (point-max))
+              (let ((preview-overlays
+                     (cl-remove-if-not
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max)))))
+                (should (= (length preview-overlays) 1))
+                (should (equal (overlay-get (car preview-overlays)
+                                            'ai-code-session-image-file)
+                               image-file))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-image-preview-max-dimensions ()
+  "Preview caps: integer customs are hard caps; nil height is uncapped."
+  ;; An explicit integer custom is used verbatim, regardless of any window.
+  (let ((ai-code-session-link-ghostel-image-preview-max-width 400)
+        (ai-code-session-link-ghostel-image-preview-max-height 300))
+    (with-temp-buffer
+      (should (equal (ai-code-session-link--image-preview-max-dimensions "")
+                     '(400 . 300)))))
+  ;; With nil customs and no window showing the buffer, only the fixed width
+  ;; fallback applies.  Height remains uncapped so screenshots can fill width.
+  (let ((ai-code-session-link-ghostel-image-preview-max-width nil)
+        (ai-code-session-link-ghostel-image-preview-max-height nil))
+    (with-temp-buffer
+      (should (equal (ai-code-session-link--image-preview-max-dimensions "  ")
+                     (cons ai-code-session-link--image-preview-fallback-max-width
+                           nil))))))
+
+(ert-deftest ai-code-session-link-test-ghostel-image-preview-common-reference-forms ()
+  "Ghostel image previews should handle common local image reference forms."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-forms-" t))
+         (image-dir (expand-file-name "generated images" root))
+         (spaced-image (expand-file-name "My Image.png" image-dir))
+         (relative-dir (expand-file-name "relative output" root))
+         (relative-image (expand-file-name "Relative Image.png" relative-dir))
+         (plain-image (expand-file-name "plain.png" root)))
+    (unwind-protect
+        (progn
+          (make-directory image-dir t)
+          (make-directory relative-dir t)
+          (dolist (file (list spaced-image relative-image plain-image))
+            (with-temp-file file
+              (insert "fake image bytes")))
+          (cl-labels
+              ((preview-file-for
+                (output)
+                (let (create-image-called)
+                  (cl-letf (((symbol-function 'display-images-p)
+                             (lambda (&optional _display) t))
+                            ((symbol-function 'create-image)
+                             (lambda (data &rest args)
+                               (setq create-image-called t)
+                               (list :image data :args args))))
+                    (with-temp-buffer
+                      (setq-local ai-code-backends-infra--session-directory root)
+                      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+                      (insert output)
+                      (ai-code-session-link--linkify-session-region
+                       (point-min) (point-max))
+                      (let* ((preview-overlays
+                              (cl-remove-if-not
+                               (lambda (overlay)
+                                 (overlay-get overlay 'ai-code-session-image-preview))
+                               (overlays-in (point-min) (point-max))))
+                             (preview-count (length preview-overlays))
+                             (preview-file
+                              (and create-image-called
+                                   (overlay-get (car preview-overlays)
+                                                'ai-code-session-image-file))))
+                        (cons preview-file preview-count)))))))
+            (let ((cases
+                   (list
+                    (list (format "![preview](file://%s)\n"
+                                  (replace-regexp-in-string " " "%20" spaced-image))
+                          spaced-image)
+                    (list (format "[[file:%s][preview]]\n" plain-image)
+                          plain-image)
+                    (list (format "file://localhost%s\n" plain-image)
+                          plain-image)
+                    (list (format "Saved to: \"%s\"\n" spaced-image)
+                          spaced-image)
+                    (list (format "Saved to: %s\n"
+                                  (replace-regexp-in-string " " "\\\\ " spaced-image))
+                          spaced-image)
+                    (list "![preview](relative output/Relative Image.png)\n"
+                          relative-image))))
+              (dolist (case cases)
+                (let ((result (preview-file-for (car case))))
+                  (should (equal (car result) (cadr case)))
+                  (should (= (cdr result) 1)))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-image-preview-skips-non-ghostel-session ()
+  "Image preview overlays should not be added for non-Ghostel terminals."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-skip-" t))
+         (image-file (expand-file-name "screenshot.png" root))
+         (create-image-called nil))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (&rest _args)
+                       (setq create-image-called t)
+                       'image)))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+              (insert "Saved screenshot.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (should-not create-image-called)
+              (should-not
+               (cl-some
+                (lambda (overlay)
+                  (overlay-get overlay 'ai-code-session-image-preview))
+                (overlays-in (point-min) (point-max)))))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-image-preview-respects-size-limit ()
+  "Image previews should skip files over the configured byte limit."
+  (let* ((root (make-temp-file "ai-code-session-image-preview-size-" t))
+         (image-file (expand-file-name "large.png" root))
+         (create-image-called nil)
+         (ai-code-session-link-ghostel-image-preview-max-bytes 1))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "too large"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (&rest _args)
+                       (setq create-image-called t)
+                       'image)))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+              (insert "Saved large.png\n")
+              (ai-code-session-link--linkify-session-region (point-min) (point-max))
+              (should-not create-image-called))))
       (when (file-directory-p root)
         (delete-directory root t)))))
 


### PR DESCRIPTION
## Summary

- Preview images inline in Ghostel AI session buffers: when an AI CLI prints a local image path (for example `screenshot.png`) or a `file://` URL, the image is rendered right below its path in the session.
- Enable Ghostel's Kitty graphics `file` / `temp-file` loading mediums for trusted local sessions, so terminal programs can also transmit images through the Kitty graphics protocol.
- Make previewed image references clickable — activating one opens the underlying file.

## Details

- **Detection** (`ai-code-session-link.el`): recognizes bare local paths, `file://` URLs, and quoted / parenthesized references. Terminal hard-wrapping is handled — a long path split across wrapped rows is stitched back together, both in the live-output scan and in the visible-scrollback recovery scan.
- **Sizing**: previews fit the session window's body by default (`...-max-width` / `...-max-height` default to `nil`), scaling large images down while leaving small images at their native size; an integer imposes a fixed pixel cap instead. Display-density scaling is left to Emacs' `create-image` (`:scale 'default`), so previews match the screen scale on HiDPI displays.
- **Safety**: only local, regular, readable image files are previewed, bounded by `...-max-bytes` (10 MB default). Non-Ghostel sessions and non-image links are left untouched.
- **Rendering** (`ai-code-backends-infra-ghostel.el`): visible-region previews are refreshed on scroll / redraw through bounded, debounced timers so large scrollback stays responsive.
- New user options (documented in README): `ai-code-backends-infra-ghostel-kitty-graphics-mediums`, `ai-code-session-link-ghostel-image-preview-enabled`, `...-max-bytes`, `...-max-width`, `...-max-height`.

## Verification

Run per affected suite with repo sources preferred over the installed package, e.g.:

```
emacs -Q -batch -L . \
  --eval "(setq load-prefer-newer t)" \
  --eval "(let ((default-directory \"~/.emacs.d/elpa/\")) (normal-top-level-add-subdirs-to-load-path))" \
  -l test/test_00-bootstrap.el -l ert \
  -l test/test_ai-code-session-link.el \
  -f ert-run-tests-batch-and-exit
```

- `test/test_ai-code-session-link.el`: 44/44
- `test/test_ai-code-backends-infra-ghostel.el`: 15/15
- `test/test_ai-code-backends-infra.el`: 124/124
- `test/test_ai-code-input.el`: 87/87

`batch-byte-compile` of the four changed source files reports no new warnings (the pre-existing obsolete-`when-let` warnings come from unrelated files).
