### PR TITLE
Fix Ghostel startup blocked by linum/margin overlay false positive

### DIFF
--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -377,12 +377,26 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
          (<= (1- start) point)
          (<= point (1+ end)))))
 
+(defun ai-code-backends-infra-ghostel--margin-display-string-p (string)
+  "Return non-nil when STRING is a margin display spec, not preedit text."
+  (and (stringp string)
+       (> (length string) 0)
+       (let ((disp (get-text-property 0 'display string)))
+         (and (consp disp)
+              (or (eq (car disp) 'margin)
+                  (and (consp (car disp))
+                       (eq (caar disp) 'margin)))))))
+
 (defun ai-code-backends-infra-ghostel--known-non-preedit-overlay-p
     (overlay)
   "Return non-nil when OVERLAY is known not to represent preedit text."
   (or (overlay-get overlay 'ai-code-session-image-preview)
       (and (boundp 'ghostel--fake-cursor-overlay)
-           (eq overlay ghostel--fake-cursor-overlay))))
+           (eq overlay ghostel--fake-cursor-overlay))
+      (ai-code-backends-infra-ghostel--margin-display-string-p
+       (overlay-get overlay 'before-string))
+      (ai-code-backends-infra-ghostel--margin-display-string-p
+       (overlay-get overlay 'after-string))))
 
 (defun ai-code-backends-infra-ghostel--point-preedit-overlay-p
     (overlay buffer point)

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -1160,5 +1160,26 @@
         (should (eq (plist-get (car updates) :ghostel-progress-state) 'remove))
         (should (eq (plist-get (car updates) :ghostel-status) 'idle))))))
 
+(ert-deftest test-ai-code-backends-infra-ghostel-linum-overlay-does-not-inhibit-redraw ()
+  "Linum margin display overlays should not inhibit Ghostel redraws.
+Regression test for issue #430: linum overlays with margin display specs
+in `before-string' were misidentified as IME preedit overlays."
+  (with-temp-buffer
+    (insert "prompt line\n")
+    (goto-char (point-min))
+    (let ((overlay (make-overlay (point) (1+ (point)) (current-buffer)))
+          (margin-string (propertize " " 'display
+                                     '((margin left-margin)
+                                       #("57" 0 2 (face linum))))))
+      (unwind-protect
+          (progn
+            (overlay-put overlay 'before-string margin-string)
+            (setq-local ai-code-backends-infra--session-terminal-backend
+                        'ghostel)
+            (should-not
+             (ai-code-backends-infra-ghostel--redraw-inhibited-p
+              (current-buffer))))
+        (delete-overlay overlay)))))
+
 (provide 'test_ai-code-backends-infra-ghostel)
 ;;; test_ai-code-backends-infra-ghostel.el ends here


### PR DESCRIPTION
## Summary

Fixes #430 — Claude Code and Codex failed to start with the Ghostel backend on systems with `linum-mode` (or similar margin-display packages) enabled.

## Problem

The IME preedit redraw-inhibition logic (`--point-preedit-overlay-p`) checked whether overlays near point had a `before-string` property, treating any match as evidence of active IME composition. Linum overlays use `before-string` with a `(margin left-margin)` display spec to render line numbers, which caused a false positive — every redraw was permanently deferred, leaving the terminal blank after the initial partial render.

## Fix

- Added `ai-code-backends-infra-ghostel--margin-display-string-p` to detect strings whose first character carries a `(margin ...)` display property.
- Extended `--known-non-preedit-overlay-p` to exclude overlays whose `before-string` or `after-string` is a margin display spec.
- Added a regression test simulating a linum overlay and verifying `--redraw-inhibited-p` returns nil.

## Test plan

- [x] All 47 existing Ghostel tests pass (`emacs --batch -l ert ...`)
- [x] New regression test covers the exact linum overlay shape that triggered the bug
- [ ] Manual verification: enable `linum-mode`, start AI Code session with Ghostel backend, confirm terminal renders normally