### PR TITLE
Fix Ghostel input jitter caused by inline image anchoring

### DIFF
--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -45,6 +45,9 @@ enabled by default because it widens the terminal's local resource access."
 (declare-function ghostel-send-key "ghostel" (key-name &optional mods))
 (declare-function ghostel-send-string "ghostel" (string))
 (declare-function ghostel-paste-string "ghostel" (string))
+(declare-function ghostel--anchor-window "ghostel" (&optional window force))
+(declare-function ghostel--window-anchored-p
+                  "ghostel" (window &optional body-pixel-height))
 (declare-function ghostel--schedule-link-detection
                   "ghostel" (&optional begin end))
 (declare-function ghostel--run-queued-plain-link-detection
@@ -74,12 +77,16 @@ enabled by default because it widens the terminal's local resource access."
   (defvar ghostel-set-title-function)
   (defvar ghostel--copy-mode-active)
   (defvar ghostel--fake-cursor-overlay)
+  (defvar ghostel--cursor-char-pos)
   (defvar ghostel--input-mode)
   (defvar ghostel--plain-link-detection-begin)
   (defvar ghostel--plain-link-detection-end))
 
 (defvar-local ai-code-backends-infra-ghostel--progress-function nil
   "Original Ghostel progress function captured before AI Code wrapping.")
+
+(defvar ai-code-backends-infra-ghostel--preserving-image-preview-follow nil
+  "Non-nil while a linkification batch preserves Ghostel follow state.")
 
 (defconst ai-code-backends-infra-ghostel--linkify-redraw-delay 0.05
   "Seconds to wait before relinkifying recent Ghostel output.")
@@ -331,6 +338,79 @@ STATE and PROGRESS use the signature of `ghostel-progress-function'."
                                 (+ start
                                    ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
               (and (< start end) (cons start end)))))))))
+
+(defun ai-code-backends-infra-ghostel--window-has-image-preview-p (window)
+  "Return non-nil when WINDOW's remaining buffer contains an image preview."
+  (when (and (window-live-p window)
+             (buffer-live-p (window-buffer window)))
+    (with-current-buffer (window-buffer window)
+      (let ((start (window-start window))
+            (end (point-max)))
+        (cl-some
+         (lambda (overlay)
+           (overlay-get overlay 'ai-code-session-image-preview))
+         (delete-dups
+          (append (and (< start end) (overlays-in start end))
+                  (overlays-at start)
+                  (overlays-at end))))))))
+
+(defun ai-code-backends-infra-ghostel--window-pixel-anchor-state
+    (window &optional body-pixel-height)
+  "Return WINDOW's pixel anchor state, or `unknown' when unmeasurable.
+The symbols `anchored' and `unanchored' account for display-only content such
+as image preview overlay strings.  BODY-PIXEL-HEIGHT has the same meaning as
+in `ghostel--window-anchored-p'."
+  (if (not (and (window-live-p window)
+                (buffer-live-p (window-buffer window))))
+      'unknown
+    (with-current-buffer (window-buffer window)
+      (let* ((body-pixel-height
+              (or body-pixel-height (window-body-height window t)))
+             (default-line-height
+              (and (numberp body-pixel-height)
+                   (> body-pixel-height 0)
+                   (with-selected-window window (default-line-height))))
+             (fit-height
+              (and (numberp default-line-height)
+                   (> default-line-height 0)
+                   (+ body-pixel-height default-line-height)))
+             (pixel-vscroll
+              (max 0 (or (ignore-errors (window-vscroll window t)) 0)))
+             (visible-limit
+              (and fit-height (+ fit-height pixel-vscroll)))
+             (size
+              (and visible-limit
+                   (ignore-errors
+                     (window-text-pixel-size
+                      window (window-start window) (point-max)
+                      nil (1+ visible-limit)))))
+             (content-height
+              ;; With the integer FROM above, `window-text-pixel-size'
+              ;; returns (WIDTH . HEIGHT).
+              (and (consp size) (numberp (cdr size)) (cdr size))))
+        (if (numberp content-height)
+            (if (<= content-height visible-limit)
+                'anchored
+              'unanchored)
+          'unknown)))))
+
+(defun ai-code-backends-infra-ghostel--window-anchored-p-around
+    (original window &optional body-pixel-height)
+  "Correct ORIGINAL's anchor result for image preview pixels in WINDOW.
+BODY-PIXEL-HEIGHT is forwarded to ORIGINAL and used for the pixel check."
+  (let ((anchored (funcall original window body-pixel-height)))
+    (if (and anchored
+             (ai-code-backends-infra-ghostel--ai-session-buffer-p
+              (window-buffer window))
+             (ai-code-backends-infra-ghostel--window-has-image-preview-p
+              window))
+        (pcase
+            (ai-code-backends-infra-ghostel--window-pixel-anchor-state
+             window body-pixel-height)
+          ('anchored t)
+          ('unanchored nil)
+          (_ anchored))
+      anchored)))
 
 (defun ai-code-backends-infra-ghostel--trusted-local-session-p ()
   "Return non-nil when this Ghostel session can safely read local files."
@@ -680,6 +760,108 @@ BEGIN and END are the Ghostel link-detection bounds."
      :around
      #'ai-code-backends-infra-ghostel--around-run-queued-link-detection)))
 
+(defun ai-code-backends-infra-ghostel--image-preview-overlays-in-region
+    (start end)
+  "Return image preview overlays touching START through END."
+  (cl-remove-if-not
+   (lambda (overlay)
+     (overlay-get overlay 'ai-code-session-image-preview))
+   (delete-dups
+    (append (overlays-in start end)
+            (overlays-at start)
+            (overlays-at end)))))
+
+(defun ai-code-backends-infra-ghostel--input-row-bounds ()
+  "Return the bounds of Ghostel's live cursor row, or nil."
+  (let ((cursor (and (boundp 'ghostel--cursor-char-pos)
+                     ghostel--cursor-char-pos)))
+    (when (and (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+               (integer-or-marker-p cursor))
+      (save-excursion
+        (goto-char (max (point-min)
+                        (min (point-max) cursor)))
+        (cons (line-beginning-position) (line-end-position))))))
+
+(defun ai-code-backends-infra-ghostel--remove-input-image-previews
+    (start end)
+  "Remove image preview overlays touching the input region START through END."
+  (dolist (overlay
+           (ai-code-backends-infra-ghostel--image-preview-overlays-in-region
+            start end))
+    (delete-overlay overlay)))
+
+(defun ai-code-backends-infra-ghostel--apply-image-preview-for-file-around
+    (original match-start match-end link-text file &optional display-text)
+  "Call ORIGINAL unless MATCH-START through MATCH-END is live Ghostel input.
+LINK-TEXT, FILE, and optional DISPLAY-TEXT are forwarded unchanged."
+  (if-let* ((input-bounds
+             (ai-code-backends-infra-ghostel--input-row-bounds))
+            ((<= (car input-bounds) match-start))
+            ((<= match-start (cdr input-bounds))))
+      (progn
+        (ai-code-backends-infra-ghostel--remove-input-image-previews
+         match-start match-end)
+        nil)
+    (funcall original match-start match-end link-text file display-text)))
+
+(defun ai-code-backends-infra-ghostel--call-preserving-image-preview-follow
+    (buffer start end windows function)
+  "Call FUNCTION while preserving image preview follow state in BUFFER.
+START and END bound the overlays inspected.  WINDOWS limits the windows
+considered; when nil, use every window displaying BUFFER."
+  (if ai-code-backends-infra-ghostel--preserving-image-preview-follow
+      (funcall function)
+    (let ((ai-code-backends-infra-ghostel--preserving-image-preview-follow t))
+      (with-current-buffer buffer
+        (let* ((windows (or windows (get-buffer-window-list buffer nil t)))
+           (anchored-windows
+            (when (and (fboundp 'ghostel--window-anchored-p)
+                       (fboundp 'ghostel--anchor-window))
+              (cl-remove-if-not
+               (lambda (window)
+                 (and (window-live-p window)
+                      (eq (window-buffer window) buffer)
+                      (ignore-errors
+                        (ghostel--window-anchored-p window))))
+               windows)))
+           (previews-before
+            (ai-code-backends-infra-ghostel--image-preview-overlays-in-region
+             start end))
+           (result (funcall function)))
+          (when (and anchored-windows
+                     (cl-some
+                      (lambda (overlay)
+                        (not (memq overlay previews-before)))
+                      (ai-code-backends-infra-ghostel--image-preview-overlays-in-region
+                       start end)))
+            (dolist (window anchored-windows)
+              (when (and (window-live-p window)
+                         (eq (window-buffer window) buffer))
+                (ghostel--anchor-window window))))
+          result)))))
+
+(defun ai-code-backends-infra-ghostel--linkify-session-region-around
+    (original start end)
+  "Call ORIGINAL for START through END while preserving Ghostel follow state."
+  (if (ai-code-backends-infra-ghostel--ai-session-buffer-p)
+      (ai-code-backends-infra-ghostel--call-preserving-image-preview-follow
+       (current-buffer) start end nil
+       (lambda () (funcall original start end)))
+    (funcall original start end)))
+
+(defun ai-code-backends-infra-ghostel--linkify-bounded-region
+    (buffer start end &optional windows)
+  "Linkify BUFFER from START to END while preserving follow state.
+WINDOWS limits the windows considered; when nil, use every window displaying
+BUFFER."
+  (ai-code-backends-infra-ghostel--call-preserving-image-preview-follow
+   buffer start end windows
+   (lambda ()
+     (ai-code-backends-infra-ghostel--linkify-session-region start end)
+     (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
+       (ai-code-session-link--linkify-strict-image-preview-region start end))
+     (ai-code-backends-infra-ghostel--cache-preserved-link-spans start end))))
+
 (defun ai-code-backends-infra-ghostel--linkify-visible-image-previews
     (buffer window)
   "Linkify session links and image previews in BUFFER shown by WINDOW."
@@ -695,16 +877,8 @@ BEGIN and END are the Ghostel link-detection bounds."
         (when-let* ((region
                      (ai-code-backends-infra-ghostel--visible-image-region
                       window)))
-          (ai-code-backends-infra-ghostel--linkify-session-region
-           (car region)
-           (cdr region))
-          (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
-            (ai-code-session-link--linkify-strict-image-preview-region
-             (car region)
-             (cdr region)))
-          (ai-code-backends-infra-ghostel--cache-preserved-link-spans
-           (car region)
-           (cdr region)))))))
+          (ai-code-backends-infra-ghostel--linkify-bounded-region
+           buffer (car region) (cdr region) (list window)))))))
 
 (defun ai-code-backends-infra-ghostel--cancel-visible-image-linkify-timers
     (window)
@@ -773,13 +947,8 @@ accidentally scan an entire scrollback buffer."
                              (- end
                                 ai-code-backends-infra-ghostel-visible-image-linkify-max-chars))))
                 (when (< start end)
-                  (ai-code-backends-infra-ghostel--linkify-session-region
-                   start end)
-                  (when (ai-code-backends-infra-ghostel--trusted-local-session-p)
-                    (ai-code-session-link--linkify-strict-image-preview-region
-                     start end))
-                  (ai-code-backends-infra-ghostel--cache-preserved-link-spans
-                   start end))))))))))
+                  (ai-code-backends-infra-ghostel--linkify-bounded-region
+                   buffer start end))))))))))
 
 (defun ai-code-backends-infra-ghostel-schedule-visible-image-linkify
     (window &optional delays)
@@ -853,7 +1022,28 @@ Optional DELAYS overrides the default visible image linkification delays."
          buffer start end)))))
 
 (defun ai-code-backends-infra-ghostel--install-image-preview-advice ()
-  "Install Ghostel advice used to add and refresh image previews."
+  "Install Ghostel advice used to display stable image previews."
+  (when (not
+         (advice-member-p
+          #'ai-code-backends-infra-ghostel--apply-image-preview-for-file-around
+          'ai-code-session-link--apply-image-preview-for-file))
+    (advice-add
+     'ai-code-session-link--apply-image-preview-for-file
+     :around
+     #'ai-code-backends-infra-ghostel--apply-image-preview-for-file-around))
+  (when (not (advice-member-p
+              #'ai-code-backends-infra-ghostel--linkify-session-region-around
+              'ai-code-session-link--linkify-session-region))
+    (advice-add 'ai-code-session-link--linkify-session-region
+                :around
+                #'ai-code-backends-infra-ghostel--linkify-session-region-around))
+  (when (and (fboundp 'ghostel--window-anchored-p)
+             (not (advice-member-p
+                   #'ai-code-backends-infra-ghostel--window-anchored-p-around
+                   'ghostel--window-anchored-p)))
+    (advice-add 'ghostel--window-anchored-p
+                :around
+                #'ai-code-backends-infra-ghostel--window-anchored-p-around))
   (when (and (fboundp 'ghostel--run-queued-plain-link-detection)
              (not (advice-member-p
                    #'ai-code-backends-infra-ghostel--run-queued-link-detection-around

--- a/ai-code-session-link.el
+++ b/ai-code-session-link.el
@@ -67,6 +67,18 @@ impose a fixed hard cap instead."
                  (integer :tag "Fixed pixel cap"))
   :group 'ai-code)
 
+(defcustom ai-code-session-link-ghostel-image-preview-vertical-margin 'auto
+  "Vertical margin around Ghostel session image previews.
+The default value `auto' uses 0.3 times the session window's line height, so
+the spacing follows font-size changes.  Set a non-negative integer to use a
+fixed pixel margin instead; zero disables the margin."
+  :type '(choice (const :tag "Automatic (0.3 line height)" auto)
+                 (natnum :tag "Fixed pixels"))
+  :group 'ai-code)
+
+(defconst ai-code-session-link--image-preview-auto-margin-ratio 0.3
+  "Line-height fraction used for automatic image preview margins.")
+
 (defconst ai-code-session-link--visible-image-preview-max-line-width 2048
   "Maximum candidate width inspected by strict visible image preview scanning.")
 
@@ -632,6 +644,12 @@ Expensive project-wide resolution stays in
               (<= (file-attribute-size attrs)
                   ai-code-session-link-ghostel-image-preview-max-bytes)))))
 
+(defun ai-code-session-link--image-preview-file-signature (file)
+  "Return a size and modification-time signature for image FILE."
+  (when-let* ((attributes (file-attributes file 'integer)))
+    (cons (file-attribute-size attributes)
+          (file-attribute-modification-time attributes))))
+
 (defun ai-code-session-link--parse-file-link-text (text)
   "Parse file-like session link TEXT into a plist."
   (when-let* ((text (ai-code-session-link--normalize-link-text text)))
@@ -662,8 +680,11 @@ Expensive project-wide resolution stays in
               ((ai-code-session-link--safe-local-image-file-p abs-file)))
     abs-file))
 
-(defun ai-code-session-link--delete-image-preview-overlays (start end)
-  "Delete image preview overlays touching START through END."
+(defun ai-code-session-link--delete-image-preview-overlays
+    (start end &optional stale-only)
+  "Delete image preview overlays touching START through END.
+When STALE-ONLY is non-nil, preserve overlays still anchored to their image
+link text."
   (let* ((line-start (save-excursion
                        (goto-char start)
                        (line-beginning-position)))
@@ -678,7 +699,11 @@ Expensive project-wide resolution stays in
                               (overlays-at end)
                               (overlays-at line-end)
                               (overlays-at scan-end))))
-      (when (overlay-get overlay 'ai-code-session-image-preview)
+      (when (and (overlay-get overlay 'ai-code-session-image-preview)
+                 (or (not stale-only)
+                     (not
+                      (ai-code-session-link--live-image-preview-overlay-p
+                       overlay))))
         (delete-overlay overlay)))))
 
 (defun ai-code-session-link--image-preview-indent (match-start)
@@ -744,6 +769,26 @@ INDENT is inserted before the image on the preview line."
   (when (ai-code-session-link--image-preview-enabled-p)
     (ai-code-session-link--image-preview-file link-text)))
 
+(defun ai-code-session-link--image-preview-vertical-margin ()
+  "Return the current image preview vertical margin in pixels."
+  (let ((setting ai-code-session-link-ghostel-image-preview-vertical-margin))
+    (cond
+     ((integerp setting) (max 0 setting))
+     ((eq setting 'auto)
+      (let* ((window (get-buffer-window (current-buffer) t))
+             (line-height
+              (ignore-errors
+                (if window
+                    (with-selected-window window (default-line-height))
+                  (default-line-height)))))
+        (if (and (numberp line-height) (> line-height 0))
+            (max 1
+                 (round
+                  (* ai-code-session-link--image-preview-auto-margin-ratio
+                     line-height)))
+          6)))
+     (t 0))))
+
 (defun ai-code-session-link--live-image-preview-overlay-p (overlay)
   "Return non-nil when OVERLAY is still anchored to its image link text."
   (and (overlayp overlay)
@@ -751,10 +796,22 @@ INDENT is inserted before the image on the preview line."
        (overlay-get overlay 'ai-code-session-image-preview)
        (< (overlay-start overlay) (overlay-end overlay))
        (let ((link-text (overlay-get overlay 'ai-code-session-image-link-text))
+             (file (overlay-get overlay 'ai-code-session-image-file))
+             (file-signature
+              (overlay-get overlay 'ai-code-session-image-file-signature))
+             (vertical-margin
+              (overlay-get overlay 'ai-code-session-image-vertical-margin))
              (display-text
               (or (overlay-get overlay 'ai-code-session-image-display-text)
                   (overlay-get overlay 'ai-code-session-image-link-text))))
          (and link-text
+              file
+              file-signature
+              (equal file-signature
+                     (ai-code-session-link--image-preview-file-signature file))
+              (integerp vertical-margin)
+              (= vertical-margin
+                 (ai-code-session-link--image-preview-vertical-margin))
               display-text
               (get-text-property (overlay-start overlay)
                                  'ai-code-session-link)
@@ -852,11 +909,12 @@ when no window shows the buffer."
      (and (integerp ai-code-session-link-ghostel-image-preview-max-height)
           ai-code-session-link-ghostel-image-preview-max-height))))
 
-(defun ai-code-session-link--create-image-preview (file max-width max-height)
+(defun ai-code-session-link--create-image-preview
+    (file max-width max-height vertical-margin)
   "Create a data-backed preview image for FILE.
 MAX-WIDTH and MAX-HEIGHT are pixel caps passed to `create-image', which only
 scales down, so a smaller image keeps its native size.  A nil cap leaves that
-dimension unbounded.
+dimension unbounded.  VERTICAL-MARGIN is the pixel gap above and below it.
 
 Using image data instead of a file-backed image spec keeps inline previews
 stable when `image-mode' opens and flushes the same image file."
@@ -867,7 +925,9 @@ stable when `image-mode' opens and flushes the same image file."
     (ignore-errors
       (apply #'create-image
              data type data-p
-             (append (when max-width (list :max-width max-width))
+             (append (when (> vertical-margin 0)
+                       (list :margin (cons 0 vertical-margin)))
+                     (when max-width (list :max-width max-width))
                      (when max-height (list :max-height max-height)))))))
 
 (defun ai-code-session-link--apply-image-preview (match-start match-end link-text)
@@ -893,19 +953,28 @@ stable when `image-mode' opens and flushes the same image file."
               display-text))
            (indent (ai-code-session-link--image-preview-indent match-start))
            (dimensions (ai-code-session-link--image-preview-max-dimensions indent))
-           (image (ai-code-session-link--create-image-preview
-                   file (car dimensions) (cdr dimensions))))
-      (when image
-        (let ((overlay (make-overlay match-start anchor-end nil nil nil)))
-          (overlay-put overlay 'ai-code-session-image-preview t)
-          (overlay-put overlay 'ai-code-session-image-file file)
-          (overlay-put overlay 'ai-code-session-image-link-text link-text)
-          (overlay-put overlay 'ai-code-session-image-display-text
-                       (or display-text link-text))
-          (overlay-put overlay 'after-string
-                       (ai-code-session-link--image-preview-string
-                        image file indent))
-          overlay)))))
+           (vertical-margin
+            (ai-code-session-link--image-preview-vertical-margin))
+           (existing
+            (ai-code-session-link--image-preview-overlay-present-p
+             match-start match-end display-text)))
+      (unless existing
+        (when-let* ((image (ai-code-session-link--create-image-preview
+                            file (car dimensions) (cdr dimensions)
+                            vertical-margin)))
+          (let ((overlay (make-overlay match-start anchor-end nil nil nil)))
+            (overlay-put overlay 'ai-code-session-image-preview t)
+            (overlay-put overlay 'ai-code-session-image-file file)
+            (overlay-put overlay 'ai-code-session-image-file-signature
+                         (ai-code-session-link--image-preview-file-signature file))
+            (overlay-put overlay 'ai-code-session-image-vertical-margin
+                         vertical-margin)
+            (overlay-put overlay 'ai-code-session-image-link-text link-text)
+            (overlay-put overlay 'ai-code-session-image-display-text display-text)
+            (overlay-put overlay 'after-string
+                         (ai-code-session-link--image-preview-string
+                          image file indent))
+            overlay))))))
 
 (defun ai-code-session-link--apply-properties (start end &optional text help-echo)
   "Apply session link properties from START to END.
@@ -1478,7 +1547,7 @@ MATCH-END is the end of the first-row URL match.  SCAN-END bounds the search."
 ALLOW-LOCAL-PROBING controls local existence checks and image previews."
   (let ((inhibit-read-only t)
         (inhibit-modification-hooks t))
-    (ai-code-session-link--delete-image-preview-overlays start end)
+    (ai-code-session-link--delete-image-preview-overlays start end t)
     (let ((ai-code-session-link--project-files-cache
            (ai-code-session-link--buffer-project-files-cache))
           (ai-code-session-link--resolved-path-cache
@@ -1658,7 +1727,7 @@ visible-window recovery in large terminal scrollback."
   (when (ai-code-session-link--image-preview-enabled-p)
     (let ((inhibit-read-only t)
           (inhibit-modification-hooks t))
-      (ai-code-session-link--delete-image-preview-overlays start end)
+      (ai-code-session-link--delete-image-preview-overlays start end t)
       (save-excursion
         (let ((case-fold-search t)
               (candidate-count 0)

--- a/test/test_ai-code-backends-infra-ghostel.el
+++ b/test/test_ai-code-backends-infra-ghostel.el
@@ -22,6 +22,7 @@
 (defvar ai-code-session-link-inhibit-functions)
 (defvar ai-code-backends-infra--session-directory)
 (defvar ghostel--fake-cursor-overlay)
+(defvar ghostel--cursor-char-pos)
 (defvar ghostel--plain-link-detection-begin)
 (defvar ghostel--plain-link-detection-end)
 (defvar ghostel-link-map)
@@ -426,13 +427,105 @@
   "Ghostel AI session configuration should install visible image recovery."
   (with-temp-buffer
     (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
-    (cl-letf (((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
-               (lambda () nil))
-              ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
-               (lambda () nil)))
-      (ai-code-backends-infra--configure-ghostel-buffer))
+    (cl-letf
+        (((symbol-function 'ghostel--window-anchored-p)
+          (lambda (&rest _args) t))
+         ((symbol-function 'ai-code-backends-infra--configure-session-input-shortcuts)
+          (lambda () nil))
+         ((symbol-function 'ai-code-backends-infra--install-navigation-cursor-sync)
+          (lambda () nil)))
+      (ai-code-backends-infra--configure-ghostel-buffer)
+      (should
+       (advice-member-p
+        #'ai-code-backends-infra-ghostel--window-anchored-p-around
+        'ghostel--window-anchored-p))
+      (should
+       (advice-member-p
+        #'ai-code-backends-infra-ghostel--linkify-session-region-around
+        'ai-code-session-link--linkify-session-region)))
     (should (memq #'ai-code-backends-infra-ghostel--window-scroll
                   window-scroll-functions))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel--window-anchored-p-around-image-overflow ()
+  "An overflowing image should prevent Ghostel redraw re-anchoring."
+  (save-window-excursion
+    (with-temp-buffer
+      (let ((window (selected-window))
+            (buffer (current-buffer)))
+        (set-window-buffer window buffer)
+        (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+        (insert "Saved screenshot.png\ninput\n")
+        (let ((preview (make-overlay 7 21 buffer))
+              (measured-height 500)
+              (pixel-vscroll 0)
+              (original-result t)
+              (pixel-calls 0)
+              (original-calls 0))
+          (overlay-put preview 'ai-code-session-image-preview t)
+          (overlay-put preview 'after-string "\n[large image]\n")
+          (set-window-start window (point-min) t)
+          (cl-letf (((symbol-function 'window-body-height)
+                     (lambda (target-window &optional pixelwise)
+                       (should (eq target-window window))
+                       (should pixelwise)
+                       300))
+                    ((symbol-function 'default-line-height)
+                     (lambda () 20))
+                    ((symbol-function 'window-vscroll)
+                     (lambda (target-window &optional pixelwise)
+                       (should (eq target-window window))
+                       (should pixelwise)
+                       pixel-vscroll))
+                    ((symbol-function 'window-text-pixel-size)
+                     (lambda (target-window from to &rest _args)
+                       (setq pixel-calls (1+ pixel-calls))
+                       (should (eq target-window window))
+                       (should (= from (window-start window)))
+                       (should (= to (point-max)))
+                       (cons 100 measured-height)))
+                    ((symbol-function 'original-window-anchored-p)
+                     (lambda (&rest _args)
+                       (setq original-calls (1+ original-calls))
+                       original-result)))
+            ;; Text rows fit, but image pixels overflow the body plus
+            ;; Ghostel's one-line partial-row tolerance.
+            (should-not
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            ;; The same display is anchored once its measured height fits.
+            (setq measured-height 320)
+            (should
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            ;; Pixel vscroll represents preview content already clipped above
+            ;; the window start after Ghostel bottom-aligns a tall preview.
+            (setq measured-height 330
+                  pixel-vscroll 10)
+            (should
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            ;; A malformed measurement safely preserves Ghostel's result.
+            (setq measured-height 'invalid)
+            (should
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            (should (= pixel-calls 4))
+            ;; Without an AI image preview, preserve Ghostel's result.
+            (delete-overlay preview)
+            (setq measured-height 500)
+            (should
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            (should (= pixel-calls 4))
+            ;; A window Ghostel already considers unanchored needs no
+            ;; display geometry measurement.
+            (move-overlay preview 7 21 buffer)
+            (setq original-result nil)
+            (should-not
+             (ai-code-backends-infra-ghostel--window-anchored-p-around
+              #'original-window-anchored-p window))
+            (should (= pixel-calls 4))
+            (should (= original-calls 6))))))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-configures-image-mediums ()
   "Ghostel AI session configuration should enable local image mediums."
@@ -511,6 +604,120 @@
                   1)))))
       (when (file-directory-p root)
         (delete-directory root t)))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel--visible-linkify-keeps-input-at-bottom ()
+  "Adding a preview to a following window should keep its input visible."
+  (save-window-excursion
+    (with-temp-buffer
+      (let ((window (selected-window))
+            (anchor-count 0)
+            (following t)
+            input-visible)
+        (set-window-buffer window (current-buffer))
+        (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+        (insert "Saved screenshot.png\ninput\n")
+        (cl-letf
+            (((symbol-function
+               'ai-code-backends-infra-ghostel--redraw-inhibited-p)
+              (lambda (_buffer) nil))
+             ((symbol-function
+               'ai-code-backends-infra-ghostel--visible-image-region)
+              (lambda (_window) (cons (point-min) (point-max))))
+             ((symbol-function
+               'ai-code-backends-infra-ghostel--linkify-session-region)
+              (lambda (&rest _args) nil))
+             ((symbol-function
+               'ai-code-backends-infra-ghostel--cache-preserved-link-spans)
+              (lambda (&rest _args) nil))
+             ((symbol-function
+               'ai-code-backends-infra-ghostel--trusted-local-session-p)
+              (lambda () t))
+             ((symbol-function 'ghostel--window-anchored-p)
+              (lambda (target-window &optional _body-height)
+                (should (eq target-window window))
+                following))
+             ((symbol-function 'ghostel--anchor-window)
+              (lambda (&optional target-window _force)
+                (should (eq target-window window))
+                (setq anchor-count (1+ anchor-count)
+                      input-visible t)))
+             ((symbol-function
+               'ai-code-session-link--linkify-strict-image-preview-region)
+              (lambda (start end)
+                (unless
+                    (cl-some
+                     (lambda (overlay)
+                       (overlay-get overlay 'ai-code-session-image-preview))
+                     (overlays-in start end))
+                  (let ((preview (make-overlay start end)))
+                    (overlay-put preview 'ai-code-session-image-preview t))))))
+          (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+           (current-buffer) window)
+          (should input-visible)
+          (should (= anchor-count 1))
+          ;; An unchanged rescan must not introduce another anchor jump.
+          (setq input-visible nil)
+          (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+           (current-buffer) window)
+          (should-not input-visible)
+          (should (= anchor-count 1))
+          ;; Adding a preview while reading scrollback must not steal focus.
+          (dolist (overlay (overlays-in (point-min) (point-max)))
+            (when (overlay-get overlay 'ai-code-session-image-preview)
+              (delete-overlay overlay)))
+          (setq following nil)
+          (ai-code-backends-infra-ghostel--linkify-visible-image-previews
+           (current-buffer) window)
+          (should-not input-visible)
+          (should (= anchor-count 1))
+          ;; The generic delayed linkifier used by the process filter must
+          ;; preserve the same follow transition.
+          (dolist (overlay (overlays-in (point-min) (point-max)))
+            (when (overlay-get overlay 'ai-code-session-image-preview)
+              (delete-overlay overlay)))
+          (setq following t)
+          (ai-code-backends-infra-ghostel--linkify-session-region-around
+           (lambda (start end)
+             (ai-code-session-link--linkify-strict-image-preview-region
+              start end))
+           (point-min)
+           (point-max))
+          (should input-visible)
+          (should (= anchor-count 2)))))))
+
+(ert-deftest test-ai-code-backends-infra-ghostel--apply-image-preview-for-file-around-live-input-row ()
+  "Ghostel should keep image paths in its live input row text-only."
+  (with-temp-buffer
+    (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+    (let ((history-start (point)))
+      (insert "/tmp/history.png\n")
+      (let ((input-start (point)))
+        (insert "/tmp/input.png")
+        (setq-local ghostel--cursor-char-pos (point-max))
+        (let ((below-start (progn
+                             (insert "\n")
+                             (point))))
+          (insert "/tmp/below.png")
+          (let (calls input-preview)
+            (ai-code-backends-infra-ghostel--apply-image-preview-for-file-around
+             (lambda (start &rest _args)
+               (push start calls))
+             history-start (1- input-start) "/tmp/history.png"
+             "/tmp/history.png")
+            (setq input-preview
+                  (make-overlay input-start (1- below-start)))
+            (overlay-put input-preview 'ai-code-session-image-preview t)
+            (overlay-put input-preview 'after-string "[preview]")
+            (ai-code-backends-infra-ghostel--apply-image-preview-for-file-around
+             (lambda (start &rest _args)
+               (push start calls))
+             input-start (1- below-start) "/tmp/input.png" "/tmp/input.png")
+            (ai-code-backends-infra-ghostel--apply-image-preview-for-file-around
+             (lambda (start &rest _args)
+               (push start calls))
+             below-start (point-max) "/tmp/below.png" "/tmp/below.png")
+            (should (equal calls (list below-start history-start)))
+            (should-not (overlay-buffer input-preview))))))))
 
 (ert-deftest test-ai-code-backends-infra-ghostel-schedules-visible-linkify ()
   "Visible image linkification should schedule bounded window scans."

--- a/test/test_ai-code-session-link.el
+++ b/test/test_ai-code-session-link.el
@@ -1254,6 +1254,8 @@
   "Ghostel sessions should preview local image file links."
   (let* ((root (make-temp-file "ai-code-session-image-preview-" t))
          (image-file (expand-file-name "screenshot.png" root))
+         (ai-code-session-link-ghostel-image-preview-vertical-margin 'auto)
+         (line-height 20)
          (created-image nil))
     (unwind-protect
         (progn
@@ -1264,7 +1266,9 @@
                     ((symbol-function 'create-image)
                      (lambda (data &rest args)
                        (setq created-image (cons data args))
-                       (list :image data :args args))))
+                       (list :image data :args args)))
+                    ((symbol-function 'default-line-height)
+                     (lambda () line-height)))
             (with-temp-buffer
               (setq-local ai-code-backends-infra--session-directory root)
               (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
@@ -1293,8 +1297,26 @@
                 (should (equal (car created-image) "fake image bytes"))
                 (should-not (equal (car created-image) image-file))
                 (should (nth 2 created-image))
+                (should (equal (cadr (memq :margin created-image))
+                               '(0 . 6)))
                 (should (member :max-width created-image))
-                (should-not (member :max-height created-image))))))
+                (should-not (member :max-height created-image))
+                (setq line-height 30)
+                (ai-code-session-link--linkify-session-region
+                 (point-min) (point-max))
+                (should (equal (cadr (memq :margin created-image))
+                               '(0 . 9)))
+                (setq ai-code-session-link-ghostel-image-preview-vertical-margin
+                      4)
+                (ai-code-session-link--linkify-session-region
+                 (point-min) (point-max))
+                (should (equal (cadr (memq :margin created-image))
+                               '(0 . 4)))
+                (setq ai-code-session-link-ghostel-image-preview-vertical-margin
+                      0)
+                (ai-code-session-link--linkify-session-region
+                 (point-min) (point-max))
+                (should-not (memq :margin created-image))))))
       (when (file-directory-p root)
         (delete-directory root t)))))
 
@@ -1668,6 +1690,52 @@ detection regexp must stitch those rows back together."
                       (overlay-get overlay 'ai-code-session-image-preview))
                     (overlays-in (point-min) (point-max))))
                   1)))))
+      (when (file-directory-p root)
+        (delete-directory root t)))))
+
+(ert-deftest test-ai-code-session-link--linkify-strict-image-preview-region-refresh ()
+  "Repeated scans preserve unchanged previews and refresh changed files."
+  (let* ((root (make-temp-file "ai-code-session-image-rescan-" t))
+         (image-file (expand-file-name "preview.png" root))
+         (create-count 0))
+    (unwind-protect
+        (progn
+          (with-temp-file image-file
+            (insert "fake image bytes"))
+          (cl-letf (((symbol-function 'display-images-p)
+                     (lambda (&optional _display) t))
+                    ((symbol-function 'create-image)
+                     (lambda (data &rest args)
+                       (setq create-count (1+ create-count))
+                       (list :image data :args args))))
+            (with-temp-buffer
+              (setq-local ai-code-backends-infra--session-directory root)
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'ghostel)
+              (insert "Saved " image-file "\n")
+              (ai-code-session-link--linkify-strict-image-preview-region
+               (point-min) (point-max))
+              (let ((preview
+                     (cl-find-if
+                      (lambda (overlay)
+                        (overlay-get overlay 'ai-code-session-image-preview))
+                      (overlays-in (point-min) (point-max)))))
+                (should preview)
+                (ai-code-session-link--linkify-strict-image-preview-region
+                 (point-min) (point-max))
+                (should (= create-count 1))
+                (should (eq (overlay-buffer preview) (current-buffer)))
+                (with-temp-file image-file
+                  (insert "updated image bytes with a different size"))
+                (ai-code-session-link--linkify-strict-image-preview-region
+                 (point-min) (point-max))
+                (should (= create-count 2))
+                (should-not (overlay-buffer preview))
+                (should
+                 (cl-find-if
+                  (lambda (overlay)
+                    (overlay-get overlay 'ai-code-session-image-preview))
+                  (overlays-in (point-min) (point-max))))))))
       (when (file-directory-p root)
         (delete-directory root t)))))
 


### PR DESCRIPTION
## Summary

- Make Ghostel follow-output detection account for the pixel height of AI Code inline image previews.
- Preserve unchanged preview overlays across delayed linkification scans and refresh them when the backing file changes.
- Preserve follow state when a new preview changes display height, keeping the live input at the bottom without re-anchoring unchanged scans.
- Use font-relative vertical spacing by default, with fixed-pixel and disabled modes available.

## Root cause

Ghostel determines whether a window follows live output by counting buffer lines. AI Code previews are rendered through overlay after-string content, so their displayed height is absent from that count. A viewport containing a large image could therefore be classified as anchored even when its pixel content overflowed the window.

There is also a transition when linkification first inserts a preview: the window can be following output before insertion, then become taller afterward without receiving a new bottom anchor. In that state the image remains visible but pushes the live input below the viewport. IME input makes both problems especially disruptive.

Delayed linkification scans previously deleted and recreated valid preview overlays, briefly changing display geometry and sometimes leaving the image hidden.

## Changes

- Correct Ghostel anchor classification only for AI Code Ghostel windows containing image preview overlays.
- Measure displayed content up to the window body plus the existing one-line tolerance.
- Capture follow state before any generic or Ghostel-specific linkifier inserts a preview.
- Anchor a previously following window once after a new preview changes display height.
- Do not anchor unchanged rescans or windows whose user is reading scrollback.
- Preserve unchanged previews, but refresh them when the file signature or effective margin changes.
- Default the vertical margin to 0.3 times the current session window line height.
- Allow a non-negative integer for fixed pixels; zero disables the margin.
- Keep pixel measurement failure paths safe by preserving the native Ghostel decision.

## Scope

Other Ghostel buffers and terminal backends retain their existing behavior. No changes from unrelated worktrees are included.

## Configuration

- auto: 0.3 times the current line height
- integer: fixed pixel margin
- 0: no margin

## Testing

- [x] Ghostel backend tests: 49/49
- [x] Session-link tests: 66/66
- [x] Full test suite: 1006 passed, 13 skipped, 0 unexpected
- [x] Byte compilation with emacs -Q
- [x] Checkdoc on touched files
- [x] Manual Ghostel verification with a top image attachment and macOS IME input
- [x] Manual verification that completed output with an image keeps the live input at the bottom