### PR TITLE
Fix Ghostel IME preedit flicker

### DIFF
--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -50,11 +50,14 @@ enabled by default because it widens the terminal's local resource access."
 (declare-function ghostel--redispatch-scroll-event "ghostel" (event))
 (declare-function ghostel-copy-mode "ghostel" ())
 (declare-function ghostel-emacs-mode "ghostel" ())
+(declare-function ghostel-ime-mode "ghostel-ime" (&optional arg))
 (declare-function ai-code-session-link--linkify-strict-image-preview-region
                   "ai-code-session-link" (start end))
 
 (defvar ai-code-backends-infra--session-terminal-backend)
 (defvar ai-code-backends-infra--session-directory)
+(defvar ai-code-session-link-inhibit-functions)
+(defvar ghostel-inhibit-redraw-functions)
 (defvar ghostel-kitty-graphics-mediums)
 (eval-when-compile
   (defvar ghostel-command-finish-functions)
@@ -63,6 +66,7 @@ enabled by default because it widens the terminal's local resource access."
   (defvar ghostel-progress-function)
   (defvar ghostel-set-title-function)
   (defvar ghostel--copy-mode-active)
+  (defvar ghostel--fake-cursor-overlay)
   (defvar ghostel--input-mode)
   (defvar ghostel--plain-link-detection-begin)
   (defvar ghostel--plain-link-detection-end))
@@ -92,6 +96,34 @@ history responsive even when Ghostel has a large scrollback."
   "Debounce delay before scanning visible Ghostel text after scrolling."
   :type 'number
   :group 'ai-code-backends-infra)
+
+(defcustom ai-code-backends-infra-ghostel-enable-ime-integration t
+  "Enable Ghostel IME integration in AI Code Ghostel sessions.
+
+When available, `ghostel-ime-mode' defers Ghostel redraws while an
+Emacs Lisp input-method composition is active, preventing active TUI
+redraws from clobbering in-progress preedit text."
+  :type 'boolean
+  :group 'ai-code-backends-infra)
+
+(defcustom ai-code-backends-infra-ghostel-inhibit-redraw-during-native-preedit t
+  "Defer Ghostel redraws while a GUI-native preedit overlay is active.
+
+This covers native input-method preedit paths that do not go through
+`ghostel-ime-mode', such as GUI framework preedit overlays."
+  :type 'boolean
+  :group 'ai-code-backends-infra)
+
+(defcustom ai-code-backends-infra-ghostel-native-preedit-overlay-symbols
+  '(x-preedit-overlay pgtk-preedit-overlay ns-preedit-overlay
+                      mac-preedit-overlay)
+  "Overlay variables that may hold an active GUI-native preedit overlay."
+  :type '(repeat symbol)
+  :group 'ai-code-backends-infra)
+
+(defconst ai-code-backends-infra-ghostel--preedit-properties
+  '(preedit preedit-text input-method)
+  "Text and overlay properties that identify in-progress preedit text.")
 
 (defvar-local ai-code-backends-infra-ghostel--visible-image-linkify-timers nil
   "Alist of (WINDOW . TIMERS) for visible image preview scans.")
@@ -227,24 +259,166 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
         (or ai-code-backends-infra--session-directory
             default-directory))))
 
+(defun ai-code-backends-infra-ghostel--active-preedit-overlay-p
+    (overlay buffer)
+  "Return non-nil when OVERLAY is an active preedit overlay in BUFFER."
+  (and (overlayp overlay)
+       (eq (overlay-buffer overlay) buffer)
+       (overlay-start overlay)
+       (overlay-end overlay)
+       (or (< (overlay-start overlay) (overlay-end overlay))
+           (overlay-get overlay 'after-string)
+           (overlay-get overlay 'before-string)
+           (overlay-get overlay 'display))))
+
+(defun ai-code-backends-infra-ghostel--preedit-value-active-p (value)
+  "Return non-nil when VALUE represents active preedit state."
+  (cond
+   ((stringp value) (> (length value) 0))
+   ((overlayp value) (overlay-buffer value))
+   ((consp value) t)
+   (t value)))
+
+(defun ai-code-backends-infra-ghostel--preedit-property-active-p
+    (getter object)
+  "Return non-nil when GETTER finds a preedit property on OBJECT."
+  (cl-some
+   (lambda (property)
+     (ai-code-backends-infra-ghostel--preedit-value-active-p
+      (funcall getter object property)))
+   ai-code-backends-infra-ghostel--preedit-properties))
+
+(defun ai-code-backends-infra-ghostel--overlay-near-point-p
+    (overlay point)
+  "Return non-nil when OVERLAY is attached near POINT."
+  (let ((start (overlay-start overlay))
+        (end (overlay-end overlay)))
+    (and start
+         end
+         (<= (1- start) point)
+         (<= point (1+ end)))))
+
+(defun ai-code-backends-infra-ghostel--known-non-preedit-overlay-p
+    (overlay)
+  "Return non-nil when OVERLAY is known not to represent preedit text."
+  (or (overlay-get overlay 'ai-code-session-image-preview)
+      (and (boundp 'ghostel--fake-cursor-overlay)
+           (eq overlay ghostel--fake-cursor-overlay))))
+
+(defun ai-code-backends-infra-ghostel--point-preedit-overlay-p
+    (overlay buffer point)
+  "Return non-nil when OVERLAY looks like preedit text near POINT in BUFFER."
+  (and (ai-code-backends-infra-ghostel--active-preedit-overlay-p
+        overlay buffer)
+       (ai-code-backends-infra-ghostel--overlay-near-point-p
+        overlay point)
+       (not
+        (ai-code-backends-infra-ghostel--known-non-preedit-overlay-p
+         overlay))
+       (or (ai-code-backends-infra-ghostel--preedit-property-active-p
+            #'overlay-get overlay)
+           (overlay-get overlay 'after-string)
+           (overlay-get overlay 'before-string)
+           (overlay-get overlay 'display))))
+
+(defun ai-code-backends-infra-ghostel--point-preedit-overlays-p
+    (buffer)
+  "Return non-nil when BUFFER has preedit overlays around point."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let* ((point (point))
+             (start (max (point-min) (1- point)))
+             (end (min (point-max) (1+ point)))
+             (overlays (delete-dups
+                        (append (overlays-at point)
+                                (overlays-in start end)))))
+        (cl-some
+         (lambda (overlay)
+           (ai-code-backends-infra-ghostel--point-preedit-overlay-p
+            overlay buffer point))
+         overlays)))))
+
+(defun ai-code-backends-infra-ghostel--point-preedit-properties-p
+    (buffer)
+  "Return non-nil when BUFFER has preedit text properties around point."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((positions (delete-dups
+                        (list (point)
+                              (max (point-min) (1- (point)))))))
+        (cl-some
+         (lambda (position)
+           (and (<= (point-min) position)
+                (< position (point-max))
+                (ai-code-backends-infra-ghostel--preedit-property-active-p
+                 #'get-text-property position)))
+         positions)))))
+
+(defun ai-code-backends-infra-ghostel--preedit-symbol-active-p ()
+  "Return non-nil when a native preedit dynamic variable is active."
+  (and (boundp 'preedit-text)
+       (ai-code-backends-infra-ghostel--preedit-value-active-p
+        (symbol-value 'preedit-text))))
+
+(defun ai-code-backends-infra-ghostel--native-preedit-active-p
+    (&optional buffer)
+  "Return non-nil when BUFFER has an active GUI-native preedit overlay.
+
+BUFFER defaults to the current buffer.  This function is installed in
+`ghostel-inhibit-redraw-functions' for AI Code Ghostel sessions."
+  (let ((buffer (or buffer (current-buffer))))
+    (and ai-code-backends-infra-ghostel-inhibit-redraw-during-native-preedit
+         (buffer-live-p buffer)
+         (ai-code-backends-infra-ghostel--ai-session-buffer-p buffer)
+         (with-current-buffer buffer
+           (or
+            (ai-code-backends-infra-ghostel--preedit-symbol-active-p)
+            (cl-some
+             (lambda (symbol)
+               (and (boundp symbol)
+                    (ai-code-backends-infra-ghostel--active-preedit-overlay-p
+                     (symbol-value symbol)
+                     buffer)))
+             ai-code-backends-infra-ghostel-native-preedit-overlay-symbols)
+            (ai-code-backends-infra-ghostel--point-preedit-overlays-p
+             buffer)
+            (ai-code-backends-infra-ghostel--point-preedit-properties-p
+             buffer))))))
+
+(defun ai-code-backends-infra-ghostel--install-preedit-redraw-inhibition ()
+  "Install native preedit redraw inhibition for the current Ghostel buffer."
+  (when ai-code-backends-infra-ghostel-inhibit-redraw-during-native-preedit
+    (add-hook 'ghostel-inhibit-redraw-functions
+              #'ai-code-backends-infra-ghostel--native-preedit-active-p
+              nil
+              t)
+    (add-hook 'ai-code-session-link-inhibit-functions
+              #'ai-code-backends-infra-ghostel--native-preedit-active-p
+              nil
+              t)))
+
 (defun ai-code-backends-infra-ghostel--linkify-visible-image-previews
     (buffer window)
   "Linkify session links and image previews in BUFFER shown by WINDOW."
   (when (and (buffer-live-p buffer)
              (window-live-p window)
              (eq (window-buffer window) buffer))
-    (with-current-buffer buffer
-      (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
-      (when-let* ((region
-                   (ai-code-backends-infra-ghostel--visible-image-region
-                    window)))
-        (ai-code-session-link--linkify-session-region
-         (car region)
-         (cdr region))
-        (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
-          (ai-code-session-link--linkify-strict-image-preview-region
+    (if (ai-code-backends-infra-ghostel--native-preedit-active-p buffer)
+        (ai-code-backends-infra-ghostel-schedule-visible-image-linkify
+         window
+         (list ai-code-session-link--linkify-inhibited-retry-delay))
+      (with-current-buffer buffer
+        (ai-code-backends-infra-ghostel--prune-visible-image-linkify-timers)
+        (when-let* ((region
+                     (ai-code-backends-infra-ghostel--visible-image-region
+                      window)))
+          (ai-code-session-link--linkify-session-region
            (car region)
-           (cdr region)))))))
+           (cdr region))
+          (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
+            (ai-code-session-link--linkify-strict-image-preview-region
+             (car region)
+             (cdr region))))))))
 
 (defun ai-code-backends-infra-ghostel--cancel-visible-image-linkify-timers
     (window)
@@ -284,7 +458,10 @@ accidentally scan an entire scrollback buffer."
              (integer-or-marker-p start)
              (integer-or-marker-p end))
     (with-current-buffer buffer
-      (when (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+      (when (and (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+                 (not
+                  (ai-code-backends-infra-ghostel--native-preedit-active-p
+                   buffer)))
         (save-restriction
           (widen)
           (let ((start (if (markerp start) (marker-position start) start))
@@ -431,6 +608,13 @@ Optional DELAYS overrides the default visible image linkification delays."
     (setq-local ghostel-kitty-graphics-mediums
                 (ai-code-backends-infra-ghostel--effective-kitty-graphics-mediums))))
 
+(defun ai-code-backends-infra-ghostel--enable-ime-integration ()
+  "Enable Ghostel IME integration for the current AI Code session."
+  (when (and ai-code-backends-infra-ghostel-enable-ime-integration
+             (require 'ghostel-ime nil t)
+             (fboundp 'ghostel-ime-mode))
+    (ghostel-ime-mode 1)))
+
 (defun ai-code-backends-infra-ghostel-send-string (string &optional paste)
   "Send STRING to the current Ghostel process.
 If PASTE is non-nil, send it as a pasted string."
@@ -461,6 +645,8 @@ Ghostel owns terminal-model resizing through its mode-local window hooks."
   (setq-local ghostel-set-title-function nil)
   (setq-local ghostel-kill-buffer-on-exit nil)
   (ai-code-backends-infra-ghostel--configure-image-support)
+  (ai-code-backends-infra-ghostel--enable-ime-integration)
+  (ai-code-backends-infra-ghostel--install-preedit-redraw-inhibition)
   (ai-code-backends-infra-ghostel--install-lifecycle-hooks)
   (ai-code-backends-infra-ghostel--install-image-preview-advice)
   (add-hook 'window-scroll-functions

--- a/ai-code-session-link.el
+++ b/ai-code-session-link.el
@@ -122,6 +122,16 @@ impose a fixed hard cap instead."
 (defconst ai-code-session-link--linkify-redraw-delay 0
   "Seconds to wait before relinkifying recent terminal output.")
 
+(defconst ai-code-session-link--linkify-inhibited-retry-delay 0.05
+  "Seconds to wait before retrying linkification after inhibition.")
+
+(defvar-local ai-code-session-link-inhibit-functions nil
+  "Abnormal hook run before delayed session linkification.
+
+Each function is called with the current buffer.  If any function
+returns non-nil, delayed linkification is retried later instead of
+touching text properties immediately.")
+
 (defconst ai-code-session-link--url-pattern-regexp
   "\\(https?://[^][(){}<>\"' \t\n]+\\)"
   "Regexp matching http/https URLs in session buffers.")
@@ -1838,16 +1848,43 @@ visible-window recovery in large terminal scrollback."
        (buffer-live-p buffer)
        (ai-code-session-link--recent-output-may-contain-links-p output)))
 
+(defun ai-code-session-link--linkify-inhibited-p (&optional buffer)
+  "Return non-nil when BUFFER should defer delayed linkification."
+  (let ((buffer (or buffer (current-buffer))))
+    (and (buffer-live-p buffer)
+         (with-current-buffer buffer
+           (with-demoted-errors "ai-code-session-link-inhibit-functions error: %S"
+             (run-hook-with-args-until-success
+              'ai-code-session-link-inhibit-functions buffer))))))
+
+(defun ai-code-session-link--schedule-pending-linkify (buffer delay)
+  "Schedule delayed linkification for BUFFER after DELAY seconds."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (unless ai-code-session-link--linkify-timer
+        (setq ai-code-session-link--linkify-timer
+              (run-at-time
+               delay nil
+               (lambda (buf)
+                 (when (buffer-live-p buf)
+                   (with-current-buffer buf
+                     (ai-code-session-link--flush-scheduled-linkify))))
+               buffer))))))
+
 (defun ai-code-session-link--flush-scheduled-linkify ()
   "Apply any delayed session linkification pending in the current buffer."
   (let ((tail-width ai-code-session-link--pending-tail-width))
-    (setq ai-code-session-link--pending-tail-width 0
-          ai-code-session-link--linkify-timer nil)
+    (setq ai-code-session-link--linkify-timer nil)
     (when (> tail-width 0)
-      (let ((end (point-max)))
-        (ai-code-session-link--linkify-session-region
-         (max (point-min) (- end tail-width))
-         end)))))
+      (if (ai-code-session-link--linkify-inhibited-p)
+          (ai-code-session-link--schedule-pending-linkify
+           (current-buffer)
+           ai-code-session-link--linkify-inhibited-retry-delay)
+        (setq ai-code-session-link--pending-tail-width 0)
+        (let ((end (point-max)))
+          (ai-code-session-link--linkify-session-region
+           (max (point-min) (- end tail-width))
+           end))))))
 
 (defun ai-code-session-link--schedule-linkify-recent-output (buffer output &optional delay)
   "Linkify recent OUTPUT in BUFFER after terminal redraw settles.
@@ -1857,15 +1894,9 @@ Optional DELAY overrides the default redraw delay in seconds."
       (setq ai-code-session-link--pending-tail-width
             (max ai-code-session-link--pending-tail-width
                  (ai-code-session-link--recent-output-tail-width output)))
-      (unless ai-code-session-link--linkify-timer
-        (setq ai-code-session-link--linkify-timer
-              (run-at-time
-               (or delay ai-code-session-link--linkify-redraw-delay) nil
-               (lambda (buf)
-                 (when (buffer-live-p buf)
-                   (with-current-buffer buf
-                     (ai-code-session-link--flush-scheduled-linkify))))
-               buffer))))))
+      (ai-code-session-link--schedule-pending-linkify
+       buffer
+       (or delay ai-code-session-link--linkify-redraw-delay)))))
 
 (defun ai-code-session-link--linkify-recent-output (output)
   "Linkify the recent tail of the current session buffer after OUTPUT."

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -18,9 +18,13 @@
 (defvar ghostel-set-title-function)
 (defvar ghostel-kill-buffer-on-exit)
 (defvar ghostel-kitty-graphics-mediums)
+(defvar ghostel-inhibit-redraw-functions)
+(defvar ai-code-session-link-inhibit-functions)
+(defvar ai-code-backends-infra--session-directory)
+(defvar ghostel--fake-cursor-overlay)
 (defvar ghostel--plain-link-detection-begin)
 (defvar ghostel--plain-link-detection-end)
-(defvar ai-code-backends-infra--session-directory)
+(defvar x-preedit-overlay)
 
 (ert-deftest test-ai-code-backends-infra-ghostel-create-session-restores-ai-state ()
   "Ghostel session creation should restore AI Code local state after mode reset."
@@ -81,6 +85,103 @@
                 #'ai-code-backends-infra-ghostel--progress))
     (should (eq ai-code-backends-infra-ghostel--progress-function
                 #'ignore))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-configures-ime-redraw-inhibition ()
+  "Ghostel AI session configuration should enable IME redraw inhibition."
+  (let (enabled)
+    (with-temp-buffer
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+                 (lambda () nil))
+                ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+                 (lambda () nil))
+                ((symbol-function 'require)
+                 (lambda (feature &optional _filename _noerror)
+                   (when (eq feature 'ghostel-ime)
+                     t)))
+                ((symbol-function 'ghostel-ime-mode)
+                 (lambda (arg)
+                   (setq enabled arg))))
+        (ai-code-backends-infra--configure-ghostel-buffer))
+      (should (equal enabled 1)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-detects-native-preedit-overlay ()
+  "Native GUI preedit overlays should inhibit Ghostel redraws."
+  (with-temp-buffer
+    (insert "prompt")
+    (let ((overlay (make-overlay (point-min) (point-min) (current-buffer))))
+      (unwind-protect
+          (progn
+            (overlay-put overlay 'after-string "拼")
+            (setq-local ai-code-backends-infra--session-terminal-backend
+                        'ghostel)
+            (setq-local x-preedit-overlay overlay)
+            (should
+             (ai-code-backends-infra-ghostel--native-preedit-active-p
+              (current-buffer))))
+        (delete-overlay overlay)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-detects-unbound-preedit-overlay-at-point ()
+  "Native preedit overlays at point may not be reachable from a symbol."
+  (with-temp-buffer
+    (insert "prompt")
+    (goto-char (point-max))
+    (let ((overlay (make-overlay (point) (point) (current-buffer))))
+      (unwind-protect
+          (progn
+            (overlay-put overlay 'after-string "zhong")
+            (setq-local ai-code-backends-infra--session-terminal-backend
+                        'ghostel)
+            (should
+             (ai-code-backends-infra-ghostel--native-preedit-active-p
+              (current-buffer))))
+        (delete-overlay overlay)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-ignores-fake-cursor-overlay ()
+  "Ghostel's fake cursor overlay should not inhibit redraws."
+  (with-temp-buffer
+    (insert "prompt")
+    (goto-char (point-max))
+    (let ((overlay (make-overlay (point) (point) (current-buffer))))
+      (unwind-protect
+          (progn
+            (overlay-put overlay 'after-string " ")
+            (setq-local ai-code-backends-infra--session-terminal-backend
+                        'ghostel)
+            (setq-local ghostel--fake-cursor-overlay overlay)
+            (should-not
+             (ai-code-backends-infra-ghostel--native-preedit-active-p
+              (current-buffer))))
+        (delete-overlay overlay)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-ignores-composition-at-point ()
+  "Ordinary composed text at point should not inhibit Ghostel redraws."
+  (with-temp-buffer
+    (insert "zhong")
+    (put-text-property (point-min) (point-max) 'composition t)
+    (goto-char (point-max))
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (should-not
+     (ai-code-backends-infra-ghostel--native-preedit-active-p
+      (current-buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-configures-native-preedit-redraw-inhibition ()
+  "Ghostel AI session configuration should defer redraw during GUI preedit."
+  (with-temp-buffer
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (setq-local ghostel-inhibit-redraw-functions nil)
+    (setq-local ai-code-session-link-inhibit-functions nil)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+               (lambda () nil))
+              ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+               (lambda () nil)))
+      (ai-code-backends-infra--configure-ghostel-buffer))
+    (should
+     (memq #'ai-code-backends-infra-ghostel--native-preedit-active-p
+           ghostel-inhibit-redraw-functions))
+    (should
+     (memq #'ai-code-backends-infra-ghostel--native-preedit-active-p
+           ai-code-session-link-inhibit-functions))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-configures-visible-image-hook ()
   "Ghostel AI session configuration should install visible image recovery."
@@ -207,6 +308,38 @@
            (selected-window))
           (should (= (length scheduled) 1))
           (should (equal (caar scheduled) 0.1)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-retries-during-preedit ()
+  "Visible linkification should retry instead of touching text during preedit."
+  (let (rescheduled linkified)
+    (with-temp-buffer
+      (set-window-buffer (selected-window) (current-buffer))
+      (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+      (insert "src/File.el:1\n")
+      (goto-char (point-max))
+      (let ((overlay (make-overlay (point) (point) (current-buffer))))
+        (unwind-protect
+            (progn
+              (overlay-put overlay 'after-string "zhong")
+              (cl-letf (((symbol-function
+                          'ai-code-backends-infra-ghostel-schedule-visible-image-linkify)
+                         (lambda (window delays)
+                           (setq rescheduled (list window delays))))
+                        ((symbol-function
+                          'ai-code-session-link--linkify-session-region)
+                         (lambda (&rest _args)
+                           (setq linkified t))))
+                (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+                 (current-buffer)
+                 (selected-window)))
+              (should
+               (equal rescheduled
+                      (list
+                       (selected-window)
+                       (list
+                        ai-code-session-link--linkify-inhibited-retry-delay))))
+              (should-not linkified))
+          (delete-overlay overlay))))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-visible-linkify-wraps-url ()
   "Visible Ghostel linkification should relinkify wrapped URLs."

--- a/test/test_ai-code-session-link.el
+++ b/test/test_ai-code-session-link.el
@@ -2021,6 +2021,36 @@ Bare wrapped paths -- as printed by tools such as Claude, which omit the
       (should-not ai-code-session-link--linkify-timer)
       (should (zerop ai-code-session-link--pending-tail-width)))))
 
+(ert-deftest ai-code-session-link-test-scheduled-linkify-defers-while-inhibited ()
+  "Delayed linkification should wait while a buffer-local inhibit hook is active."
+  (let (called rescheduled)
+    (with-temp-buffer
+      (insert "src/File.el:12\n")
+      (let ((inhibited t)
+            (ai-code-session-link--linkify-inhibited-retry-delay 3600))
+        (setq-local ai-code-session-link--pending-tail-width 20)
+        (setq-local ai-code-session-link-inhibit-functions
+                    (list (lambda (_buffer) inhibited)))
+        (cl-letf (((symbol-function
+                    'ai-code-session-link--linkify-session-region)
+                   (lambda (start end)
+                     (setq called (cons start end)))))
+          (unwind-protect
+              (progn
+                (ai-code-session-link--flush-scheduled-linkify)
+                (setq rescheduled ai-code-session-link--linkify-timer)
+                (should rescheduled)
+                (should (= ai-code-session-link--pending-tail-width 20))
+                (should-not called)
+                (cancel-timer rescheduled)
+                (setq ai-code-session-link--linkify-timer nil
+                      inhibited nil)
+                (ai-code-session-link--flush-scheduled-linkify)
+                (should called)
+                (should (= ai-code-session-link--pending-tail-width 0)))
+            (when (timerp ai-code-session-link--linkify-timer)
+              (cancel-timer ai-code-session-link--linkify-timer))))))))
+
 (provide 'test_ai-code-session-link)
 
 ;;; test_ai-code-session-link.el ends here


### PR DESCRIPTION
## Summary

- enable Ghostel IME integration for AI Code Ghostel sessions when available
- defer Ghostel redraws while native preedit overlays are active
- defer delayed session linkification during active preedit text

## Verification

- `emacs -Q --batch -L . -l ert -l test/test_ai-code-backends-infra-ghostel.el -f ert-run-tests-batch-and-exit`
- `emacs -Q --batch -L . -l ert -l test/test_ai-code-session-link.el -f ert-run-tests-batch-and-exit`
- `emacs -Q --batch -L . -f batch-byte-compile ai-code-backends-infra-ghostel.el ai-code-session-link.el`
- `emacs -Q --batch -L . --eval '(progn (require (quote checkdoc)) (dolist (file (quote ("ai-code-backends-infra-ghostel.el" "ai-code-session-link.el"))) (checkdoc-file file)))'`
- `emacs -Q --batch -L . -l ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" -f ert-run-tests-batch-and-exit`
- `git diff --check`
