### PR TITLE
Fix wrapped session link hover coverage in Ghostel

### DIFF
--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -229,16 +229,19 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
 
 (defun ai-code-backends-infra-ghostel--linkify-visible-image-previews
     (buffer window)
-  "Linkify image previews for visible text in BUFFER shown by WINDOW."
+  "Linkify session links and image previews in BUFFER shown by WINDOW."
   (when (and (buffer-live-p buffer)
              (window-live-p window)
              (eq (window-buffer window) buffer))
     (with-current-buffer buffer
       (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
-      (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
-        (when-let* ((region
-                     (ai-code-backends-infra-ghostel--visible-image-region
-                      window)))
+      (when-let* ((region
+                   (ai-code-backends-infra-ghostel--visible-image-region
+                    window)))
+        (ai-code-session-link--linkify-session-region
+         (car region)
+         (cdr region))
+        (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
           (ai-code-session-link--linkify-strict-image-preview-region
            (car region)
            (cdr region)))))))
@@ -274,15 +277,14 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
 
 (defun ai-code-backends-infra-ghostel--linkify-image-preview-region
     (buffer start end)
-  "Linkify image previews in BUFFER between START and END.
+  "Linkify session links and image previews in BUFFER between START and END.
 The region is bounded so Ghostel redraw/link-detection advice cannot
 accidentally scan an entire scrollback buffer."
   (when (and (buffer-live-p buffer)
              (integer-or-marker-p start)
              (integer-or-marker-p end))
     (with-current-buffer buffer
-      (when (and (ai-code-backends-infra-ghostel--ai-session-buffer-p)
-                 (ai-code-backends-infra-ghostel--trusted-local-session-p))
+      (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
         (save-restriction
           (widen)
           (let ((start (if (markerp start) (marker-position start) start))
@@ -308,12 +310,14 @@ accidentally scan an entire scrollback buffer."
                              (- end
                                 ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
                 (when (< start end)
-                  (ai-code-session-link--linkify-strict-image-preview-region
-                   start end))))))))))
+                  (ai-code-session-link--linkify-session-region start end)
+                  (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
+                    (ai-code-session-link--linkify-strict-image-preview-region
+                     start end)))))))))))
 
 (defun ai-code-backends-infra-ghostel-schedule-visible-image-linkify
     (window &optional delays)
-  "Schedule image preview linkification for visible Ghostel text in WINDOW.
+  "Schedule visible session link and image preview linkification for WINDOW.
 Optional DELAYS overrides
 `ai-code-backends-infra-ghostel-visible-image-linkify-delays'."
   (when (and (window-live-p window)
@@ -324,22 +328,21 @@ Optional DELAYS overrides
           (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
           (ai-code-backends-infra-ghostel--cancel-visible-image-linkify-timers
            window)
-          (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
-            (let ((timers
-                   (mapcar
-                    (lambda (delay)
-                      (run-at-time
-                       delay nil
-                       #'ai-code-backends-infra-ghostel--linkify-visible-image-previews
-                       buffer window))
-                    (or delays
-                        ai-code-backends-infra-ghostel-visible-image-linkify-delays))))
-              (ai-code-backends-infra-ghostel--register-visible-image-linkify-timers
-               window timers))))))))
+          (let ((timers
+                 (mapcar
+                  (lambda (delay)
+                    (run-at-time
+                     delay nil
+                     #'ai-code-backends-infra-ghostel--linkify-visible-image-previews
+                     buffer window))
+                  (or delays
+                      ai-code-backends-infra-ghostel-visible-image-linkify-delays))))
+            (ai-code-backends-infra-ghostel--register-visible-image-linkify-timers
+             window timers)))))))
 
 (defun ai-code-backends-infra-ghostel-schedule-visible-image-linkify-for-buffer
     (&optional buffer delays)
-  "Schedule visible image preview linkification for BUFFER's live windows.
+  "Schedule visible session link and image preview linkification for BUFFER.
 Optional DELAYS overrides the default visible image linkification delays."
   (let ((buffer (or buffer (current-buffer))))
     (when (buffer-live-p buffer)
@@ -348,19 +351,19 @@ Optional DELAYS overrides the default visible image linkification delays."
          window delays)))))
 
 (defun ai-code-backends-infra-ghostel--window-scroll (window _display-start)
-  "Schedule visible image preview linkification after WINDOW scrolls."
+  "Schedule visible session link and image preview linkification for WINDOW."
   (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
    window
    (list ai-code-backends-infra-ghostel-scroll-image-linkify-delay)))
 
 (defun ai-code-backends-infra-ghostel--after-readonly-command (&rest _args)
-  "Schedule visible image preview linkification after Ghostel mode changes."
+  "Schedule visible session link and image preview linkification."
   (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
     (ai-code-backends-infra-ghostel-schedule-visible-image-linkify-for-buffer
      (current-buffer))))
 
 (defun ai-code-backends-infra-ghostel--after-redispatch-scroll-event (event)
-  "Schedule visible image preview linkification after Ghostel scroll EVENT."
+  "Schedule visible session link and image preview linkification after EVENT."
   (when-let* ((window (ignore-errors (posn-window (event-start event))))
               ((window-live-p window)))
     (ai-code-backends-infra-ghostel-schedule-visible-image-linkify

--- a/ai-code-session-link.el
+++ b/ai-code-session-link.el
@@ -100,6 +100,22 @@ impose a fixed hard cap instead."
     map)
   "Keymap used to keep inline image previews from opening file links.")
 
+(defconst ai-code-session-link--managed-properties
+  '(ai-code-session-link nil
+    ai-code-session-symbol-link nil
+    ai-code-session-symbol-file nil
+    ai-code-session-hover-link nil
+    mouse-face nil
+    help-echo nil
+    keymap nil
+    follow-link nil
+    font-lock-face nil
+    face nil)
+  "Text properties managed by AI Code session linkification.")
+
+(defconst ai-code-session-link--linkify-rules-version 1
+  "Version of session linkification rules used by unchanged-region caching.")
+
 (defconst ai-code-session-link--linkify-min-tail-width 512
   "Minimum number of tail characters to rescan for session links.")
 
@@ -109,6 +125,33 @@ impose a fixed hard cap instead."
 (defconst ai-code-session-link--url-pattern-regexp
   "\\(https?://[^][(){}<>\"' \t\n]+\\)"
   "Regexp matching http/https URLs in session buffers.")
+
+(defconst ai-code-session-link--url-fragment-regexp
+  "[^][(){}<>\"' \t\n\r]+"
+  "Regexp matching one terminal row fragment of a URL.")
+
+(defconst ai-code-session-link--url-continuation-end-cue-regexp
+  "[?#&=._%+-]"
+  "Regexp matching URL punctuation that can end a wrapped row.")
+
+(defconst ai-code-session-link--url-continuation-start-cue-regexp
+  "[/?#&=._%+-]"
+  "Regexp matching URL punctuation that can start a wrapped row.")
+
+(defconst ai-code-session-link--url-query-fragment-regexp
+  "[?#&=]"
+  "Regexp matching query punctuation inside a wrapped URL fragment.")
+
+(defconst ai-code-session-link--url-mid-token-cue-regexp
+  "[-._~%]"
+  "Regexp matching path token punctuation that suggests a URL wraps mid-token.")
+
+(defconst ai-code-session-link--url-mid-token-fragment-regexp
+  "\\`[[:alnum:]][[:alnum:]._~%-]*\\'"
+  "Regexp matching a URL path token fragment split across terminal rows.")
+
+(defconst ai-code-session-link--wrapped-url-max-lines 8
+  "Maximum number of terminal rows inspected for one wrapped URL.")
 
 (defconst ai-code-session-link--symbol-neighborhood-max-width 168
   "Maximum number of characters to scan for symbols near a file link.")
@@ -340,6 +383,9 @@ Tolerates Ghostel hard-wrapping via
 (defvar-local ai-code-session-link--last-region-text nil
   "Last relinkified region text used to skip unchanged property churn.")
 
+(defvar-local ai-code-session-link--last-region-rules-version nil
+  "Linkification rules version used for the last relinkified region.")
+
 (defvar ai-code-session-link--project-files-cache nil
   "Dynamic cache of project file lists used during one linkify pass.")
 
@@ -380,6 +426,11 @@ Tolerates Ghostel hard-wrapping via
   (when (stringp text)
     (replace-regexp-in-string "[\n\r][ \t]*" "" text)))
 
+(defun ai-code-session-link--normalize-url-link-text (text)
+  "Normalize visible URL TEXT across terminal-wrapped rows."
+  (when (stringp text)
+    (replace-regexp-in-string "[ \t]*[\n\r][ \t]*" "" text)))
+
 (defun ai-code-session-link--cache-get-or-compute (cache key compute)
   "Return cached value from CACHE for KEY, or call COMPUTE and store it."
   (if cache
@@ -400,6 +451,8 @@ Tolerates Ghostel hard-wrapping via
 (defun ai-code-session-link--unchanged-region-p (bounds region-text)
   "Return non-nil when BOUNDS and REGION-TEXT match the last relinkified region."
   (and (equal ai-code-session-link--last-region-bounds bounds)
+       (equal ai-code-session-link--last-region-rules-version
+              ai-code-session-link--linkify-rules-version)
        (equal ai-code-session-link--last-region-text region-text)))
 
 (defun ai-code-session-link--project-files (root)
@@ -473,21 +526,42 @@ Optional PROJECT-FILES supplies the project file list."
                    (file-exists-p candidate)))
             (ai-code-session-link--local-path-candidates path root)))
 
-(defun ai-code-session-link--cheap-file-link-candidate-p (path &optional root)
+(defun ai-code-session-link--syntactic-file-link-candidate-p (path)
+  "Return non-nil when PATH is syntactically file-like."
+  (when-let* ((normalized (ai-code-session-link--normalize-file path)))
+    (let ((extension (file-name-extension normalized)))
+      (or (string-match-p "\\`file:" normalized)
+          (file-name-absolute-p normalized)
+          (string-prefix-p "~/" normalized)
+          (string-prefix-p "./" normalized)
+          (string-prefix-p "../" normalized)
+          (string-match-p "[/\\\\]" normalized)
+          (and extension
+               (member (downcase extension)
+                       ai-code-session-link--basename-file-extensions))))))
+
+(defun ai-code-session-link--cheap-file-link-candidate-p
+    (path &optional root allow-local-probing)
   "Return non-nil when PATH is worth linkifying without project scans.
 Optional ROOT is the session project root used for bounded local existence
-checks.  Expensive project-wide resolution stays in
+checks.  When ALLOW-LOCAL-PROBING is nil, only syntactic checks are used.
+Expensive project-wide resolution stays in
 `ai-code-session-link--resolve-session-file' on activation."
   (when-let* ((normalized (ai-code-session-link--normalize-file path)))
     (let ((extension (file-name-extension normalized)))
-      (or (ai-code-session-link--resolve-existing-local-path normalized root)
+      (or (and allow-local-probing
+               (ai-code-session-link--resolve-existing-local-path
+                normalized root))
           (and (not (file-name-absolute-p normalized))
                (or (string-prefix-p "./" normalized)
                    (string-prefix-p "../" normalized)
                    (string-match-p "[/\\\\]" normalized)
                    (and extension
                         (member (downcase extension)
-                                ai-code-session-link--basename-file-extensions))))))))
+                                ai-code-session-link--basename-file-extensions))))
+          (and (not allow-local-probing)
+               (ai-code-session-link--syntactic-file-link-candidate-p
+                normalized))))))
 
 (defun ai-code-session-link--resolve-session-file (path)
   "Resolve PATH to an existing local path or a matching project file."
@@ -714,7 +788,8 @@ INDENT is inserted before the image on the preview line."
            (ai-code-session-link--buffer-project-files-cache))
           (ai-code-session-link--resolved-path-cache
            (make-hash-table :test 'equal)))
-      (dolist (file-link (ai-code-session-link--collect-file-links start end))
+      (dolist (file-link (ai-code-session-link--collect-file-links
+                          start end t))
         (let ((link-start (plist-get file-link :start))
               (link-end (plist-get file-link :end))
               (link-text (plist-get file-link :text)))
@@ -841,7 +916,16 @@ Optional HELP-ECHO overrides the hover help text."
 
 (defun ai-code-session-link--apply-link-properties-to-visible-text
     (start end properties)
-  "Apply PROPERTIES from START to END, skipping wrapped-line indentation."
+  "Apply PROPERTIES from START to END, skipping wrapped-line indentation.
+
+The visual link face is applied only to visible path fragments, but
+`mouse-face' spans the full wrapped range so hovering any fragment highlights
+the complete path."
+  (when-let* ((mouse-face (plist-get properties 'mouse-face)))
+    (add-text-properties
+     start end
+     (list 'ai-code-session-hover-link t
+           'mouse-face mouse-face)))
   (save-excursion
     (goto-char start)
     (let ((segment-start start)
@@ -851,12 +935,37 @@ Optional HELP-ECHO overrides the hover help text."
         (skip-chars-forward " \t" (min end (line-end-position)))
         (setq segment-start (point)
               segment-end (min end (line-end-position)))
-        (when (< segment-start segment-end)
-          (add-text-properties segment-start segment-end properties))
+        (let ((visible-end segment-end))
+          (while (and (< segment-start visible-end)
+                      (memq (char-before visible-end) '(?\s ?\t)))
+            (setq visible-end (1- visible-end)))
+          (when (< segment-start visible-end)
+            (add-text-properties segment-start visible-end properties)))
         (setq segment-start
               (if (< segment-end end)
                   (1+ segment-end)
                 end))))))
+
+(defun ai-code-session-link--remove-managed-properties-in-spans
+    (start end property)
+  "Remove managed properties from START to END in spans carrying PROPERTY."
+  (let ((pos start))
+    (while (< pos end)
+      (let ((next (or (next-single-property-change pos property nil end)
+                      end)))
+        (when (get-text-property pos property)
+          (remove-text-properties
+           pos next ai-code-session-link--managed-properties))
+        (setq pos next)))))
+
+(defun ai-code-session-link--remove-managed-properties (start end)
+  "Remove managed session link properties from START to END."
+  (ai-code-session-link--remove-managed-properties-in-spans
+   start end 'ai-code-session-hover-link)
+  ;; Keep removing older linkified regions that predate
+  ;; `ai-code-session-hover-link'.
+  (ai-code-session-link--remove-managed-properties-in-spans
+   start end 'ai-code-session-link))
 
 (defun ai-code-session-link--apply-symbol-properties (start end symbol file-link)
   "Apply clickable SYMBOL properties from START to END using FILE-LINK."
@@ -993,10 +1102,10 @@ Optional NEXT-FILE-START caps the scan boundary."
                  symbol-start symbol-end candidate file-link)
                 (setq link-count (1+ link-count))))))))))
 
-(defun ai-code-session-link--sort-and-prune-file-links (file-links)
-  "Return FILE-LINKS ordered by start, with contained links removed."
+(defun ai-code-session-link--sort-and-prune-links (links)
+  "Return LINKS ordered by start, with contained links removed."
   (let ((sorted
-         (sort file-links
+         (sort links
                (lambda (left right)
                  (let ((left-start (plist-get left :start))
                        (right-start (plist-get right :start))
@@ -1023,6 +1132,24 @@ Optional NEXT-FILE-START caps the scan boundary."
     (goto-char start)
     (skip-chars-forward " \t" end)
     (>= (point) end)))
+
+(defun ai-code-session-link--blank-or-url-closer-between-p (start end)
+  "Return non-nil when START to END is blank or URL closing syntax."
+  (save-excursion
+    (goto-char start)
+    (skip-chars-forward " \t" end)
+    (while (and (< (point) end)
+                (memq (char-after) '(?\" ?' ?\) ?\] ?\})))
+      (forward-char 1)
+      (skip-chars-forward " \t" end))
+    (>= (point) end)))
+
+(defun ai-code-session-link--path-token-separator-at-p (position limit)
+  "Return non-nil when POSITION is a path token separator before LIMIT."
+  (save-excursion
+    (goto-char position)
+    (and (< (point) limit)
+         (memq (char-after) '(?\s ?\t)))))
 
 (defun ai-code-session-link--wrapped-suffix-prefix-between-p (start end)
   "Return non-nil when text between START and END may precede a wrapped suffix."
@@ -1056,18 +1183,23 @@ Optional NEXT-FILE-START caps the scan boundary."
   (or (ai-code-session-link--file-suffix-end-at base-end line-end)
       base-end))
 
-(defun ai-code-session-link--wrapped-file-link-candidate-p (text root)
-  "Return non-nil when wrapped link TEXT resolves to a local file for ROOT."
+(defun ai-code-session-link--wrapped-file-link-candidate-p
+    (text root allow-local-probing)
+  "Return non-nil when wrapped link TEXT is a file reference.
+ROOT is used for local existence checks when ALLOW-LOCAL-PROBING is non-nil."
   (when-let* ((parsed (ai-code-session-link--parse-file-link-text text))
               (file (plist-get parsed :file))
               (normalized (ai-code-session-link--normalize-file file)))
-    (ai-code-session-link--resolve-existing-local-path normalized root)))
+    (if allow-local-probing
+        (ai-code-session-link--resolve-existing-local-path normalized root)
+      (ai-code-session-link--syntactic-file-link-candidate-p normalized))))
 
 (defun ai-code-session-link--wrapped-file-link-at
-    (match-start match-end scan-end root)
+    (match-start match-end scan-end root allow-local-probing)
   "Return a wrapped file link candidate starting at MATCH-START.
 MATCH-END is the end of the first-row path match.  SCAN-END bounds the
-search, and ROOT is the session project root."
+search, and ROOT is the session project root.  ALLOW-LOCAL-PROBING
+controls whether local existence checks are allowed."
   (save-excursion
     (goto-char match-start)
     (let ((first-line-end (min scan-end (line-end-position)))
@@ -1095,9 +1227,14 @@ search, and ROOT is the session project root."
               (let* ((base-end (cdr fragment))
                      (link-end
                       (ai-code-session-link--file-link-end-at
-                       base-end next-line-end)))
-                (if (not (ai-code-session-link--blank-between-p
-                          link-end next-line-end))
+                       base-end next-line-end))
+                     (blank-after-link
+                      (ai-code-session-link--blank-between-p
+                       link-end next-line-end))
+                     (token-ends-after-link
+                      (ai-code-session-link--path-token-separator-at-p
+                       link-end next-line-end)))
+                (if (not (or blank-after-link token-ends-after-link))
                     (setq scan nil)
                   (cl-incf continued-lines)
                   (let ((link-text
@@ -1105,16 +1242,19 @@ search, and ROOT is the session project root."
                           (buffer-substring-no-properties
                            match-start link-end))))
                     (when (ai-code-session-link--wrapped-file-link-candidate-p
-                           link-text root)
+                           link-text root allow-local-probing)
                       (setq best-link
                             (list :start match-start
                                   :end link-end
                                   :text link-text))))
-                  (setq current-line-end next-line-end)))))))
+                  (setq current-line-end next-line-end
+                        scan blank-after-link)))))))
       best-link)))
 
-(defun ai-code-session-link--collect-wrapped-file-links (start end root)
-  "Return hard-wrapped file link matches between START and END for ROOT."
+(defun ai-code-session-link--collect-wrapped-file-links
+    (start end root allow-local-probing)
+  "Return hard-wrapped file link matches between START and END for ROOT.
+ALLOW-LOCAL-PROBING controls whether local existence checks are allowed."
   (let (file-links)
     (save-excursion
       (goto-char start)
@@ -1124,23 +1264,27 @@ search, and ROOT is the session project root."
                       (match-beginning 0)
                       (match-end 0)
                       end
-                      root)))
+                      root
+                      allow-local-probing)))
           (push file-link file-links))))
     (nreverse file-links)))
 
-(defun ai-code-session-link--collect-file-links (start end)
-  "Return file link matches between START and END without eager resolution."
+(defun ai-code-session-link--collect-file-links
+    (start end allow-local-probing)
+  "Return file link matches between START and END.
+When ALLOW-LOCAL-PROBING is nil, only syntactic checks are used."
   (let ((root (ai-code-session-link--project-root-for-paths))
         (seen-starts (make-hash-table :test 'eql))
         file-links)
     (setq file-links
-          (ai-code-session-link--collect-wrapped-file-links start end root))
+          (ai-code-session-link--collect-wrapped-file-links
+           start end root allow-local-probing))
     (cl-labels
         ((add-link
           (match-start match-end link-text &optional candidate-text)
           (unless (gethash match-start seen-starts)
             (when (ai-code-session-link--cheap-file-link-candidate-p
-                   (or candidate-text link-text) root)
+                   (or candidate-text link-text) root allow-local-probing)
               (puthash match-start t seen-starts)
               (push (list :start match-start
                           :end match-end
@@ -1165,22 +1309,163 @@ search, and ROOT is the session project root."
                match-start match-end
                (buffer-substring-no-properties match-start match-end)
                path))))))
-    (ai-code-session-link--sort-and-prune-file-links file-links)))
+    (ai-code-session-link--sort-and-prune-links file-links)))
+
+(defun ai-code-session-link--trim-url-end (start end)
+  "Return URL end from START to END without terminal punctuation."
+  (while (and (< start end)
+              (memq (char-before end) '(?. ?, ?\; ?: ?! ??)))
+    (setq end (1- end)))
+  end)
+
+(defun ai-code-session-link--line-hard-wrapped-p (start end)
+  "Return non-nil when START to END appears to fill the session window."
+  (when-let* ((window (get-buffer-window (current-buffer) t)))
+    (>= (string-width (buffer-substring-no-properties start end))
+        (max 1 (window-body-width window)))))
+
+(defun ai-code-session-link--line-url-fragment-bounds (start end)
+  "Return URL fragment bounds between START and END after indentation."
+  (save-excursion
+    (goto-char start)
+    (skip-chars-forward " \t" end)
+    (let ((fragment-start (point)))
+      (when (looking-at ai-code-session-link--url-fragment-regexp)
+        (let ((fragment-end (min (match-end 0) end)))
+          (when (< fragment-start fragment-end)
+            (cons fragment-start fragment-end)))))))
+
+(defun ai-code-session-link--url-path-tail (url)
+  "Return the final path token in URL, or nil when URL has no path."
+  (when (string-match "\\`https?://[^/]+/\\(.+\\)\\'" url)
+    (let* ((path (replace-regexp-in-string "[?#].*\\'" "" (match-string 1 url)))
+           (tail (car (last (split-string path "/" t)))))
+      (and (not (string-empty-p tail)) tail))))
+
+(defun ai-code-session-link--url-mid-token-continuation-p
+    (fragment previous-fragment)
+  "Return non-nil when FRAGMENT continues PREVIOUS-FRAGMENT mid-token."
+  (when-let* ((tail (ai-code-session-link--url-path-tail previous-fragment)))
+    (and (not (string-suffix-p "/" previous-fragment))
+         (string-match-p ai-code-session-link--url-mid-token-cue-regexp tail)
+         (string-match-p ai-code-session-link--url-mid-token-fragment-regexp
+                         fragment))))
+
+(defun ai-code-session-link--url-continuation-fragment-p
+    (fragment previous-fragment hard-wrap-p)
+  "Return non-nil when FRAGMENT can continue PREVIOUS-FRAGMENT.
+HARD-WRAP-P means the previous terminal row appears to fill the window."
+  (or hard-wrap-p
+      (string-match-p
+       (concat ai-code-session-link--url-continuation-end-cue-regexp "\\'")
+       previous-fragment)
+      (string-match-p
+       (concat "\\`" ai-code-session-link--url-continuation-start-cue-regexp)
+       fragment)
+      (string-match-p ai-code-session-link--url-query-fragment-regexp
+                      fragment)
+      (ai-code-session-link--url-mid-token-continuation-p
+       fragment previous-fragment)))
+
+(defun ai-code-session-link--wrapped-url-at (match-start match-end scan-end)
+  "Return a wrapped URL candidate starting at MATCH-START.
+MATCH-END is the end of the first-row URL match.  SCAN-END bounds the search."
+  (save-excursion
+    (goto-char match-start)
+    (let* ((current-line-start (line-beginning-position))
+           (current-line-end (min scan-end (line-end-position)))
+           (current-line-hard-wrap
+            (ai-code-session-link--line-hard-wrapped-p
+             current-line-start current-line-end))
+           (first-link-end
+            (ai-code-session-link--trim-url-end match-start match-end))
+           (previous-fragment
+            (buffer-substring-no-properties match-start first-link-end))
+           (continued-lines 0)
+           (best-link nil)
+           (scan (and (= first-link-end match-end)
+                      (ai-code-session-link--blank-between-p
+                       match-end current-line-end))))
+      (while (and scan
+                  (< continued-lines ai-code-session-link--wrapped-url-max-lines)
+                  (< current-line-end scan-end)
+                  (eq (char-after current-line-end) ?\n))
+        (let* ((next-line-start (1+ current-line-end))
+               (next-line-end
+                (save-excursion
+                  (goto-char next-line-start)
+                  (min scan-end (line-end-position))))
+               (fragment
+                (ai-code-session-link--line-url-fragment-bounds
+                 next-line-start next-line-end)))
+          (if (not fragment)
+              (setq scan nil)
+            (let* ((fragment-start (car fragment))
+                   (fragment-end (cdr fragment))
+                   (trimmed-end
+                    (ai-code-session-link--trim-url-end
+                     fragment-start fragment-end))
+                   (fragment-text
+                    (buffer-substring-no-properties
+                     fragment-start fragment-end)))
+              (if (or (not (ai-code-session-link--blank-or-url-closer-between-p
+                            fragment-end next-line-end))
+                      (not
+                       (ai-code-session-link--url-continuation-fragment-p
+                        fragment-text previous-fragment current-line-hard-wrap)))
+                  (setq scan nil)
+                (cl-incf continued-lines)
+                (setq best-link
+                      (list :start match-start
+                            :end trimmed-end
+                            :text
+                            (ai-code-session-link--normalize-url-link-text
+                             (buffer-substring-no-properties
+                              match-start trimmed-end))))
+                (setq previous-fragment fragment-text
+                      current-line-start next-line-start
+                      current-line-end next-line-end
+                      current-line-hard-wrap
+                      (ai-code-session-link--line-hard-wrapped-p
+                       current-line-start current-line-end)))))))
+      best-link)))
+
+(defun ai-code-session-link--collect-url-links (start end)
+  "Return URL link matches between START and END."
+  (let (url-links)
+    (save-excursion
+      (goto-char start)
+      (while (re-search-forward ai-code-session-link--url-pattern-regexp end t)
+        (let* ((match-start (match-beginning 1))
+               (match-end (match-end 1))
+               (wrapped-link
+                (ai-code-session-link--wrapped-url-at
+                 match-start match-end end))
+               (link-end (or (plist-get wrapped-link :end)
+                             (ai-code-session-link--trim-url-end
+                              match-start match-end)))
+               (link-text
+                (or (plist-get wrapped-link :text)
+                    (buffer-substring-no-properties match-start link-end))))
+          (push (list :start match-start
+                      :end link-end
+                      :text link-text)
+                url-links))))
+    (ai-code-session-link--sort-and-prune-links url-links)))
 
 (defun ai-code-session-link--linkify-url-region (start end)
   "Apply URL session links between START and END."
-  (save-excursion
-    (goto-char start)
-    (while (re-search-forward ai-code-session-link--url-pattern-regexp end t)
-      (let* ((url-start (match-beginning 1))
-             (raw-url (match-string-no-properties 1))
-             (trimmed-url (replace-regexp-in-string "[.,;:!?]+\\'" "" raw-url))
-             (url-end (+ url-start (length trimmed-url))))
-        (ai-code-session-link--apply-properties
-         url-start url-end trimmed-url "mouse-1: Open URL")))))
+  (dolist (url-link (ai-code-session-link--collect-url-links start end))
+    (ai-code-session-link--apply-properties
+     (plist-get url-link :start)
+     (plist-get url-link :end)
+     (plist-get url-link :text)
+     "mouse-1: Open URL")))
 
-(defun ai-code-session-link--linkify-file-region (start end)
-  "Apply file session links between START and END."
+(defun ai-code-session-link--linkify-file-region
+    (start end allow-local-probing)
+  "Apply file session links between START and END.
+ALLOW-LOCAL-PROBING controls local existence checks and image previews."
   (let ((inhibit-read-only t)
         (inhibit-modification-hooks t))
     (ai-code-session-link--delete-image-preview-overlays start end)
@@ -1188,7 +1473,8 @@ search, and ROOT is the session project root."
            (ai-code-session-link--buffer-project-files-cache))
           (ai-code-session-link--resolved-path-cache
            (make-hash-table :test 'equal)))
-      (let ((file-links (ai-code-session-link--collect-file-links start end)))
+      (let ((file-links (ai-code-session-link--collect-file-links
+                         start end allow-local-probing)))
         (while file-links
           (let* ((file-link (car file-links))
                  (next-file-link (cadr file-links))
@@ -1196,7 +1482,9 @@ search, and ROOT is the session project root."
                  (match-end (plist-get file-link :end))
                  (link-text (plist-get file-link :text))
                  (image-link-file
-                  (ai-code-session-link--image-preview-link-file link-text)))
+                  (and allow-local-probing
+                       (ai-code-session-link--image-preview-link-file
+                        link-text))))
             (if image-link-file
                 (ai-code-session-link--apply-properties
                  match-start match-end link-text
@@ -1207,8 +1495,9 @@ search, and ROOT is the session project root."
                 (ai-code-session-link--linkify-symbols-near-file
                  link-text match-end end
                  (and next-file-link (plist-get next-file-link :start)))))
-            (ai-code-session-link--apply-image-preview
-             match-start match-end link-text)
+            (when allow-local-probing
+              (ai-code-session-link--apply-image-preview
+               match-start match-end link-text))
             (setq file-links (cdr file-links))))))))
 
 (defun ai-code-session-link--strict-image-candidate-bounds (match-start match-end)
@@ -1511,29 +1800,16 @@ visible-window recovery in large terminal scrollback."
                             region-text)
                            (ai-code-session-link--image-preview-refresh-needed-p
                             start end))
-                  (ai-code-session-link--linkify-file-region start end))
-              (let ((pos start))
-                (while (< pos end)
-                  (let ((next (or (next-single-property-change
-                                   pos 'ai-code-session-link nil end)
-                                  end)))
-                    (when (get-text-property pos 'ai-code-session-link)
-                      (remove-text-properties
-                       pos next
-                       '(ai-code-session-link nil
-                         ai-code-session-symbol-link nil
-                         ai-code-session-symbol-file nil
-                         mouse-face nil
-                         help-echo nil
-                         keymap nil
-                         follow-link nil
-                         font-lock-face nil
-                         face nil)))
-                    (setq pos next))))
+                  (ai-code-session-link--linkify-file-region start end t))
+              (ai-code-session-link--remove-managed-properties start end)
               (ai-code-session-link--linkify-url-region start end)
-              (ai-code-session-link--linkify-file-region start end)
+              (ai-code-session-link--linkify-file-region
+               start end
+               (ai-code-session-link--trusted-local-session-p))
               (setq ai-code-session-link--last-region-bounds bounds
-                    ai-code-session-link--last-region-text region-text))))))))
+                    ai-code-session-link--last-region-text region-text
+                    ai-code-session-link--last-region-rules-version
+                    ai-code-session-link--linkify-rules-version))))))))
 
 (defun ai-code-session-link--recent-output-tail-width (output)
   "Return the tail width to rescan after OUTPUT."

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -187,7 +187,97 @@
           (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
            (selected-window))
           (should (equal (mapcar #'car (reverse scheduled))
-                         '(0.1 0.5))))))))
+                          '(0.1 0.5))))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-schedules-visible-linkify-remotely ()
+  "Visible linkification should still refresh URL links for remote sessions."
+  (let (scheduled)
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local default-directory "/ssh:example:/repo/")
+      (setq-local ai-code-backends-infra--session-directory default-directory)
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (let ((ai-code-backends-infra-ghostel-visible-image-linkify-delays
+             '(0.1)))
+        (cl-letf (((symbol-function 'run-at-time)
+                   (lambda (delay _repeat function &rest args)
+                     (push (list delay function args) scheduled)
+                     'mock-timer)))
+          (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+           (selected-window))
+          (should (= (length scheduled) 1))
+          (should (equal (caar scheduled) 0.1)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-wraps-url ()
+  "Visible Ghostel linkification should relinkify wrapped URLs."
+  (with-temp-buffer
+    (set-window-buffer (selected-window) (current-buffer))
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (insert "origin\n")
+    (insert "https://example.com/repo/project-int   \n")
+    (insert "erface.el\n")
+    (insert "HEAD\n")
+    (goto-char (point-min))
+    (set-window-start (selected-window) (point-min) t)
+    (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+     (current-buffer)
+     (selected-window))
+    (goto-char (point-min))
+    (search-forward "https://example.com/repo/project-int")
+    (let ((url "https://example.com/repo/project-interface.el"))
+      (should (equal (get-text-property (match-beginning 0)
+                                        'ai-code-session-link)
+                     url))
+      (search-forward "erface.el")
+      (should (equal (get-text-property (match-beginning 0)
+                                        'ai-code-session-link)
+                     url)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-remote-url ()
+  "Visible Ghostel linkification should linkify URLs for remote sessions."
+  (with-temp-buffer
+    (set-window-buffer (selected-window) (current-buffer))
+    (setq-local default-directory "/ssh:example:/repo/")
+    (setq-local ai-code-backends-infra--session-directory default-directory)
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (insert "https://example.com/repo/project-int   \n")
+    (insert "erface.el\n")
+    (goto-char (point-min))
+    (set-window-start (selected-window) (point-min) t)
+    (cl-letf (((symbol-function
+                'ai-code-session-link--linkify-strict-image-preview-region)
+               (lambda (&rest _args)
+                 (error "Strict image previews should be skipped remotely"))))
+      (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+       (current-buffer)
+       (selected-window)))
+    (goto-char (point-min))
+    (search-forward "erface.el")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/repo/project-interface.el"))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-region-linkify-remote-url ()
+  "Queued Ghostel region linkification should linkify remote URLs only."
+  (with-temp-buffer
+    (setq-local default-directory "/ssh:example:/repo/")
+    (setq-local ai-code-backends-infra--session-directory default-directory)
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (insert "https://example.com/repo/project-int   \n")
+    (insert "erface.el\n")
+    (cl-letf (((symbol-function
+                'ai-code-session-link--linkify-strict-image-preview-region)
+               (lambda (&rest _args)
+                 (error "Strict image previews should be skipped remotely"))))
+      (ai-code-backends-infra-ghostel--linkify-image-preview-region
+       (current-buffer)
+       (point-min)
+       (point-max)))
+    (goto-char (point-min))
+    (search-forward "erface.el")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/repo/project-interface.el"))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-schedules-visible-linkify-per-window ()
   "Visible image linkification timers should be isolated per window."
@@ -281,7 +371,7 @@
       (setq-local ai-code-backends-infra--session-directory
                   "/ssh:example:/repo/")
       (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
-      (insert "remote.png\n")
+      (insert "./remote.png\n")
       (goto-char (point-min))
       (set-window-start (selected-window) (point-min) t)
       (cl-letf (((symbol-function
@@ -303,6 +393,11 @@
          (current-buffer)
          (point-min)
          (point-max))
+        (goto-char (point-min))
+        (search-forward "./remote.png")
+        (should (equal (get-text-property (match-beginning 0)
+                                          'ai-code-session-link)
+                       "./remote.png"))
         (should-not strict-linkify-called)
         (should-not path-resolution-called)))))
 

--- a/test/test_ai-code-session-link.el
+++ b/test/test_ai-code-session-link.el
@@ -33,9 +33,15 @@
   (should (equal (ai-code-session-link--normalize-file
                   "file:///tmp/project/image-\nwrapped.png")
                  "/tmp/project/image-wrapped.png"))
+  (should (equal (ai-code-session-link--normalize-link-text
+                  "/tmp/project/My \n Image.png")
+                 "/tmp/project/My Image.png"))
+  (should (equal (ai-code-session-link--normalize-url-link-text
+                  "https://example.com/app-   \n  page=true")
+                 "https://example.com/app-page=true"))
   (should (equal (ai-code-session-link--normalize-file
-                  "/tmp/sloth-\nlayout-check/\nsloth-window-\nafter-53660.png")
-                 "/tmp/sloth-layout-check/sloth-window-after-53660.png"))
+                  "/tmp/layout-\ncheck/window-\nafter-53660.png")
+                 "/tmp/layout-check/window-after-53660.png"))
   (should (equal (ai-code-session-link--normalize-file
                   "<file:///tmp/project/My%20Image.png>")
                  "/tmp/project/My Image.png"))
@@ -141,6 +147,205 @@
         (delete-file outside-file))
       (when (file-directory-p root)
         (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-wrapped-url ()
+  "Linkify all terminal rows of a hard-wrapped URL."
+  (with-temp-buffer
+    (insert "https://chatgpt.com/codex?app-landing-\npage=true\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://chatgpt.com/codex?app-landing-")
+    (let ((url "https://chatgpt.com/codex?app-landing-page=true")
+          (first-row-pos (match-beginning 0))
+          (newline-pos (line-end-position)))
+      (should (equal (get-text-property first-row-pos 'ai-code-session-link)
+                     url))
+      (should (eq (get-text-property first-row-pos 'face) 'link))
+      (should (eq (get-text-property newline-pos 'mouse-face)
+                  'highlight))
+      (search-forward "page=true")
+      (let ((second-row-pos (match-beginning 0)))
+        (should (equal (get-text-property second-row-pos
+                                          'ai-code-session-link)
+                       url))
+        (should (eq (get-text-property second-row-pos 'face) 'link))))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-mid-token-url-wrap ()
+  "Linkify URLs split in the middle of a path token."
+  (with-temp-buffer
+    (insert "origin\n")
+    (insert "https://example.com/repo/project-int\n")
+    (insert "erface.el\n")
+    (insert "HEAD\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/repo/project-int")
+    (let ((url "https://example.com/repo/project-interface.el")
+          (first-row-pos (match-beginning 0))
+          (newline-pos (line-end-position)))
+      (should (equal (get-text-property first-row-pos 'ai-code-session-link)
+                     url))
+      (should (eq (get-text-property newline-pos 'mouse-face) 'highlight))
+      (search-forward "erface.el")
+      (let ((second-row-pos (match-beginning 0)))
+        (should (equal (get-text-property second-row-pos
+                                          'ai-code-session-link)
+                       url))
+        (should (eq (get-text-property second-row-pos 'face) 'link)))
+      (search-forward "HEAD")
+      (should-not (get-text-property (match-beginning 0)
+                                     'ai-code-session-link)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-url-wrap-after-padding ()
+  "Linkify wrapped URLs when terminal rows contain trailing padding."
+  (with-temp-buffer
+    (insert "origin\n")
+    (insert "https://example.com/repo/project-int   \n")
+    (insert "erface.el\n")
+    (insert "HEAD\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/repo/project-int")
+    (let ((url "https://example.com/repo/project-interface.el")
+          (first-row-pos (match-beginning 0))
+          (padding-pos (match-end 0)))
+      (should (equal (get-text-property first-row-pos 'ai-code-session-link)
+                     url))
+      (should-not (get-text-property padding-pos 'ai-code-session-link))
+      (should (eq (get-text-property padding-pos 'mouse-face) 'highlight))
+      (search-forward "erface.el")
+      (should (equal (get-text-property (match-beginning 0)
+                                        'ai-code-session-link)
+                     url)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-quoted-url-wrap ()
+  "Linkify wrapped URLs terminated by a closing quote."
+  (with-temp-buffer
+    (insert "(use-package ai-code\n")
+    (insert "  :vc (:url\n")
+    (insert "\"https://example.com/repo/pkg\n")
+    (insert "-interface.el\"\n")
+    (insert "      :rev \"1.88\"))\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/repo/pkg")
+    (let ((url "https://example.com/repo/pkg-interface.el")
+          (first-row-pos (match-beginning 0))
+          (newline-pos (line-end-position)))
+      (should (equal (get-text-property first-row-pos
+                                        'ai-code-session-link)
+                     url))
+      (should (eq (get-text-property newline-pos 'mouse-face)
+                  'highlight))
+      (search-forward "-interface.el")
+      (let ((second-row-pos (match-beginning 0))
+            (closing-quote-pos (match-end 0)))
+        (should (equal (get-text-property second-row-pos
+                                          'ai-code-session-link)
+                       url))
+        (should (eq (get-text-property second-row-pos 'mouse-face)
+                    'highlight))
+        (should-not (get-text-property closing-quote-pos
+                                       'ai-code-session-link))
+        (should-not (get-text-property closing-quote-pos 'mouse-face))))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-rejects-url-wrap-with-suffix ()
+  "Do not wrap URL fragments when a continuation row has trailing prose."
+  (with-temp-buffer
+    (insert "https://example.com/repo/pkg\n")
+    (insert "-interface.el suffix\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/repo/pkg")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/repo/pkg"))
+    (search-forward "-interface.el")
+    (should-not (equal (get-text-property (match-beginning 0)
+                                          'ai-code-session-link)
+                       "https://example.com/repo/pkg-interface.el"))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-indented-wrapped-url ()
+  "Linkify wrapped URL continuations while leaving indentation unstyled."
+  (with-temp-buffer
+    (insert "https://example.com/app-\n  page=true.\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (let ((url "https://example.com/app-page=true"))
+      (search-forward "https://example.com/app-")
+      (should (equal (get-text-property (match-beginning 0)
+                                        'ai-code-session-link)
+                     url))
+      (search-forward "  page=true")
+      (let ((indent-pos (match-beginning 0))
+            (path-pos (+ (match-beginning 0) 2))
+            (punctuation-pos (1- (line-end-position))))
+        (should-not (get-text-property indent-pos 'ai-code-session-link))
+        (should-not (get-text-property indent-pos 'face))
+        (should (eq (get-text-property indent-pos 'mouse-face)
+                    'highlight))
+        (should (equal (get-text-property path-pos 'ai-code-session-link)
+                       url))
+        (should-not (get-text-property punctuation-pos
+                                       'ai-code-session-link))))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-does-not-wrap-url-into-prose ()
+  "Do not merge an ordinary following prose line into a URL."
+  (with-temp-buffer
+    (insert "Visit https://example.com/path\nnext line\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/path")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/path"))
+    (forward-line 1)
+    (should-not (get-text-property (point) 'ai-code-session-link))
+    (should-not (get-text-property (point) 'mouse-face))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-does-not-wrap-url-into-word ()
+  "Do not merge a single ordinary following word into a URL."
+  (with-temp-buffer
+    (insert "Visit https://example.com/path\ndone\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/path")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/path"))
+    (forward-line 1)
+    (should-not (get-text-property (point) 'ai-code-session-link))
+    (should-not (get-text-property (point) 'mouse-face))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-does-not-wrap-url-after-slash ()
+  "Do not merge prose after an ordinary URL ending in a slash."
+  (with-temp-buffer
+    (insert "Visit https://example.com/path/\ndone\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/path/")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/path/"))
+    (forward-line 1)
+    (should-not (get-text-property (point) 'ai-code-session-link))
+    (should-not (get-text-property (point) 'mouse-face))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-does-not-wrap-url-after-sentence-punctuation ()
+  "Do not merge prose after a URL with trailing sentence punctuation."
+  (with-temp-buffer
+    (insert "See https://example.com/path.\nDone\n")
+    (ai-code-session-link--linkify-session-region (point-min) (point-max))
+    (goto-char (point-min))
+    (search-forward "https://example.com/path")
+    (should (equal (get-text-property (match-beginning 0)
+                                      'ai-code-session-link)
+                   "https://example.com/path"))
+    (goto-char (match-end 0))
+    (should-not (get-text-property (point) 'ai-code-session-link))
+    (forward-line 1)
+    (should-not (get-text-property (point) 'ai-code-session-link))
+    (should-not (get-text-property (point) 'mouse-face))))
 
 (ert-deftest ai-code-session-link-test-linkify-session-region-matches-unique-project-basename ()
   "Linkify basename references when they uniquely match a project file."
@@ -728,11 +933,11 @@
 (ert-deftest ai-code-session-link-test-linkify-session-region-supports-wrapped-local-file ()
   "Linkify all terminal rows of a hard-wrapped local file path."
   (let* ((root (make-temp-file "ai-code-session-links-wrapped-path-" t))
-         (dir (expand-file-name "sloth-layout-check" root))
-         (file (expand-file-name "sloth-window-after-53660.png" dir))
+         (dir (expand-file-name "layout-check" root))
+         (file (expand-file-name "window-after-53660.png" dir))
          (wrapped-file
           (concat (file-name-as-directory root)
-                  "sloth-\n  layout-check/\n  sloth-window-\n  after-53660.png")))
+                  "layout-\n  check/\n  window-\n  after-53660.png")))
     (unwind-protect
         (progn
           (make-directory dir t)
@@ -749,7 +954,7 @@
               (should (equal (get-text-property first-row-pos 'ai-code-session-link)
                              file))
               (should (eq (get-text-property first-row-pos 'face) 'link)))
-            (search-forward "  layout-check/")
+            (search-forward "  check/")
             (let ((indent-pos (match-beginning 0))
                   (second-row-pos (+ (match-beginning 0) 2)))
               (should-not (get-text-property indent-pos 'ai-code-session-link))
@@ -757,7 +962,7 @@
               (should (equal (get-text-property second-row-pos 'ai-code-session-link)
                              file))
               (should (eq (get-text-property second-row-pos 'face) 'link)))
-            (search-forward "  sloth-window-")
+            (search-forward "  window-")
             (let ((indent-pos (match-beginning 0))
                   (third-row-pos (+ (match-beginning 0) 2)))
               (should-not (get-text-property indent-pos 'ai-code-session-link))
@@ -773,6 +978,111 @@
               (should (equal (get-text-property last-row-pos 'ai-code-session-link)
                              file))
               (should (eq (get-text-property last-row-pos 'face) 'link)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-supports-wrapped-file-before-argument ()
+  "Linkify a hard-wrapped file path followed by another command argument."
+  (let* ((root (make-temp-file "ai-code-session-links-wrapped-arg-" t))
+         (dir (expand-file-name "tmp/config" root))
+         (file (expand-file-name "init.el" dir))
+         (prefix (file-name-as-directory root))
+         (suffix (file-relative-name file prefix)))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (with-temp-file file
+            (insert ";;; init.el\n"))
+          (with-temp-buffer
+            (setq-local ai-code-backends-infra--session-directory root)
+            (insert "emacs -Q --batch -l ")
+            (insert prefix)
+            (insert "\n")
+            (insert suffix)
+            (insert " --eval\n")
+            (ai-code-session-link--linkify-session-region (point-min) (point-max))
+            (goto-char (point-min))
+            (search-forward prefix)
+            (let ((first-row-pos (match-beginning 0))
+                  (newline-pos (line-end-position)))
+              (should (equal (get-text-property first-row-pos
+                                                'ai-code-session-link)
+                             file))
+              (should (eq (get-text-property newline-pos 'mouse-face)
+                          'highlight)))
+            (search-forward suffix)
+            (let ((second-row-pos (match-beginning 0))
+                  (argument-pos (match-end 0)))
+              (should (equal (get-text-property second-row-pos
+                                                'ai-code-session-link)
+                             file))
+              (should (eq (get-text-property second-row-pos 'face)
+                          'link))
+              (should-not (get-text-property argument-pos
+                                             'ai-code-session-link))
+              (should-not (get-text-property argument-pos 'mouse-face)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-rejects-missing-wrapped-file-before-argument ()
+  "Do not merge missing hard-wrapped file paths before arguments."
+  (let* ((root (make-temp-file "ai-code-session-links-missing-arg-" t))
+         (prefix (file-name-as-directory root))
+         (suffix "tmp/config/missing.el"))
+    (unwind-protect
+        (with-temp-buffer
+          (setq-local ai-code-backends-infra--session-directory root)
+          (insert "emacs -Q --batch -l ")
+          (insert prefix)
+          (insert "\n")
+          (insert suffix)
+          (insert " --eval\n")
+          (ai-code-session-link--linkify-session-region (point-min) (point-max))
+          (goto-char (point-min))
+          (search-forward prefix)
+          (should-not (equal (get-text-property (match-beginning 0)
+                                                'ai-code-session-link)
+                             (concat prefix suffix)))
+          (search-forward suffix)
+          (should-not (equal (get-text-property (match-beginning 0)
+                                                'ai-code-session-link)
+                             (concat prefix suffix))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest ai-code-session-link-test-linkify-session-region-connects-wrapped-hover ()
+  "Hover properties should span wrapped path gaps without underlining them."
+  (let* ((root (make-temp-file "ai-code-session-links-wrapped-hover-" t))
+         (src-dir (expand-file-name "src" root))
+         (file (expand-file-name "feature.el" src-dir)))
+    (unwind-protect
+        (progn
+          (make-directory src-dir t)
+          (with-temp-file file
+            (insert ";;; feature.el\n"))
+          (with-temp-buffer
+            (setq-local ai-code-backends-infra--session-directory root)
+            (insert "src/\n  feature.el\n")
+            (ai-code-session-link--linkify-session-region (point-min) (point-max))
+            (goto-char (point-min))
+            (search-forward "src/")
+            (let ((first-row-pos (match-beginning 0))
+                  (newline-pos (line-end-position)))
+              (should (eq (get-text-property first-row-pos 'mouse-face)
+                          'highlight))
+              (should (eq (get-text-property newline-pos 'mouse-face)
+                          'highlight)))
+            (search-forward "  feature.el")
+            (let ((indent-pos (match-beginning 0))
+                  (file-pos (+ (match-beginning 0) 2)))
+              (should-not (get-text-property indent-pos 'ai-code-session-link))
+              (should-not (get-text-property indent-pos 'face))
+              (should (eq (get-text-property indent-pos 'mouse-face)
+                          'highlight))
+              (should (equal (get-text-property file-pos 'ai-code-session-link)
+                             "src/feature.el"))
+              (should (eq (get-text-property file-pos 'mouse-face)
+                          'highlight)))))
       (when (file-directory-p root)
         (delete-directory root t)))))
 
@@ -1072,6 +1382,11 @@
         (insert "Saved ./remote.png\n")
         (ai-code-session-link--linkify-session-region
          (point-min) (point-max))
+        (goto-char (point-min))
+        (search-forward "./remote.png")
+        (should (equal (get-text-property (match-beginning 0)
+                                          'ai-code-session-link)
+                       "./remote.png"))
         (should-not file-exists-called)
         (should-not create-image-called)
         (should-not
@@ -1231,7 +1546,8 @@ detection regexp must stitch those rows back together."
               (search-forward "screenshot.png")
               (should (get-text-property (match-beginning 0)
                                          'ai-code-session-link))
-              (ai-code-session-link--linkify-file-region (point-min) (point-max))
+              (ai-code-session-link--linkify-file-region
+               (point-min) (point-max) t)
               (should
                (= (length
                    (cl-remove-if-not
@@ -1502,9 +1818,9 @@ Bare wrapped paths -- as printed by tools such as Claude, which omit the
   "Strict visible scanning should rejoin bare paths wrapped over three rows."
   (let* ((root (make-temp-file
                 "ai-code-session-image-preview-visible-wrap-three-" t))
-         (dir (expand-file-name "sloth-layout-check" root))
-         (image-file (expand-file-name "sloth-window-after-53660.png" dir))
-         (needle "sloth-layout-check/sloth-window-after-53660.png")
+         (dir (expand-file-name "layout-check" root))
+         (image-file (expand-file-name "window-after-53660.png" dir))
+         (needle "layout-check/window-after-53660.png")
          (needle-start (string-match (regexp-quote needle) image-file))
          (path-prefix (substring image-file 0 needle-start)))
     (unwind-protect
@@ -1523,7 +1839,7 @@ Bare wrapped paths -- as printed by tools such as Claude, which omit the
                           'ghostel)
               (insert "  ")
               (insert path-prefix)
-              (insert "sloth-layout-\n    check/sloth-window-after-\n    53660.png\n")
+              (insert "layout-\n    check/window-after-\n    53660.png\n")
               (setq buffer-read-only t)
               (ai-code-session-link--linkify-strict-image-preview-region
                (point-min) (point-max))
@@ -1533,6 +1849,24 @@ Bare wrapped paths -- as printed by tools such as Claude, which omit the
                         (overlay-get overlay 'ai-code-session-image-preview))
                       (overlays-in (point-min) (point-max)))))
                 (should (= (length preview-overlays) 1))
+                (goto-char (point-min))
+                (search-forward "layout-")
+                (should (eq (get-text-property (match-beginning 0)
+                                               'mouse-face)
+                            'highlight))
+                (search-forward "    check/")
+                (let ((indent-pos (match-beginning 0))
+                      (path-pos (+ (match-beginning 0) 4)))
+                  (should-not (get-text-property indent-pos
+                                                 'ai-code-session-link))
+                  (should-not (get-text-property indent-pos 'face))
+                  (should (eq (get-text-property indent-pos 'mouse-face)
+                              'highlight))
+                  (should (equal (get-text-property path-pos
+                                                    'ai-code-session-link)
+                                 image-file))
+                  (should (eq (get-text-property path-pos 'mouse-face)
+                              'highlight)))
                 (should (equal (overlay-get (car preview-overlays)
                                             'ai-code-session-image-file)
                                image-file))))))


### PR DESCRIPTION
## Summary

- Rebuild hard-wrapped URLs and file paths across terminal rows before applying session link properties.
- Keep hover coverage continuous over wrapped link gaps, while avoiding underlines/keymaps on indentation and terminal padding.
- Refresh visible Ghostel scrollback linkification so restored/visible output gets corrected after scroll or redraw.
- Preserve remote-session safety: URLs and syntactic file references are still linkified remotely, but local file/image checks only run for trusted local sessions.
- Add regression coverage for wrapped URLs, quoted/padded URL continuations, wrapped paths before command args, image previews, remote Ghostel behavior, file names with spaces at wraps, and URL sentence-punctuation boundaries.

## Verification

- `emacs -Q -batch -L . -f batch-byte-compile ai-code-session-link.el ai-code-backends-infra-ghostel.el`
- `emacs -Q -batch -L . -l checkdoc --eval "(mapc #'checkdoc-file '(\"ai-code-session-link.el\" \"ai-code-backends-infra-ghostel.el\"))"`
- `emacs -Q -batch -L . -l ert -l test/test_ai-code-session-link.el -f ert-run-tests-batch-and-exit`
- `emacs -Q -batch -L . -l ert -l test/test_ai-code-backends-infra-ghostel.el -f ert-run-tests-batch-and-exit`
- `emacs -Q -batch -L . -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit`

Full ERT result: 987 tests, 974 passed, 13 skipped, 0 unexpected.
