### PR TITLE
Clarify user-owned decisions in grilling harness

### DIFF
--- a/prompt/grilling.v1.md
+++ b/prompt/grilling.v1.md
@@ -4,6 +4,8 @@ Ask exactly one question at a time and wait for the user's response. For every q
 
 Before asking the user for factual information, inspect the available repository, files, tests, documentation, tools, and environment. Ask the user only about decisions, preferences, priorities, trade-offs, scope, constraints, and acceptance criteria that cannot be determined from the environment.
 
+The decisions belong to the user. Provide a recommendation, but do not silently adopt it or move past the decision until the user answers.
+
 Follow important branches of the decision tree and resolve dependent decisions in a sensible order. Avoid questions that would not materially change the result.
 
 Do not modify code, files, configuration, or external state until the user explicitly confirms that shared understanding has been reached.


### PR DESCRIPTION
## Summary

- clarify that recommendations in the grilling harness do not replace user decisions
- require the agent to wait for the user's answer before adopting or moving past a decision

## Why

The original grilling workflow explicitly separates discoverable facts from user-owned decisions. The existing harness already asks the agent to provide recommendations, but it did not state strongly enough that those recommendations must not be silently accepted on the user's behalf.

## User impact

Grill-me sessions should now stay aligned with the user's actual choices while still offering a recommended answer for each question.

## Validation

- prompt-only change
- no code behavior changed
