### PR TITLE
Add native insertion into AI sessions

### DIFF
--- a/README.org
+++ b/README.org
@@ -148,6 +148,27 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 - `projectile`: For project root initialization.
 - `helm-gtags`: For tags creation and symbol navigation fallback from clickable session symbols.
 
+*** Optional Screenshot Capture
+
+The Insert submenu's =Screenshot= commands rely on an external program to
+capture an image.  Install or configure the option for your platform:
+
+| Platform        | Screenshot capture                | Setup                                      |
+|-----------------+-----------------------------------+--------------------------------------------|
+| macOS           | =screencapture=                   | Preinstalled; used by default with =-i=.   |
+| Linux (Wayland) | =grim=                            | Install =grim=; selected when =WAYLAND_DISPLAY= is set. |
+| Linux (X11)     | =import= from ImageMagick         | Install the ImageMagick package.           |
+| Windows         | No compatible tool is bundled     | Configure a capture program as shown below. |
+
+Customize =ai-code-send-screenshot-command= when the default is unavailable.
+The command is a list containing the program followed by its arguments; AI Code
+appends the destination PNG path when invoking it:
+
+#+begin_src emacs-lisp
+(setopt ai-code-send-screenshot-command
+        '("my-screenshot-program" "--interactive"))
+#+end_src
+
 ** Key Features
 
 - *Transient-Driven Hub (`C-c a`)*: One keystroke opens a contextual transient menu that groups every capability (CLI control, code actions, agile workflows, utilities) so you never need to memorize scattered keybindings.
@@ -163,12 +184,16 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 [[./clickable_link_ai_session.png]]
 - *Context-Aware Code Actions*: The menu exposes dedicated entries for changing code (`c`), implementing TODOs (`i`), asking questions (`q`), explaining code (`x`), sending free-form commands (`<SPC>`), and refreshing AI context (`@`). Each command automatically captures the surrounding function, region, or clipboard contents (via `C-u`) to keep prompts precise.
   - When a visible AI session buffer already exists, prompts can be routed to that session directly instead of opening a new one.
+- *Insert into AI Sessions*: Open the configurable `ai-code-menu` prefix (`C-c a` in the configuration examples), then press `I` to open the Insert submenu for files, Dired selections, regions, diagnostics-aware DWIM, screenshots, and clipboard images. The `I` entry always remains available. If no session is running, pressing it reports that state; if only sessions for other projects are running, it opens the submenu with just the `to...` entries for choosing one explicitly. An editor viewport associated with the destination session receives the insertion when present; otherwise AI Code inserts into that session's TUI input without submitting it. Screenshot capture may require the [[*Optional Screenshot Capture][platform-specific utility described above]].
+  - Inserted TUI content is always preceded and followed by two newline characters.[fn:insert-tui-spacing] In a viewport, AI Code omits the leading two newlines when the viewport is empty, keeps them when it already contains content, and always appends two newlines. Viewport attachments follow the same spacing rule.
 - *Agile Development Workflows*: Use the refactoring navigator (`r`), the guided TDD cycle (`t`), and the pull/review diff helper (`v`) to keep AI-assisted work aligned with agile best practices. Prompt authoring is first-class through quick access to the prompt file (`p`), build/test helper (`b`), and AI-assisted shell/file execution (`!`). In prompt files, send the current block with `C-c C-c`.
 - *Productivity & Debugging Utilities*: Initialize project navigation assets (`.`), investigate exceptions (`e`), debug Emacs runtime issues (`d`), auto-fix Flycheck issues in scope (`f`), copy or open file paths formatted for prompts (`k`, `o`), generate MCP inspector commands (`m`), capture session notes straight into Org (`n`), search notes with AI (`/`), dictate prompts with speech-to-text (`:`), and toggle desktop notifications (`N`) to get alerted when AI responses are ready in background sessions.
 - *Architecture Document Generation*: Derive practical architecture documents for the current repository with `C-c a A` (`ai-code-derive-architecture-document`). The command can generate architecture guardrails, a C4 PlantUML overview, a lightweight DDD context, or a test context document under `.ai.code.files/architecture/` so future AI coding sessions can reuse module boundaries, dependency rules, runtime flows, and validation expectations. See [[./docs/architecture/c4-overview.org][the C4 architecture overview for this repository]] for an example C4 diagram guide.
 - *Seamless Prompt Management*: Open the prompt file via `ai-code-open-prompt-file` (stored under `.ai.code.files/.ai.code.prompt.org` by default), send regions with `ai-code-prompt-send-block`, and reuse prompt snippets via `yasnippet` to keep conversations organized.
 - *Interactive Chat & Context Tools*: Dedicated buffers hold long-running chats, automatically enriched with file paths, diffs, and history from Magit or Git commands for richer AI responses.
 - *AI-Assisted Bash Commands*: From Dired, shell, eshell, or vterm, run `C-c a !` and type natural-language commands prefixed with `:` (e.g., `:count lines of python code recursively`); the tool generates the shell command for review and executes it in a compile buffer.
+
+[fn:insert-tui-spacing] Managed TUI sessions expose rendered terminal contents, not a backend-independent logical input value. AI Code therefore cannot reliably determine whether a TUI input is empty and conservatively keeps the leading separator.
 
 *** Typical Workflows Example
 

--- a/ai-code-autoloads.el
+++ b/ai-code-autoloads.el
@@ -64,9 +64,60 @@ ARG is the prefix argument.
 (autoload 'ai-code-cli-switch-to-buffer-or-hide "ai-code" "\
 Hide the current buffer when its name both begins and ends with '*'.
 Otherwise switch to AI CLI buffer." t)
+(autoload 'ai-code-insert-menu "ai-code" "\
+Insert files and editor selections into an AI Code session or viewport." t)
 (autoload 'ai-code-menu "ai-code" "\
 Show the AI Code transient menu selected by `ai-code-menu-layout`." t)
 (register-definition-prefixes "ai-code" '("ai-code-"))
+
+
+;;; Generated autoloads from ai-code-send.el
+
+(defvar ai-code-send-screenshot-command
+  (cond
+   ((eq system-type 'darwin) '("/usr/sbin/screencapture" "-i"))
+   ((and (eq system-type 'gnu/linux) (getenv "WAYLAND_DISPLAY")) '("grim"))
+   ((eq system-type 'windows-nt) nil)
+   (t '("import")))
+  "Command used by `ai-code-send-screenshot' to capture an image.
+macOS uses the preinstalled screencapture program.  GNU/Linux uses grim under
+Wayland and ImageMagick's import program under X11.  Other Unix-like systems
+use import by default.  Windows does not bundle a compatible capture program,
+so customize this option there.
+
+The destination file name is appended to this list.")
+(custom-autoload 'ai-code-send-screenshot-command "ai-code-send" t)
+(autoload 'ai-code-send-file "ai-code-send" "Insert a file or selected Dired files into an ai-code session.
+When PROMPT-FOR-FILE is non-nil, always prompt for a file.
+When PICK-SESSION is non-nil, choose the destination session.
+
+(fn &optional PROMPT-FOR-FILE PICK-SESSION)" t)
+(autoload 'ai-code-send-file-to "ai-code-send" "Insert a file into a selected ai-code session.
+With PROMPT-FOR-FILE, always prompt for a file.
+
+(fn &optional PROMPT-FOR-FILE)" t)
+(autoload 'ai-code-send-current-file "ai-code-send" "Insert the current file into an ai-code session." t)
+(autoload 'ai-code-send-other-file "ai-code-send" "Prompt for and insert another file into an ai-code session." t)
+(autoload 'ai-code-send-screenshot "ai-code-send" "Capture and insert a screenshot into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session.
+
+(fn &optional PICK-SESSION)" t)
+(autoload 'ai-code-send-screenshot-to "ai-code-send" "Capture and insert a screenshot into a selected ai-code session." t)
+(autoload 'ai-code-send-clipboard-image "ai-code-send" "Save and insert the clipboard image into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session.
+
+(fn &optional PICK-SESSION)" t)
+(autoload 'ai-code-send-clipboard-image-to "ai-code-send" "Save and insert the clipboard image into a selected ai-code session." t)
+(autoload 'ai-code-send-region "ai-code-send" "Insert the active region into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session.
+
+(fn &optional PICK-SESSION)" t)
+(autoload 'ai-code-send-region-to "ai-code-send" "Insert the active region into a selected ai-code session." t)
+(autoload 'ai-code-send-dwim "ai-code-send" "Insert the most relevant editor input into an ai-code session.
+Prefer Dired files, the active region, diagnostics at point, then the current
+line." t)
+(autoload 'ai-code-send-dwim-to "ai-code-send" "Insert relevant editor input into a selected ai-code session." t)
+(register-definition-prefixes "ai-code-send" '("ai-code-send-"))
 
 
 ;;; Generated autoloads from ai-code-agent-shell.el

--- a/ai-code-backends-infra-eat.el
+++ b/ai-code-backends-infra-eat.el
@@ -28,6 +28,10 @@ a more stable viewing experience when working with multiple windows."
                   "ai-code-backends-infra" (output))
 (declare-function ai-code-backends-infra--set-session-directory
                   "ai-code-backends-infra" (buffer directory))
+(declare-function ai-code-backends-infra--send-string-with-paste
+                  "ai-code-backends-infra"
+                  (string paste send-function paste-function paste-active-p
+                          backend-name))
 (declare-function ai-code-backends-infra--strip-alternate-screen-sequences
                   "ai-code-backends-infra" (str))
 (declare-function ai-code-backends-infra--sync-terminal-cursor
@@ -36,6 +40,7 @@ a more stable viewing experience when working with multiple windows."
                   "ai-code-editor-viewport-transport" (process output))
 (declare-function eat-term-send-string "eat" (&rest args))
 (declare-function eat-term-send-string-as-yank "eat" (&rest args))
+(declare-function eat--t-term-bracketed-yank "eat" (terminal))
 (declare-function eat--adjust-process-window-size "eat" (&rest args))
 (declare-function eat-mode "eat" ())
 (declare-function eat-exec "eat" (&rest args))
@@ -68,9 +73,16 @@ a more stable viewing experience when working with multiple windows."
   "Send STRING to the current Eat terminal.
 If PASTE is non-nil, send it as a pasted string."
   (when (bound-and-true-p eat-terminal)
-    (if (and paste (fboundp 'eat-term-send-string-as-yank))
-        (eat-term-send-string-as-yank eat-terminal string)
-      (eat-term-send-string eat-terminal string))))
+    (ai-code-backends-infra--send-string-with-paste
+     string paste
+     (lambda (text) (eat-term-send-string eat-terminal text))
+     (and (fboundp 'eat-term-send-string-as-yank)
+          (lambda (text)
+            (eat-term-send-string-as-yank eat-terminal (list text))))
+     (lambda ()
+       (and (fboundp 'eat--t-term-bracketed-yank)
+            (eat--t-term-bracketed-yank eat-terminal)))
+     "Eat")))
 
 (defun ai-code-backends-infra-eat-send-escape ()
   "Send escape to the current Eat terminal."

--- a/ai-code-backends-infra-ghostel.el
+++ b/ai-code-backends-infra-ghostel.el
@@ -39,6 +39,10 @@ enabled by default because it widens the terminal's local resource access."
                   "ai-code-backends-infra" (output))
 (declare-function ai-code-backends-infra--set-session-directory
                   "ai-code-backends-infra" (buffer directory))
+(declare-function ai-code-backends-infra--send-string-with-paste
+                  "ai-code-backends-infra"
+                  (string paste send-function paste-function paste-active-p
+                          backend-name))
 (declare-function ai-code-backends-infra--sync-terminal-cursor
                   "ai-code-backends-infra" ())
 (declare-function ai-code-editor-viewport-filter-output
@@ -49,6 +53,7 @@ enabled by default because it widens the terminal's local resource access."
 (declare-function ghostel-send-key "ghostel" (key-name &optional mods))
 (declare-function ghostel-send-string "ghostel" (string))
 (declare-function ghostel-paste-string "ghostel" (string))
+(declare-function ghostel--mode-enabled "ghostel-module" (term mode))
 (declare-function ghostel-cursor-point "ghostel" ())
 (declare-function ghostel--schedule-link-detection
                   "ghostel" (&optional begin end))
@@ -69,6 +74,7 @@ enabled by default because it widens the terminal's local resource access."
 (defvar ghostel-inhibit-redraw-functions)
 (defvar ghostel-kitty-graphics-mediums)
 (defvar ghostel-link-map)
+(defvar ghostel--term)
 (defvar ghostel-use-native-pty)
 (eval-when-compile
   (defvar ghostel-command-finish-functions)
@@ -906,9 +912,14 @@ ORIG-FILTER is Ghostel's original process filter."
 (defun ai-code-backends-infra-ghostel-send-string (string &optional paste)
   "Send STRING to the current Ghostel process.
 If PASTE is non-nil, send it as a pasted string."
-  (if (and paste (fboundp 'ghostel-paste-string))
-      (ghostel-paste-string string)
-    (ghostel-send-string string)))
+  (ai-code-backends-infra--send-string-with-paste
+   string paste #'ghostel-send-string
+   (and (fboundp 'ghostel-paste-string) #'ghostel-paste-string)
+   (lambda ()
+     (and (fboundp 'ghostel--mode-enabled)
+          (bound-and-true-p ghostel--term)
+          (ghostel--mode-enabled ghostel--term 2004)))
+   "Ghostel"))
 
 (defun ai-code-backends-infra-ghostel-send-escape ()
   "Send escape to the current Ghostel process."

--- a/ai-code-backends-infra-vterm.el
+++ b/ai-code-backends-infra-vterm.el
@@ -33,6 +33,10 @@
                   "ai-code-backends-infra" (buffer))
 (declare-function ai-code-backends-infra--set-session-directory
                   "ai-code-backends-infra" (buffer directory))
+(declare-function ai-code-backends-infra--send-string-with-paste
+                  "ai-code-backends-infra"
+                  (string paste send-function paste-function paste-active-p
+                          backend-name))
 (declare-function ai-code-backends-infra--strip-alternate-screen-sequences
                   "ai-code-backends-infra" (str))
 (declare-function ai-code-backends-infra--sync-terminal-cursor
@@ -42,6 +46,7 @@
 (declare-function ai-code-notifications-response-ready
                   "ai-code-notifications" (&optional backend-name))
 (declare-function vterm "vterm" (&optional buffer-name))
+(declare-function vterm--update "vterm-module")
 (declare-function vterm-send-string "vterm" (&rest args))
 (declare-function vterm-send-escape "vterm" ())
 (declare-function vterm-send-return "vterm" ())
@@ -50,6 +55,7 @@
 
 (defvar ai-code-backends-infra-strip-alternate-screen)
 (defvar ai-code-backends-infra--session-terminal-backend)
+(defvar vterm--term)
 (defvar vterm-copy-mode)
 (defvar vterm-copy-mode-hook)
 (defvar vterm-environment)
@@ -94,12 +100,28 @@ set by the subprocess, and `injected' for AI Code's ANSI gray foreground.")
   (add-hook 'vterm-copy-mode-hook
             #'ai-code-backends-infra--sync-terminal-cursor nil t))
 
+(defun ai-code-backends-infra-vterm--bracketed-paste-active-p ()
+  "Return non-nil when bracketed paste mode is active in vterm."
+  (when (and (bound-and-true-p vterm--term)
+             (fboundp 'vterm--update)
+             (fboundp 'vterm--flush-output))
+    (condition-case nil
+        (let (encoded)
+          (cl-letf (((symbol-function 'vterm--flush-output)
+                     (lambda (output)
+                       (setq encoded (concat encoded output)))))
+            (vterm--update vterm--term "<start_paste>"))
+          (and encoded (string-match-p "\e\\[200~\\'" encoded)))
+      (error nil))))
+
 (defun ai-code-backends-infra-vterm-send-string (string &optional paste)
   "Send STRING to the current vterm buffer.
 If PASTE is non-nil, send it as a pasted string."
-  (if paste
-      (vterm-send-string string paste)
-    (vterm-send-string string)))
+  (ai-code-backends-infra--send-string-with-paste
+   string paste #'vterm-send-string
+   (lambda (text) (vterm-send-string text t))
+   #'ai-code-backends-infra-vterm--bracketed-paste-active-p
+   "vterm"))
 
 (defun ai-code-backends-infra-vterm-send-escape ()
   "Send escape to the current vterm buffer."

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -16,6 +16,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'seq)
 (require 'subr-x)
 (require 'ai-code-editor-viewport)
 (require 'ai-code-session)
@@ -747,6 +748,100 @@ use the branch name."
         (puthash key session-buffer ai-code-backends-infra--file-session-map)
       (remhash key ai-code-backends-infra--file-session-map))))
 
+(defun ai-code-backends-infra--live-terminal-session-p (buffer)
+  "Return non-nil when BUFFER is a managed terminal with a live process."
+  (and (buffer-live-p buffer)
+       (buffer-local-value
+        'ai-code-backends-infra--session-terminal-backend buffer)
+       (when-let* ((process (get-buffer-process buffer)))
+         (process-live-p process))))
+
+(defun ai-code-backends-infra--preferred-session (sessions)
+  "Return an unambiguous session from SESSIONS, or nil."
+  (cond
+   ((memq ai-code-backends-infra--last-accessed-buffer sessions)
+    ai-code-backends-infra--last-accessed-buffer)
+   ((length= sessions 1) (car sessions))))
+
+(defun ai-code-backends-infra--attached-sessions (source)
+  "Return live sessions explicitly attached to SOURCE's file."
+  (when-let* ((file (buffer-local-value 'buffer-file-name source))
+              (normalized-file
+               (ai-code-backends-infra--normalize-file-path file)))
+    (let (sessions)
+      (maphash
+       (lambda (key session)
+         (when (and (equal (cdr-safe key) normalized-file)
+                    (ai-code-backends-infra--live-terminal-session-p session))
+           (push session sessions)))
+       ai-code-backends-infra--file-session-map)
+      (delete-dups sessions))))
+
+(defun ai-code-backends-infra--project-sessions (source)
+  "Return live sessions belonging to SOURCE's current project."
+  (when-let* ((root
+               (with-current-buffer source
+                 (ai-code--session-project-root)))
+              (normalized-root
+               (ignore-errors
+                 (ai-code-backends-infra--normalize-session-directory root))))
+    (seq-filter
+     (lambda (session)
+       (when-let* ((directory
+                    (ai-code-backends-infra-session-directory session)))
+         (string= directory normalized-root)))
+     (ai-code-backends-infra-session-buffers))))
+
+(defun ai-code-backends-infra-current-buffer-session (&optional buffer)
+  "Return the unambiguous live TUI session associated with BUFFER.
+BUFFER defaults to the current buffer.  Return BUFFER itself when it is a
+managed terminal session.  Prefer a session explicitly attached to BUFFER's
+file.  Otherwise use the sole session in BUFFER's project, or the most recently
+accessed project session.  Return nil instead of choosing arbitrarily."
+  (let ((source (or buffer (current-buffer))))
+    (when (buffer-live-p source)
+      (if (ai-code-backends-infra--live-terminal-session-p source)
+          source
+        (let ((attached (ai-code-backends-infra--attached-sessions source)))
+          (or (ai-code-backends-infra--preferred-session attached)
+              (unless attached
+                (ai-code-backends-infra--preferred-session
+                 (ai-code-backends-infra--project-sessions source)))))))))
+
+(defun ai-code-backends-infra-session-buffers ()
+  "Return all live managed terminal session buffers."
+  (cl-remove-if-not #'ai-code-backends-infra--live-terminal-session-p
+                    (buffer-list)))
+
+(defun ai-code-backends-infra--send-string-with-paste
+    (string paste send-function paste-function paste-active-p backend-name)
+  "Send STRING safely through a terminal backend.
+Use SEND-FUNCTION for ordinary input.  When PASTE is non-nil, use
+PASTE-FUNCTION only while PASTE-ACTIVE-P returns non-nil, or report that
+BACKEND-NAME cannot paste safely."
+  (cond
+   ((not paste) (funcall send-function string))
+   ((and paste-function paste-active-p (funcall paste-active-p))
+    (funcall paste-function string))
+   (t
+    (user-error
+     "This %s session cannot paste multiline input without submitting"
+     backend-name))))
+
+(defun ai-code-backends-infra-insert-string (string buffer)
+  "Insert STRING into TUI session BUFFER without submitting it.
+Multiline input uses the terminal backend's paste operation so embedded
+newlines are not interpreted as Return keys."
+  (unless (ai-code-backends-infra--live-terminal-session-p buffer)
+    (user-error "AI session is no longer available"))
+  (with-current-buffer buffer
+    (ai-code-backends-infra--terminal-send-string
+     string (and (string-match-p "\n" string) t)))
+  (setq ai-code-backends-infra--last-accessed-buffer buffer)
+  (if-let* ((window (get-buffer-window buffer)))
+      (select-window window)
+    (ai-code-backends-infra--display-buffer-in-side-window buffer)))
+
 (defun ai-code-backends-infra--attached-file-session (prefix source-buffer working-dir)
   "Return attached session state for PREFIX and SOURCE-BUFFER.
 WORKING-DIR is the directory used to validate compatible sessions.
@@ -822,7 +917,7 @@ SOURCE-BUFFER unless FORCE-PROMPT is non-nil."
       (setq-local ai-code-backends-infra--session-directory
                   (ai-code-backends-infra--normalize-session-directory directory)))))
 
-(defun ai-code-backends-infra--buffer-session-directory (buffer)
+(defun ai-code-backends-infra-session-directory (buffer)
   "Return BUFFER session directory, using legacy `default-directory' as fallback."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
@@ -917,7 +1012,7 @@ Return a cons of (base-name . instance-name) or nil."
        (when-let* ((parsed (ai-code-backends-infra--parse-session-buffer-name
                             (buffer-name buf)
                             prefix)))
-         (if-let* ((buffer-directory (ai-code-backends-infra--buffer-session-directory buf)))
+         (if-let* ((buffer-directory (ai-code-backends-infra-session-directory buf)))
              (string= (ai-code-backends-infra--normalize-session-directory buffer-directory)
                       target-directory)
            (string= (car parsed) base))))
@@ -942,7 +1037,7 @@ Return a cons of (base-name . instance-name) or nil."
   "Return non-nil when BUFFER is live and still belongs to DIRECTORY."
   (and (buffer-live-p buffer)
        (when-let* ((buffer-directory
-                    (ai-code-backends-infra--buffer-session-directory buffer)))
+                    (ai-code-backends-infra-session-directory buffer)))
          (string=
           (ai-code-backends-infra--normalize-session-directory buffer-directory)
           (ai-code-backends-infra--normalize-session-directory directory)))))

--- a/ai-code-editor-viewport-attachments.el
+++ b/ai-code-editor-viewport-attachments.el
@@ -17,8 +17,10 @@
 (require 'seq)
 (require 'subr-x)
 
+(declare-function ai-code-editor-viewport-source-directory
+                  "ai-code-editor-viewport" (&optional viewport))
+
 (defvar ai-code-editor-viewport-mode)
-(defvar ai-code-editor-viewport--source-directory)
 
 (defcustom ai-code-editor-viewport-image-preview-max-width 480
   "Maximum width in pixels for an image inserted into a viewport."
@@ -33,7 +35,7 @@
 (defcustom ai-code-editor-viewport-attachment-directory
   ".ai.code.files/attachments"
   "Directory where clipboard images pasted into a viewport are saved.
-Relative values are resolved from the CLI session's project root."
+Relative values are resolved from the CLI session's working directory."
   :type 'directory
   :group 'ai-code)
 
@@ -243,22 +245,21 @@ to the path substituted for %s in ARGS, or `stdout' when it emits PNG data."
           available))
        ai-code-editor-viewport--clipboard-image-targets))))
 
-(defun ai-code-editor-viewport--project-root ()
-  "Return the project root used to shorten viewport file references."
-  (let ((directory (file-name-as-directory
-                    (expand-file-name
-                     (or ai-code-editor-viewport--source-directory
-                         default-directory)))))
-    (or (locate-dominating-file directory ".git") directory)))
+(defun ai-code-editor-viewport--session-directory ()
+  "Return the CLI session directory used for viewport file references."
+  (file-name-as-directory
+   (expand-file-name
+    (or (ai-code-editor-viewport-source-directory)
+        default-directory))))
 
-(defun ai-code-editor-viewport--attachment-directory ()
-  "Return the directory used to persist pasted viewport attachments."
+(defun ai-code-editor-viewport-ensure-attachment-directory ()
+  "Return the attachment directory, creating it when needed."
   (let ((directory
          (if (file-name-absolute-p
               ai-code-editor-viewport-attachment-directory)
-             ai-code-editor-viewport-attachment-directory
+           ai-code-editor-viewport-attachment-directory
            (expand-file-name ai-code-editor-viewport-attachment-directory
-                             (ai-code-editor-viewport--project-root)))))
+                             (ai-code-editor-viewport--session-directory)))))
     (make-directory directory t)
     (file-name-as-directory directory)))
 
@@ -276,7 +277,8 @@ Return the attachment file, or nil when no supported image target is readable."
     (let ((file
            (make-temp-file
             (expand-file-name
-             "clipboard-" (ai-code-editor-viewport--attachment-directory))
+             "clipboard-"
+             (ai-code-editor-viewport-ensure-attachment-directory))
             nil extension))
           completed)
       (unwind-protect
@@ -346,7 +348,7 @@ Return the attachment file, or nil when no supported image target is readable."
                   (make-temp-file
                    (expand-file-name
                     "clipboard-"
-                    (ai-code-editor-viewport--attachment-directory))
+                    (ai-code-editor-viewport-ensure-attachment-directory))
                    nil ".png"))
             (rename-file staging-file attachment-file t)
             (setq completed t))
@@ -362,7 +364,7 @@ Return the attachment file, or nil when no supported image target is readable."
         (when (and attachment-file (file-exists-p attachment-file))
           (delete-file attachment-file))))))
 
-(defun ai-code-editor-viewport--save-clipboard-image ()
+(defun ai-code-editor-viewport-save-clipboard-image ()
   "Save a clipboard image and return its attachment file.
 Prefer Emacs's cross-platform selection API, then try configured external
 handlers for display servers that do not expose raw image selections."
@@ -372,17 +374,18 @@ handlers for display servers that do not expose raw image selections."
 (defun ai-code-editor-viewport--try-save-clipboard-image ()
   "Save and return a clipboard image, or nil when none can be extracted."
   (condition-case nil
-      (ai-code-editor-viewport--save-clipboard-image)
+      (ai-code-editor-viewport-save-clipboard-image)
     (user-error nil)))
 
 (defun ai-code-editor-viewport--file-reference (file)
   "Return the prompt reference to FILE for the current viewport."
   (let* ((absolute-file (expand-file-name file))
-         (project-root (ai-code-editor-viewport--project-root)))
+         (session-directory
+          (ai-code-editor-viewport--session-directory)))
     (concat "@"
-            (if (and project-root
-                     (file-in-directory-p absolute-file project-root))
-                (file-relative-name absolute-file project-root)
+            (if (and session-directory
+                     (file-in-directory-p absolute-file session-directory))
+                (file-relative-name absolute-file session-directory)
               absolute-file))))
 
 (defun ai-code-editor-viewport--preview-image (file)
@@ -491,7 +494,7 @@ modification hook."
               (insert " "))))
         (buffer-substring-no-properties (point-min) (point-max))))))
 
-(defun ai-code-editor-viewport--insert-files (files)
+(defun ai-code-editor-viewport-insert-files (files)
   "Insert FILES as readable references in the current editor viewport."
   (unless ai-code-editor-viewport-mode
     (user-error "Not in an AI CLI editor viewport"))
@@ -507,7 +510,7 @@ modification hook."
 (defun ai-code-editor-viewport-handle-drop (uri action)
   "Insert the local file represented by dropped URI and return ACTION."
   (when-let* ((file (dnd-get-local-file-name uri t)))
-    (ai-code-editor-viewport--insert-files (list file))
+    (ai-code-editor-viewport-insert-files (list file))
     (or action 'copy)))
 
 (defun ai-code-editor-viewport-handle-drops (uris action)
@@ -519,7 +522,7 @@ modification hook."
                   (dnd-get-local-file-name uri t))
                 uris))))
     (when files
-      (ai-code-editor-viewport--insert-files files)
+      (ai-code-editor-viewport-insert-files files)
       (or action 'copy))))
 
 (put 'ai-code-editor-viewport-handle-drops 'dnd-multiple-handler t)
@@ -532,16 +535,16 @@ modification hook."
   (unless ai-code-editor-viewport-mode
     (user-error "Not in an AI CLI editor viewport"))
   (if-let* ((files (ai-code-editor-viewport--clipboard-files)))
-      (ai-code-editor-viewport--insert-files files)
+      (ai-code-editor-viewport-insert-files files)
     (pcase (ai-code-editor-viewport--clipboard-content-kind)
       ('image
-       (ai-code-editor-viewport--insert-files
-        (list (ai-code-editor-viewport--save-clipboard-image))))
+       (ai-code-editor-viewport-insert-files
+        (list (ai-code-editor-viewport-save-clipboard-image))))
       ('text (yank arg))
       (_
        (if-let* ((image-file
                   (ai-code-editor-viewport--try-save-clipboard-image)))
-           (ai-code-editor-viewport--insert-files (list image-file))
+           (ai-code-editor-viewport-insert-files (list image-file))
          (yank arg))))))
 
 

--- a/ai-code-editor-viewport.el
+++ b/ai-code-editor-viewport.el
@@ -66,11 +66,41 @@ the input view before AI Code sends the return key."
 (defvar-local ai-code-editor-viewport--source-directory nil
   "Working directory of the CLI session associated with this viewport.")
 
+(defvar-local ai-code-editor-viewport--source-buffer nil
+  "CLI session buffer associated with this viewport.")
+
 (defvar-local ai-code-editor-viewport--submit-function nil
   "Function that submits restored TUI input for this source buffer.")
 
 (defvar-local ai-code-editor-viewport-source-cursor-function nil
   "Function returning the live terminal cursor position for this source.")
+
+(defun ai-code-editor-viewport-source-buffer (&optional viewport)
+  "Return VIEWPORT's associated live CLI session buffer.
+VIEWPORT defaults to the current buffer."
+  (let ((buffer (or viewport (current-buffer))))
+    (when (buffer-live-p buffer)
+      (let ((source
+             (buffer-local-value
+              'ai-code-editor-viewport--source-buffer buffer)))
+        (and (buffer-live-p source) source)))))
+
+(defun ai-code-editor-viewport-source-directory (&optional viewport)
+  "Return VIEWPORT's associated CLI session directory.
+VIEWPORT defaults to the current buffer."
+  (let ((buffer (or viewport (current-buffer))))
+    (when (buffer-live-p buffer)
+      (buffer-local-value
+       'ai-code-editor-viewport--source-directory buffer))))
+
+(defun ai-code-editor-viewport-for-session (session)
+  "Return the editor viewport associated with live buffer SESSION."
+  (when (buffer-live-p session)
+    (seq-find
+     (lambda (buffer)
+       (and (buffer-local-value 'ai-code-editor-viewport-mode buffer)
+            (eq (ai-code-editor-viewport-source-buffer buffer) session)))
+     (buffer-list))))
 
 ;;;; Viewport mode
 
@@ -525,7 +555,8 @@ Return a plist that records the window and its previous buffer."
                   (buffer-auto-save-file-name nil))
               (clone-buffer name nil)))))
     (with-current-buffer viewport-buffer
-      (setq ai-code-editor-viewport--source-directory
+      (setq ai-code-editor-viewport--source-buffer source-buffer
+            ai-code-editor-viewport--source-directory
             (if (buffer-live-p source-buffer)
                 (buffer-local-value 'default-directory source-buffer)
               default-directory))

--- a/ai-code-send.el
+++ b/ai-code-send.el
@@ -1,0 +1,548 @@
+;;; ai-code-send.el --- Insert files and selections into ai-code sessions -*- lexical-binding: t; -*-
+
+;; Author: realazy
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Commands for inserting files, images, regions, diagnostics, and current lines
+;; into a session managed by ai-code.  An open viewport editor takes precedence;
+;; otherwise the selection is inserted into the TUI session attached to the
+;; current buffer without submitting it.
+
+;;; Code:
+
+(require 'dired)
+(require 'seq)
+(require 'subr-x)
+(require 'flymake)
+(require 'ai-code-backends-infra)
+(require 'ai-code-editor-viewport-attachments)
+(require 'ai-code-editor-viewport)
+(require 'ai-code-prompt-mode)
+(require 'ai-code-utils)
+
+(defvar flycheck-mode)
+
+(declare-function ai-code--prompt-filepath-candidates "ai-code-prompt-mode" ())
+(declare-function ai-code--session-project-root "ai-code-utils" ())
+(declare-function ai-code-backends-infra-current-buffer-session
+                  "ai-code-backends-infra" (&optional buffer))
+(declare-function ai-code-backends-infra-session-buffers
+                  "ai-code-backends-infra" ())
+(declare-function ai-code-backends-infra-session-directory
+                  "ai-code-backends-infra" (buffer))
+(declare-function ai-code-backends-infra-insert-string
+                  "ai-code-backends-infra" (string buffer))
+(declare-function ai-code-editor-viewport-save-clipboard-image
+                  "ai-code-editor-viewport-attachments" ())
+(declare-function ai-code-editor-viewport-ensure-attachment-directory
+                  "ai-code-editor-viewport-attachments" ())
+(declare-function ai-code-editor-viewport-insert-files
+                  "ai-code-editor-viewport-attachments" (files))
+(declare-function ai-code-editor-viewport-source-buffer
+                  "ai-code-editor-viewport" (&optional viewport))
+(declare-function ai-code-editor-viewport-source-directory
+                  "ai-code-editor-viewport" (&optional viewport))
+(declare-function ai-code-editor-viewport-for-session
+                  "ai-code-editor-viewport" (session))
+(declare-function flycheck-error-message "flycheck" (error))
+(declare-function flycheck-overlay-errors-at "flycheck" (position))
+
+(defcustom ai-code-send-screenshot-command
+  (cond
+   ((eq system-type 'darwin) '("/usr/sbin/screencapture" "-i"))
+   ((and (eq system-type 'gnu/linux) (getenv "WAYLAND_DISPLAY")) '("grim"))
+   ((eq system-type 'windows-nt) nil)
+   (t '("import")))
+  "Command used by `ai-code-send-screenshot' to capture an image.
+macOS uses the preinstalled screencapture program.  GNU/Linux uses grim under
+Wayland and ImageMagick's import program under X11.  Other Unix-like systems
+use import by default.  Windows does not bundle a compatible capture program,
+so customize this option there.
+
+The destination file name is appended to this list."
+  :type '(repeat string)
+  :group 'ai-code)
+
+(defun ai-code-send--file-reference (file &optional root)
+  "Return an @-prefixed reference for FILE relative to ROOT.
+When ROOT is nil, use the source buffer's project root."
+  (let* ((absolute (expand-file-name file))
+         (root (or root (ai-code--session-project-root))))
+    (concat "@"
+            (if (file-in-directory-p absolute root)
+                (file-relative-name absolute root)
+              absolute))))
+
+(defun ai-code-send--candidate-file (candidate)
+  "Resolve completion CANDIDATE to a local file path."
+  (let ((root (ai-code--session-project-root)))
+    (expand-file-name
+     (if (string-prefix-p "@" candidate)
+         (substring candidate 1)
+       candidate)
+     root)))
+
+(defun ai-code-send--read-file ()
+  "Prompt for a project file and return its local path."
+  (let ((candidates (ai-code--prompt-filepath-candidates)))
+    (if candidates
+        (ai-code-send--candidate-file
+         (completing-read "Insert file: " candidates nil t))
+      (read-file-name "Insert file: "
+                      (ai-code--session-project-root)
+                      nil t))))
+
+(defun ai-code-send--buffer-files ()
+  "Return files selected by the current buffer, if any."
+  (cond
+   ((derived-mode-p 'dired-mode)
+    (let ((files (or (ai-code-send--dired-region-files)
+                     (dired-get-marked-files nil nil nil nil nil))))
+      (and files (seq-filter #'file-exists-p files))))
+   ((buffer-file-name) (list (buffer-file-name)))
+   (t nil)))
+
+(defun ai-code-send--dired-region-files ()
+  "Return files represented by the active Dired region, if any."
+  (when (use-region-p)
+    (let ((start (region-beginning))
+          (end (region-end))
+          files)
+      (save-excursion
+        (goto-char start)
+        (while (< (point) end)
+          (when-let* ((file (dired-get-filename nil t)))
+            (push file files))
+          (forward-line 1)))
+      (delete-dups (nreverse files)))))
+
+(defun ai-code-send--files (&optional prompt-for-file)
+  "Return files to insert, prompting when PROMPT-FOR-FILE is non-nil."
+  (or (and (not prompt-for-file)
+           (ai-code-send--buffer-files))
+      (list (ai-code-send--read-file))))
+
+(defun ai-code-send--files-text (files &optional root)
+  "Return prompt text representing FILES relative to ROOT."
+  (mapconcat (lambda (file) (ai-code-send--file-reference file root))
+             files "\n\n"))
+
+(defun ai-code-send--language ()
+  "Return a short language name for the current buffer."
+  (let ((mode (symbol-name major-mode)))
+    (replace-regexp-in-string
+     "-mode\\'" ""
+     (replace-regexp-in-string "-ts\\'" "" mode))))
+
+(defun ai-code-send--region-available-p ()
+  "Return non-nil when the active region contains non-whitespace text."
+  (and (use-region-p)
+       (< (region-beginning) (region-end))
+       (string-match-p
+        "\\S-"
+        (buffer-substring-no-properties (region-beginning) (region-end)))))
+
+(defun ai-code-send--region-text (&optional root)
+  "Return the active region with its location relative to ROOT."
+  (unless (ai-code-send--region-available-p)
+    (user-error "No region selected"))
+  (let* ((file (buffer-file-name))
+         (start (region-beginning))
+         (end (region-end))
+         (line-start (line-number-at-pos start))
+         (line-end
+          (line-number-at-pos
+           (if (and (> end start)
+                    (save-excursion
+                      (goto-char end)
+                      (bolp)))
+               (1- end)
+             end)))
+         (content (buffer-substring-no-properties start end))
+         (location (if file
+                       (format "%s#L%d-L%d"
+                               (ai-code-send--file-reference file root)
+                               line-start line-end)
+                     (format "region L%d-L%d" line-start line-end))))
+    (format "%s\n\n```%s\n%s\n```"
+            location (ai-code-send--language) (string-trim-right content))))
+
+(defun ai-code-send--point-text (&optional root)
+  "Return the current line with its file location relative to ROOT."
+  (let* ((file (buffer-file-name))
+         (start (line-beginning-position))
+         (end (line-end-position))
+         (line (buffer-substring-no-properties start end))
+         (location (if file
+                       (format "%s#L%d"
+                               (ai-code-send--file-reference file root)
+                               (line-number-at-pos))
+                     (format "current line L%d" (line-number-at-pos)))))
+    (format "%s\n\n```%s\n%s\n```"
+            location (ai-code-send--language) line)))
+
+(defun ai-code-send--viewport-buffer (&optional session)
+  "Return the AI editor viewport associated with SESSION.
+When SESSION is nil, return the current viewport only when its source session
+is still running."
+  (if session
+      (ai-code-editor-viewport-for-session session)
+    (when (bound-and-true-p ai-code-editor-viewport-mode)
+      (let ((source (ai-code-editor-viewport-source-buffer)))
+        (and (memq source (ai-code-backends-infra-session-buffers))
+             (current-buffer))))))
+
+(defun ai-code-send--default-destination-p ()
+  "Return non-nil when this buffer has an implicit insertion destination."
+  (or (ai-code-send--viewport-buffer)
+      (ai-code-backends-infra-current-buffer-session)))
+
+(defconst ai-code-send--explicit-target-commands
+  '(ai-code-send-file-to
+    ai-code-send-region-to
+    ai-code-send-dwim-to
+    ai-code-send-screenshot-to
+    ai-code-send-clipboard-image-to)
+  "Insert commands that always ask for a destination session.")
+
+(defconst ai-code-send--region-commands
+  '(ai-code-send-region ai-code-send-region-to)
+  "Insert commands that require a non-empty region.")
+
+(defun ai-code-send--menu-child-command (child)
+  "Return the command represented by Transient CHILD."
+  (plist-get (cdr-safe child) :command))
+
+(defun ai-code-send-setup-menu-children (children)
+  "Return available Insert menu CHILDREN for the current buffer.
+Without an implicit destination, remove commands that do not ask the user to
+choose a session.  Also remove region commands when no non-empty region is
+active.  Filtering the children before Transient initializes them keeps the
+hidden keys out of its active keymap."
+  (let ((default-destination (ai-code-send--default-destination-p))
+        (region-available (ai-code-send--region-available-p)))
+    (seq-filter
+     (lambda (child)
+       (let ((command (ai-code-send--menu-child-command child)))
+         (and (or default-destination
+                  (memq command ai-code-send--explicit-target-commands))
+              (or region-available
+                  (not (memq command ai-code-send--region-commands))))))
+     children)))
+
+(defun ai-code-send--prepare-viewport-insertion ()
+  "Move to the insertion point and separate existing viewport content."
+  (goto-char (point-max))
+  (unless (zerop (buffer-size))
+    (insert "\n\n")))
+
+(defun ai-code-send--insert-into-viewport (text buffer)
+  "Append TEXT to viewport BUFFER without submitting it."
+  (with-current-buffer buffer
+    (ai-code-send--prepare-viewport-insertion)
+    (insert text "\n\n")))
+
+(defun ai-code-send--diagnostic-messages ()
+  "Return diagnostic messages at point, or nil."
+  (or
+   (when (and (bound-and-true-p flymake-mode)
+              (fboundp 'flymake-diagnostics))
+     (mapcar #'flymake-diagnostic-text
+             (flymake-diagnostics (point) (point))))
+   (when (and (bound-and-true-p flycheck-mode)
+              (fboundp 'flycheck-overlay-errors-at))
+     (mapcar #'flycheck-error-message
+             (flycheck-overlay-errors-at (point))))))
+
+(defun ai-code-send--diagnostic-text (&optional root)
+  "Return diagnostics and the current line relative to ROOT, or nil."
+  (when-let* ((messages
+               (seq-filter
+                (lambda (message)
+                  (and (stringp message) (not (string-empty-p message))))
+                (ai-code-send--diagnostic-messages))))
+    (format "Diagnostics at %s:\n%s\n\n%s"
+            (if (buffer-file-name)
+                (format "%s#L%d"
+                        (ai-code-send--file-reference
+                         (buffer-file-name) root)
+                        (line-number-at-pos))
+              (format "current line L%d" (line-number-at-pos)))
+            (mapconcat (lambda (message) (concat "- " message)) messages "\n")
+            (ai-code-send--point-text root))))
+
+(defun ai-code-send-prepare-menu ()
+  "Check session availability before displaying the Insert menu."
+  (cond
+   ((ai-code-send--default-destination-p) t)
+   ((ai-code-backends-infra-session-buffers)
+    (message "No AI session for this project")
+    t)
+   (t
+    (user-error "No AI sessions are running; start one first"))))
+
+(defun ai-code-send--default-session ()
+  "Return the session associated with the current buffer or viewport."
+  (or (and (ai-code-send--viewport-buffer)
+           (ai-code-editor-viewport-source-buffer))
+      (ai-code-backends-infra-current-buffer-session)
+      (if (ai-code-backends-infra-session-buffers)
+          (user-error "No AI session for this project")
+        (user-error "No AI sessions are running; start one first"))))
+
+(defun ai-code-send--select-session ()
+  "Prompt for any live AI session and return its buffer."
+  (let* ((buffers (ai-code-backends-infra-session-buffers))
+         (names (mapcar #'buffer-name buffers))
+         selected)
+    (unless names
+      (user-error "No AI sessions are running; start one first"))
+    (setq selected
+          (get-buffer
+           (completing-read "Insert into session: " names nil t)))
+    (unless (memq selected (ai-code-backends-infra-session-buffers))
+      (user-error "AI session is no longer available"))
+    selected))
+
+(defun ai-code-send--content-text (content root)
+  "Return CONTENT rendered for ROOT.
+CONTENT may be a string or a function accepting ROOT."
+  (if (functionp content)
+      (funcall content root)
+    content))
+
+(defun ai-code-send--tui-insertion-text (text)
+  "Return TEXT with two leading and trailing newlines for TUI insertion."
+  (concat "\n\n" text "\n\n"))
+
+(defun ai-code-send--destination-for-viewport (viewport &optional root)
+  "Return an insertion destination for VIEWPORT using ROOT when provided."
+  (list :buffer viewport
+        :viewport viewport
+        :root (or root
+                  (ai-code-editor-viewport-source-directory viewport))))
+
+(defun ai-code-send--destination-for-session (session)
+  "Return an insertion destination for SESSION."
+  (let ((viewport (ai-code-send--viewport-buffer session)))
+    (if viewport
+        (ai-code-send--destination-for-viewport
+         viewport (ai-code-backends-infra-session-directory session))
+      (list :buffer session
+            :viewport nil
+            :root (ai-code-backends-infra-session-directory session)))))
+
+(defun ai-code-send--resolve-destination (&optional pick-session)
+  "Return the implicit or explicitly selected insertion destination.
+When PICK-SESSION is non-nil, always select a live session first."
+  (if pick-session
+      (ai-code-send--destination-for-session
+       (ai-code-send--select-session))
+    (if-let* ((viewport (ai-code-send--viewport-buffer)))
+        (ai-code-send--destination-for-viewport viewport)
+      (ai-code-send--destination-for-session
+       (ai-code-send--default-session)))))
+
+(defun ai-code-send--insert-at-destination (destination content &optional files)
+  "Insert CONTENT or FILES at DESTINATION without submitting it."
+  (let ((buffer (plist-get destination :buffer))
+        (viewport (plist-get destination :viewport))
+        (root (plist-get destination :root)))
+    (if viewport
+        (if files
+            (with-current-buffer buffer
+              (ai-code-send--prepare-viewport-insertion)
+              (ai-code-editor-viewport-insert-files files)
+              (goto-char (point-max))
+              (insert "\n\n"))
+          (ai-code-send--insert-into-viewport
+           (ai-code-send--content-text content root)
+           buffer))
+      (ai-code-backends-infra-insert-string
+       (ai-code-send--tui-insertion-text
+        (ai-code-send--content-text content root))
+       buffer))))
+
+(defun ai-code-send--dispatch-files (files &optional pick-session)
+  "Insert FILES into an ai-code viewport or TUI input.
+When PICK-SESSION is non-nil, always choose the destination session first."
+  (ai-code-send--insert-at-destination
+   (ai-code-send--resolve-destination pick-session)
+   (lambda (root) (ai-code-send--files-text files root))
+   files))
+
+(defun ai-code-send--dispatch (content &optional pick-session)
+  "Insert CONTENT into an ai-code viewport or TUI input without submitting.
+CONTENT may be a string or a function accepting the destination session root.
+When PICK-SESSION is non-nil, always choose an existing session first."
+  (ai-code-send--insert-at-destination
+   (ai-code-send--resolve-destination pick-session)
+   content))
+
+(defun ai-code-send--dispatch-generated-file (producer &optional pick-session)
+  "Insert the file returned by PRODUCER, cleaning it up on failure.
+When PICK-SESSION is non-nil, select the destination before calling PRODUCER."
+  (let ((destination (ai-code-send--resolve-destination pick-session))
+        file
+        inserted)
+    (unwind-protect
+        (progn
+          (let ((buffer (plist-get destination :buffer)))
+            (unless (buffer-live-p buffer)
+              (user-error "AI session is no longer available"))
+            (setq file
+                  (with-current-buffer buffer
+                    (funcall producer))))
+          (ai-code-send--insert-at-destination
+           destination
+           (lambda (root) (ai-code-send--files-text (list file) root))
+           (list file))
+          (setq inserted t))
+      (unless inserted
+        (when (and file (file-exists-p file))
+          (delete-file file))))))
+
+(defun ai-code-send--capture-screenshot ()
+  "Capture a screenshot and return its saved file path."
+  (let* ((directory
+          (ai-code-editor-viewport-ensure-attachment-directory))
+         (command (car ai-code-send-screenshot-command)))
+    (unless (and command (executable-find command))
+      (user-error "Screenshot command is not available: %s" command))
+    (let ((local-file (make-temp-file "ai-code-screenshot-" nil ".png"))
+          file
+          completed)
+      (unwind-protect
+          (progn
+            (let ((default-directory temporary-file-directory)
+                  (arguments
+                   (append (cdr ai-code-send-screenshot-command)
+                           (list local-file))))
+              (unless (zerop
+                       (apply #'call-process command nil nil nil arguments))
+                (user-error "Screenshot command failed: %s" command)))
+            (unless (and (file-exists-p local-file)
+                         (> (file-attribute-size
+                             (file-attributes local-file))
+                            0))
+              (user-error "Screenshot command did not create an image"))
+            (setq file
+                  (make-temp-file
+                   (expand-file-name "screenshot-" directory) nil ".png"))
+            (copy-file local-file file t)
+            (setq completed t)
+            file)
+        (when (file-exists-p local-file)
+          (delete-file local-file))
+        (unless completed
+          (when (and file (file-exists-p file))
+            (delete-file file)))))))
+
+;;;###autoload
+(defun ai-code-send-file (&optional prompt-for-file pick-session)
+  "Insert a file or selected Dired files into an ai-code session.
+When PROMPT-FOR-FILE is non-nil, always prompt for a file.
+When PICK-SESSION is non-nil, choose the destination session."
+  (interactive "P")
+  (ai-code-send--dispatch-files (ai-code-send--files prompt-for-file)
+                                pick-session))
+
+;;;###autoload
+(defun ai-code-send-file-to (&optional prompt-for-file)
+  "Insert a file into a selected ai-code session.
+With PROMPT-FOR-FILE, always prompt for a file."
+  (interactive "P")
+  (ai-code-send-file prompt-for-file t))
+
+;;;###autoload
+(defun ai-code-send-current-file ()
+  "Insert the current file into an ai-code session."
+  (interactive)
+  (if-let* ((file (buffer-file-name)))
+      (ai-code-send--dispatch-files (list file))
+    (user-error "Current buffer is not visiting a file")))
+
+;;;###autoload
+(defun ai-code-send-other-file ()
+  "Prompt for and insert another file into an ai-code session."
+  (interactive)
+  (ai-code-send--dispatch-files (list (ai-code-send--read-file))))
+
+;;;###autoload
+(defun ai-code-send-screenshot (&optional pick-session)
+  "Capture and insert a screenshot into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session."
+  (interactive)
+  (ai-code-send--dispatch-generated-file
+   #'ai-code-send--capture-screenshot pick-session))
+
+;;;###autoload
+(defun ai-code-send-screenshot-to ()
+  "Capture and insert a screenshot into a selected ai-code session."
+  (interactive)
+  (ai-code-send-screenshot t))
+
+;;;###autoload
+(defun ai-code-send-clipboard-image (&optional pick-session)
+  "Save and insert the clipboard image into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session."
+  (interactive)
+  (ai-code-send--dispatch-generated-file
+   #'ai-code-editor-viewport-save-clipboard-image pick-session))
+
+;;;###autoload
+(defun ai-code-send-clipboard-image-to ()
+  "Save and insert the clipboard image into a selected ai-code session."
+  (interactive)
+  (ai-code-send-clipboard-image t))
+
+;;;###autoload
+(defun ai-code-send-region (&optional pick-session)
+  "Insert the active region into an ai-code session.
+When PICK-SESSION is non-nil, choose the destination session."
+  (interactive)
+  (ai-code-send--dispatch
+   (lambda (root) (ai-code-send--region-text root))
+   pick-session)
+  (deactivate-mark))
+
+;;;###autoload
+(defun ai-code-send-region-to ()
+  "Insert the active region into a selected ai-code session."
+  (interactive)
+  (ai-code-send-region t))
+
+(defun ai-code-send--dwim (pick-session)
+  "Insert relevant editor input, selecting a session when PICK-SESSION is set."
+  (let ((files (and (derived-mode-p 'dired-mode)
+                    (ai-code-send--buffer-files))))
+    (if files
+        (ai-code-send--dispatch-files files pick-session)
+      (ai-code-send--dispatch
+       (lambda (root)
+         (or (and (ai-code-send--region-available-p)
+                  (ai-code-send--region-text root))
+             (ai-code-send--diagnostic-text root)
+             (ai-code-send--point-text root)))
+       pick-session))
+    (when (use-region-p)
+      (deactivate-mark))))
+
+;;;###autoload
+(defun ai-code-send-dwim ()
+  "Insert the most relevant editor input into an ai-code session.
+Prefer Dired files, the active region, diagnostics at point, then the current
+line."
+  (interactive)
+  (ai-code-send--dwim nil))
+
+;;;###autoload
+(defun ai-code-send-dwim-to ()
+  "Insert relevant editor input into a selected ai-code session."
+  (interactive)
+  (ai-code-send--dwim t))
+
+(provide 'ai-code-send)
+
+;;; ai-code-send.el ends here

--- a/ai-code.el
+++ b/ai-code.el
@@ -118,6 +118,7 @@
 (require 'ai-code-input)
 (require 'ai-code-task)
 (require 'ai-code-prompt-mode)
+(require 'ai-code-send)
 (require 'ai-code-agile)
 (require 'ai-code-git)
 (require 'ai-code-github)
@@ -516,10 +517,37 @@ Shows the current backend label to the right."
   ("q" "Ask question (C-u: clipboard)" ai-code-ask-question)
   ("x" "Explain code in scope" ai-code-explain)
   ("<SPC>" "Send command (C-u: context)" ai-code-send-command)
+  ("I" "Insert to session..." ai-code-insert-menu)
   ("@" "Context (add/show/clear)" ai-code-context-action)
   ("C" "Create file or dir with AI" ai-code-create-file-or-dir)
   (":" "Speech to text input" ai-code-speech-to-text-input)
   ("w" "New worktree branch (C-u: status)" ai-code-git-worktree-action))
+
+;;;###autoload
+(transient-define-prefix ai-code-insert-menu ()
+  "Insert files and editor selections into an AI Code session or viewport."
+  ["Insert"
+   ["Files" :class transient-column
+    :setup-children ai-code-send-setup-menu-children
+    ("f" "File" ai-code-send-file)
+    ("F" "File to..." ai-code-send-file-to)
+    ("c" "Current file" ai-code-send-current-file)
+    ("o" "Other file" ai-code-send-other-file)]
+   ["Code" :class transient-column
+    :setup-children ai-code-send-setup-menu-children
+    ("r" "Region" ai-code-send-region)
+    ("R" "Region to..." ai-code-send-region-to)
+    ("d" "DWIM" ai-code-send-dwim)
+    ("D" "DWIM to..." ai-code-send-dwim-to)]
+   ["Attachments" :class transient-column
+    :setup-children ai-code-send-setup-menu-children
+    ("s" "Screenshot" ai-code-send-screenshot)
+    ("S" "Screenshot to..." ai-code-send-screenshot-to)
+    ("i" "Clipboard image" ai-code-send-clipboard-image)
+    ("I" "Clipboard image to..." ai-code-send-clipboard-image-to)]]
+  (interactive)
+  (ai-code-send-prepare-menu)
+  (transient-setup 'ai-code-insert-menu))
 
 (transient-define-group ai-code--menu-agile-development
   (ai-code--infix-select-code-change-auto-test)

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -15,12 +15,14 @@
 (require 'ai-code-notifications)
 
 (defvar vterm-copy-mode-hook)
+(defvar vterm--term)
 (defvar eat-term-name)
 (defvar ghostel-set-title-function)
 (defvar ghostel-kill-buffer-on-exit)
 (defvar ghostel--copy-mode-active)
 (defvar ghostel--input-mode)
 (defvar ghostel--process)
+(defvar ghostel--term)
 
 (defconst test-ai-code-backends-infra-valid-uuid
   "123e4567-e89b-12d3-a456-426614174000"
@@ -1165,6 +1167,88 @@ The prefix argument should also force instance-name prompting."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ai-code-backends-infra--vterm-send-string-requires-bracketed-paste ()
+  "Vterm paste should fail closed when bracketed paste mode is inactive."
+  (let (sent)
+    (with-temp-buffer
+      (setq-local vterm--term 'terminal)
+      (cl-letf (((symbol-function 'vterm--update)
+                 (lambda (_terminal _event)
+                   (funcall (symbol-function 'vterm--flush-output) "")))
+                ((symbol-function 'vterm--flush-output) #'ignore)
+                ((symbol-function 'vterm-send-string)
+                 (lambda (&rest arguments)
+                   (setq sent arguments))))
+        (should-error
+         (ai-code-backends-infra-vterm-send-string "one\ntwo" t)
+         :type 'user-error)
+        (should-not sent)))))
+
+(ert-deftest test-ai-code-backends-infra--vterm-send-string-detects-bracketed-paste ()
+  "Vterm paste should probe for and use the bracketed paste sequence."
+  (let (events sent)
+    (with-temp-buffer
+      (setq-local vterm--term 'terminal)
+      (cl-letf (((symbol-function 'vterm--update)
+                 (lambda (_terminal event)
+                   (push event events)
+                   (funcall (symbol-function 'vterm--flush-output)
+                            "\e[200~")))
+                ((symbol-function 'vterm--flush-output) #'ignore)
+                ((symbol-function 'vterm-send-string)
+                 (lambda (&rest arguments)
+                   (setq sent arguments))))
+        (ai-code-backends-infra-vterm-send-string "one\ntwo" t)
+        (should (equal events '("<start_paste>")))
+        (should (equal sent '("one\ntwo" t)))))))
+
+(ert-deftest test-ai-code-backends-infra--vterm-send-string-probe-error-fails-closed ()
+  "Vterm paste should fail closed when its mode probe signals an error."
+  (with-temp-buffer
+    (setq-local vterm--term 'terminal)
+    (cl-letf (((symbol-function 'vterm--update)
+               (lambda (&rest _arguments) (error "Probe failed")))
+              ((symbol-function 'vterm--flush-output) #'ignore)
+              ((symbol-function 'vterm-send-string)
+               (lambda (&rest _arguments)
+                 (ert-fail "Unsafe multiline input must not be sent"))))
+      (should-error
+       (ai-code-backends-infra-vterm-send-string "one\ntwo" t)
+       :type 'user-error))))
+
+(ert-deftest test-ai-code-backends-infra--vterm-send-string-missing-probe-fails-closed ()
+  "Vterm paste should fail closed when its mode probe is unavailable."
+  (let ((original
+         (and (fboundp 'vterm--update)
+              (symbol-function 'vterm--update))))
+    (unwind-protect
+        (progn
+          (when original
+            (fmakunbound 'vterm--update))
+          (with-temp-buffer
+            (setq-local vterm--term 'terminal)
+            (cl-letf (((symbol-function 'vterm-send-string)
+                       (lambda (&rest _arguments)
+                         (ert-fail
+                          "Unsafe multiline input must not be sent"))))
+              (should-error
+               (ai-code-backends-infra-vterm-send-string "one\ntwo" t)
+               :type 'user-error))))
+      (when original
+        (fset 'vterm--update original)))))
+
+(ert-deftest test-ai-code-backends-infra--vterm-send-string-skips-probe-for-plain-input ()
+  "Vterm ordinary input should not require bracketed paste mode."
+  (let (sent)
+    (cl-letf (((symbol-function 'vterm--update)
+               (lambda (&rest _arguments)
+                 (ert-fail "Ordinary input must not probe paste mode")))
+              ((symbol-function 'vterm-send-string)
+               (lambda (&rest arguments)
+                 (setq sent arguments))))
+      (ai-code-backends-infra-vterm-send-string "one" nil)
+      (should (equal sent '("one"))))))
+
 (ert-deftest test-ai-code-backends-infra-terminal-send-string-prefers-session-backend ()
   "Send should use session-local backend even after global backend changes."
   (let ((ai-code-backends-infra-terminal-backend 'eat)
@@ -1220,6 +1304,57 @@ The prefix argument should also force instance-name prompting."
         (ai-code-backends-infra--terminal-send-string "hello"))
       (should (equal calls '("hello"))))))
 
+(ert-deftest test-ai-code-backends-infra--eat-send-string-rejects-unsafe-paste-fallback ()
+  "Eat paste should error instead of sending multiline input as raw keys."
+  (let ((original
+         (and (fboundp 'eat-term-send-string-as-yank)
+              (symbol-function 'eat-term-send-string-as-yank))))
+    (unwind-protect
+        (progn
+          (when (fboundp 'eat-term-send-string-as-yank)
+            (fmakunbound 'eat-term-send-string-as-yank))
+          (with-temp-buffer
+            (setq-local eat-terminal 'terminal)
+            (cl-letf (((symbol-function 'eat-term-send-string)
+                       (lambda (&rest _args)
+                         (ert-fail "Raw multiline input must not be sent"))))
+              (should-error
+               (ai-code-backends-infra-eat-send-string "one\ntwo" t)
+               :type 'user-error))))
+      (when original
+        (fset 'eat-term-send-string-as-yank original)))))
+
+(ert-deftest test-ai-code-backends-infra--eat-send-string-requires-bracketed-paste ()
+  "Eat paste should fail closed when bracketed paste mode is inactive."
+  (let (yanked)
+    (with-temp-buffer
+      (setq-local eat-terminal 'terminal)
+      (cl-letf (((symbol-function 'eat-term-send-string)
+                 (lambda (&rest _arguments)
+                   (ert-fail "Raw multiline input must not be sent")))
+                ((symbol-function 'eat--t-term-bracketed-yank)
+                 (lambda (_terminal) nil))
+                ((symbol-function 'eat-term-send-string-as-yank)
+                 (lambda (_terminal arguments)
+                   (setq yanked arguments))))
+        (should-error
+         (ai-code-backends-infra-eat-send-string "one\ntwo" t)
+         :type 'user-error)
+        (should-not yanked)))))
+
+(ert-deftest test-ai-code-backends-infra--eat-send-string-pastes-one-argument ()
+  "Eat paste should pass text as one argument when bracketed paste is active."
+  (let (yanked)
+    (with-temp-buffer
+      (setq-local eat-terminal 'terminal)
+      (cl-letf (((symbol-function 'eat--t-term-bracketed-yank)
+                 (lambda (_terminal) t))
+                ((symbol-function 'eat-term-send-string-as-yank)
+                 (lambda (_terminal arguments)
+                   (setq yanked arguments))))
+        (ai-code-backends-infra-eat-send-string "one\ntwo" t)
+        (should (equal yanked '("one\ntwo")))))))
+
 (ert-deftest test-ai-code-backends-infra-terminal-send-string-ghostel-supports-paste ()
   "Ghostel sessions should send paste input through `ghostel-paste-string' when paste is non-nil."
   (let ((send-calls nil)
@@ -1229,15 +1364,55 @@ The prefix argument should also force instance-name prompting."
                  (push string send-calls)))
               ((symbol-function 'ghostel-paste-string)
                (lambda (string)
-                 (push string paste-calls))))
+                 (push string paste-calls)))
+              ((symbol-function 'ghostel--mode-enabled)
+               (lambda (terminal mode)
+                 (and (eq terminal 'terminal) (= mode 2004)))))
       (with-temp-buffer
         (setq-local ai-code-backends-infra--session-terminal-backend 'ghostel)
+        (setq-local ghostel--term 'terminal)
         ;; Send without paste
         (ai-code-backends-infra--terminal-send-string "hello" nil)
         ;; Send with paste
         (ai-code-backends-infra--terminal-send-string "world" t))
       (should (equal send-calls '("hello")))
       (should (equal paste-calls '("world"))))))
+
+(ert-deftest test-ai-code-backends-infra--ghostel-send-string-requires-bracketed-paste ()
+  "Ghostel paste should fail closed when bracketed paste mode is inactive."
+  (let (pasted)
+    (with-temp-buffer
+      (setq-local ghostel--term 'terminal)
+      (cl-letf (((symbol-function 'ghostel-send-string)
+                 (lambda (&rest _arguments)
+                   (ert-fail "Raw multiline input must not be sent")))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (string)
+                   (setq pasted string)))
+                ((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_terminal _mode) nil)))
+        (should-error
+         (ai-code-backends-infra-ghostel-send-string "one\ntwo" t)
+         :type 'user-error)
+        (should-not pasted)))))
+
+(ert-deftest test-ai-code-backends-infra--ghostel-send-string-rejects-unsafe-paste-fallback ()
+  "Ghostel paste should error instead of sending multiline input as raw keys."
+  (let ((original
+         (and (fboundp 'ghostel-paste-string)
+              (symbol-function 'ghostel-paste-string))))
+    (unwind-protect
+        (progn
+          (when (fboundp 'ghostel-paste-string)
+            (fmakunbound 'ghostel-paste-string))
+          (cl-letf (((symbol-function 'ghostel-send-string)
+                     (lambda (&rest _args)
+                       (ert-fail "Raw multiline input must not be sent"))))
+            (should-error
+             (ai-code-backends-infra-ghostel-send-string "one\ntwo" t)
+             :type 'user-error)))
+      (when original
+        (fset 'ghostel-paste-string original)))))
 
 (ert-deftest test-ai-code-backends-infra-terminal-send-special-keys-ghostel-uses-public-api ()
   "Ghostel sessions should send special keys through `ghostel-send-key'."
@@ -1771,6 +1946,125 @@ The prefix argument should also force instance-name prompting."
       (dolist (buf (list source old-session new-session))
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
+
+(ert-deftest test-ai-code-backends-infra--current-buffer-session-finds-attachment ()
+  "Current-buffer lookup should return its attached live session."
+  (let* ((source (generate-new-buffer " *ai-code-current-source*"))
+         (session (generate-new-buffer " *ai-code-current-target*")))
+    (unwind-protect
+        (progn
+          (clrhash ai-code-backends-infra--file-session-map)
+          (with-current-buffer source
+            (setq buffer-file-name "/tmp/ai-code-current-source/main.el"))
+          (with-current-buffer session
+            (setq-local ai-code-backends-infra--session-terminal-backend 'vterm))
+          (ai-code-backends-infra--remember-file-session-buffer
+           "codex" source session)
+          (cl-letf (((symbol-function 'get-buffer-process)
+                     (lambda (buffer)
+                       (and (eq buffer session) 'session-process)))
+                    ((symbol-function 'process-live-p)
+                     (lambda (process) (eq process 'session-process))))
+            (should (eq (ai-code-backends-infra-current-buffer-session source)
+                        session))))
+      (clrhash ai-code-backends-infra--file-session-map)
+      (kill-buffer source)
+      (kill-buffer session))))
+
+(ert-deftest test-ai-code-backends-infra--current-buffer-session-finds-project-session ()
+  "Current-buffer lookup should use one unambiguous session in its project."
+  (let* ((root (make-temp-file "ai-code-current-project-" t))
+         (source (generate-new-buffer " *ai-code-project-source*"))
+         (session (generate-new-buffer " *ai-code-project-session*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer source
+            (setq default-directory root
+                  buffer-file-name (expand-file-name "other.el" root)))
+          (cl-letf (((symbol-function 'ai-code--session-project-root)
+                     (lambda () root))
+                    ((symbol-function
+                      'ai-code-backends-infra-session-buffers)
+                     (lambda () (list session)))
+                    ((symbol-function
+                      'ai-code-backends-infra-session-directory)
+                     (lambda (buffer)
+                       (and (eq buffer session)
+                            (file-name-as-directory
+                             (file-truename root))))))
+            (should
+             (eq (ai-code-backends-infra-current-buffer-session source)
+                 session))))
+      (kill-buffer source)
+      (kill-buffer session)
+      (delete-directory root t))))
+
+(ert-deftest test-ai-code-backends-infra--current-buffer-session-avoids-ambiguity ()
+  "Current-buffer lookup should not choose arbitrarily among attachments."
+  (let* ((source (generate-new-buffer " *ai-code-ambiguous-source*"))
+         (session-a (generate-new-buffer " *ai-code-ambiguous-a*"))
+         (session-b (generate-new-buffer " *ai-code-ambiguous-b*"))
+         (ai-code-backends-infra--last-accessed-buffer nil))
+    (unwind-protect
+        (progn
+          (clrhash ai-code-backends-infra--file-session-map)
+          (with-current-buffer source
+            (setq buffer-file-name "/tmp/ai-code-ambiguous/main.el"))
+          (dolist (session (list session-a session-b))
+            (with-current-buffer session
+              (setq-local ai-code-backends-infra--session-terminal-backend
+                          'vterm)))
+          (ai-code-backends-infra--remember-file-session-buffer
+           "codex" source session-a)
+          (ai-code-backends-infra--remember-file-session-buffer
+           "gemini" source session-b)
+          (cl-letf (((symbol-function 'get-buffer-process)
+                     (lambda (buffer)
+                       (cond
+                        ((eq buffer session-a) 'process-a)
+                        ((eq buffer session-b) 'process-b))))
+                    ((symbol-function 'process-live-p)
+                     (lambda (process) (memq process '(process-a process-b)))))
+            (should-not
+             (ai-code-backends-infra-current-buffer-session source))
+            (setq ai-code-backends-infra--last-accessed-buffer session-b)
+            (should (eq (ai-code-backends-infra-current-buffer-session source)
+                        session-b))))
+      (clrhash ai-code-backends-infra--file-session-map)
+      (dolist (buffer (list source session-a session-b))
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra--session-buffers-finds-global-sessions ()
+  "Global lookup should find live managed sessions after they are renamed."
+  (with-temp-buffer
+    (let ((ordinary (current-buffer)))
+      (with-temp-buffer
+        (rename-buffer (format "*renamed-ai-session-%s*" (gensym "global-")))
+        (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+        (let ((session (current-buffer)))
+          (cl-letf (((symbol-function 'buffer-list)
+                     (lambda (&optional _frame) (list ordinary session)))
+                    ((symbol-function 'get-buffer-process)
+                     (lambda (buffer)
+                       (and (eq buffer session) 'session-process)))
+                    ((symbol-function 'process-live-p)
+                     (lambda (process) (eq process 'session-process))))
+            (should (equal (ai-code-backends-infra-session-buffers)
+                           (list session)))))))))
+
+(ert-deftest test-ai-code-backends-infra--session-buffers-excludes-stopped-sessions ()
+  "Global lookup should exclude terminal buffers whose process has stopped."
+  (with-temp-buffer
+    (rename-buffer (format "*codex[%s]*" (gensym "stopped-")))
+    (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+    (let ((session (current-buffer)))
+      (cl-letf (((symbol-function 'buffer-list)
+                 (lambda (&optional _frame) (list session)))
+                ((symbol-function 'get-buffer-process)
+                 (lambda (_buffer) 'stopped-process))
+                ((symbol-function 'process-live-p)
+                 (lambda (_process) nil)))
+        (should-not (ai-code-backends-infra-session-buffers))))))
 
 (ert-deftest test-ai-code-backends-infra-reuse-session-window-refreshes-hidden-buffer ()
   "Reusing a hidden session should refresh its state and display it."

--- a/test/test_ai-code-editor-viewport-attachments.el
+++ b/test/test_ai-code-editor-viewport-attachments.el
@@ -153,6 +153,25 @@
             (should (equal (buffer-string) "@notes/design.txt"))))
       (delete-directory directory t))))
 
+(ert-deftest test-ai-code-editor-viewport-attachments--uses-session-directory-for-reference ()
+  "File references should be relative to the viewport's CLI session directory."
+  (let* ((repository (make-temp-file "ai-code-editor-nested-project-" t))
+         (session-directory (expand-file-name "packages/app/" repository))
+         (file (expand-file-name "src/main.el" session-directory)))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name ".git" repository))
+          (make-directory (file-name-directory file) t)
+          (with-temp-file file
+            (insert ";; main"))
+          (with-temp-buffer
+            (setq-local ai-code-editor-viewport--source-directory
+                        session-directory)
+            (ai-code-editor-viewport-mode 1)
+            (ai-code-editor-viewport-insert-files (list file))
+            (should (equal (buffer-string) "@src/main.el"))))
+      (delete-directory repository t))))
+
 (ert-deftest test-ai-code-editor-viewport-attachments--yank-saves-image-preview ()
   "`C-y' should detect clipboard images without target metadata."
   (let* ((directory (make-temp-file "ai-code-editor-clipboard-image-" t))

--- a/test/test_ai-code-package-hygiene.el
+++ b/test/test_ai-code-package-hygiene.el
@@ -15,6 +15,16 @@
     (insert-file-contents path nil 0 length)
     (buffer-string)))
 
+(defun ai-code-test--variable-initializer (file definition variable)
+  "Return VARIABLE's initializer from DEFINITION in FILE."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (re-search-forward
+     (format "^(%s %s\\_>" definition variable))
+    (goto-char (match-beginning 0))
+    (nth 2 (read (current-buffer)))))
+
 (ert-deftest ai-code-test-autoloads-file-has-spdx-header ()
   "Autoloads file should advertise the package license with SPDX."
   (let ((header (ai-code-test--file-prefix "ai-code-autoloads.el" 400)))
@@ -68,6 +78,29 @@
      (re-search-forward
       "(autoload 'ai-code-lint-current-file "
       nil t))))
+
+(ert-deftest test-ai-code-package-hygiene--autoloads-includes-native-send-commands ()
+  "Autoloads file should expose the native Insert commands."
+  (with-temp-buffer
+    (insert-file-contents "ai-code-autoloads.el")
+    (dolist (command '("ai-code-send-file"
+                       "ai-code-send-screenshot"
+                       "ai-code-send-clipboard-image"
+                       "ai-code-send-region"
+                       "ai-code-send-dwim"
+                       "ai-code-send-dwim-to"))
+      (should (re-search-forward
+               (format "(autoload '%s " command)
+               nil t)))))
+
+(ert-deftest test-ai-code-package-hygiene--autoload-screenshot-default-matches-source ()
+  "Autoloads should preserve the platform-specific screenshot default."
+  (should
+   (equal
+    (ai-code-test--variable-initializer
+     "ai-code-autoloads.el" "defvar" 'ai-code-send-screenshot-command)
+    (ai-code-test--variable-initializer
+     "ai-code-send.el" "defcustom" 'ai-code-send-screenshot-command))))
 
 (ert-deftest ai-code-test-secondary-files-use-standard-keywords ()
   "Secondary package files should use standard finder keywords."

--- a/test/test_ai-code-send.el
+++ b/test/test_ai-code-send.el
@@ -1,0 +1,892 @@
+;;; test_ai-code-send.el --- Tests for ai-code-send.el -*- lexical-binding: t; -*-
+
+;; Author: realazy
+;; Package-Requires: ((emacs "29.1"))
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for inserting files and editor selections into ai-code sessions.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+(unless (featurep 'magit)
+  (defun magit-toplevel (&optional _dir) nil)
+  (defun magit-get-current-branch () nil)
+  (defun magit-git-lines (&rest _args) nil)
+  (provide 'magit))
+
+(require 'ai-code-send)
+
+(ert-deftest test-ai-code-send--file-formats-project-reference ()
+  "File sends should separate an @-prefixed project-relative reference."
+  (let* ((root (make-temp-file "ai-code-send-root-" t))
+         (file (expand-file-name "src/main.el" root))
+         inserted)
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory file) t)
+          (with-temp-file file (insert "(message \"hello\")"))
+          (with-temp-buffer
+            (setq default-directory root)
+            (cl-letf (((symbol-function 'ai-code--session-project-root)
+                       (lambda () root))
+                      ((symbol-function 'ai-code-send--default-session)
+                       (lambda () 'session-buffer))
+                      ((symbol-function 'ai-code-backends-infra-insert-string)
+                       (lambda (text buffer)
+                         (setq inserted (list text buffer))))
+                      ((symbol-function 'ai-code-send--buffer-files)
+                       (lambda () (list file))))
+              (ai-code-send-file)
+              (should (equal inserted '("\n\n@src/main.el\n\n"
+                                        session-buffer))))))
+      (delete-directory root t))))
+
+(ert-deftest test-ai-code-send--file-to-uses-selected-session-root ()
+  "Cross-project file targets should receive an absolute source reference."
+  (let* ((source-root (make-temp-file "ai-code-send-source-" t))
+         (target-root (make-temp-file "ai-code-send-target-" t))
+         (file (expand-file-name "src/main.el" source-root))
+         (session (generate-new-buffer " *ai-code-target-session*"))
+         inserted)
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory file) t)
+          (with-temp-file file (insert "(message \"hello\")"))
+          (with-temp-buffer
+            (setq default-directory source-root)
+            (cl-letf (((symbol-function 'ai-code--session-project-root)
+                       (lambda () source-root))
+                      ((symbol-function 'ai-code-send--files)
+                       (lambda (&optional _prompt-for-file) (list file)))
+                      ((symbol-function 'ai-code-send--viewport-buffer)
+                       (lambda (&optional _session) nil))
+                      ((symbol-function 'ai-code-send--select-session)
+                       (lambda () session))
+                      ((symbol-function
+                        'ai-code-backends-infra-session-directory)
+                       (lambda (buffer)
+                         (and (eq buffer session) target-root)))
+                      ((symbol-function 'ai-code-backends-infra-insert-string)
+                       (lambda (text buffer)
+                         (setq inserted (list text buffer)))))
+              (ai-code-send-file-to)
+              (should (equal inserted
+                             (list (concat "\n\n@" file "\n\n")
+                                   session))))))
+      (kill-buffer session)
+      (delete-directory source-root t)
+      (delete-directory target-root t))))
+
+(ert-deftest test-ai-code-send--region-to-uses-selected-session-root ()
+  "Cross-project region targets should receive an absolute source location."
+  (let* ((source-root (make-temp-file "ai-code-send-source-" t))
+         (target-root (make-temp-file "ai-code-send-target-" t))
+         (file (expand-file-name "src/main.el" source-root))
+         (session (generate-new-buffer " *ai-code-target-session*"))
+         inserted)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "first\nsecond\n")
+          (setq buffer-file-name file
+                default-directory source-root)
+          (goto-char (point-min))
+          (set-mark (point-max))
+          (activate-mark)
+          (cl-letf (((symbol-function 'ai-code--session-project-root)
+                     (lambda () source-root))
+                    ((symbol-function 'ai-code-send--viewport-buffer)
+                     (lambda (&optional _session) nil))
+                    ((symbol-function 'ai-code-send--select-session)
+                     (lambda () session))
+                    ((symbol-function
+                      'ai-code-backends-infra-session-directory)
+                     (lambda (buffer)
+                       (and (eq buffer session) target-root)))
+                    ((symbol-function 'ai-code-backends-infra-insert-string)
+                     (lambda (text buffer)
+                       (setq inserted (list text buffer)))))
+            (ai-code-send-region-to)
+            (should (eq (cadr inserted) session))
+            (should (string-prefix-p
+                     (format "\n\n@%s#L1-L2" file)
+                     (car inserted)))))
+      (kill-buffer session)
+      (delete-directory source-root t)
+      (delete-directory target-root t))))
+
+(ert-deftest test-ai-code-send--current-file-ignores-active-region ()
+  "Current-file insertion should insert the file even when a region is active."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "selected text")
+      (setq buffer-file-name "/tmp/current.el")
+      (set-mark (point-min))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--dispatch-files)
+                 (lambda (files &optional pick-session)
+                   (setq inserted (list files pick-session))))
+                ((symbol-function 'ai-code-send-region)
+                 (lambda (&rest _args)
+                   (ert-fail "Current-file insertion must not insert the region"))))
+        (ai-code-send-current-file)
+        (should (equal inserted '(("/tmp/current.el") nil)))))))
+
+(ert-deftest test-ai-code-send--other-file-ignores-active-region ()
+  "Other-file insertion should prompt for a file even when a region is active."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "selected text")
+      (setq buffer-file-name "/tmp/current.el")
+      (set-mark (point-min))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--read-file)
+                 (lambda () "/tmp/other.el"))
+                ((symbol-function 'ai-code-send--dispatch-files)
+                 (lambda (files &optional pick-session)
+                   (setq inserted (list files pick-session))))
+                ((symbol-function 'ai-code-send-region)
+                 (lambda (&rest _args)
+                   (ert-fail "Other-file insertion must not insert the region"))))
+        (ai-code-send-other-file)
+        (should (equal inserted '(("/tmp/other.el") nil)))))))
+
+(ert-deftest test-ai-code-send--read-file-falls-back-without-candidates ()
+  "File insertion should use a file prompt outside Git repositories."
+  (let ((root "/tmp/project/")
+        read-arguments)
+    (cl-letf (((symbol-function 'ai-code--prompt-filepath-candidates)
+               (lambda () nil))
+              ((symbol-function 'ai-code--session-project-root)
+               (lambda () root))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _arguments)
+                 (ert-fail "Empty candidate sets must use a file prompt")))
+              ((symbol-function 'read-file-name)
+               (lambda (&rest arguments)
+                 (setq read-arguments arguments)
+                 "/tmp/project/example.el")))
+      (should (equal (ai-code-send--read-file)
+                     "/tmp/project/example.el"))
+      (should (equal read-arguments
+                     '("Insert file: " "/tmp/project/" nil t))))))
+
+(ert-deftest test-ai-code-send--file-ignores-blank-region ()
+  "File insertion should use the file when the active region is blank."
+  (let (inserted)
+    (with-temp-buffer
+      (insert " \n\t")
+      (setq buffer-file-name "/tmp/current.el")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--dispatch-files)
+                 (lambda (files &optional pick-session)
+                   (setq inserted (list files pick-session))))
+                ((symbol-function 'ai-code-send-region)
+                 (lambda (&rest _args)
+                   (ert-fail "Blank regions must not replace file insertion"))))
+        (ai-code-send-file)
+        (should (equal inserted '(("/tmp/current.el") nil)))))))
+
+(ert-deftest test-ai-code-send--file-ignores-active-region ()
+  "File insertion should insert the file even when a region is active."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "selected text")
+      (setq buffer-file-name "/tmp/current.el")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--dispatch-files)
+                 (lambda (files &optional pick-session)
+                   (setq inserted (list files pick-session))))
+                ((symbol-function 'ai-code-send-region)
+                 (lambda (&rest _args)
+                   (ert-fail "File insertion must not insert the region"))))
+        (ai-code-send-file)
+        (should (equal inserted '(("/tmp/current.el") nil)))))))
+
+(ert-deftest test-ai-code-send--file-to-ignores-active-region ()
+  "File-to insertion should insert the file even when a region is active."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "selected text")
+      (setq buffer-file-name "/tmp/current.el")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--dispatch-files)
+                 (lambda (files &optional pick-session)
+                   (setq inserted (list files pick-session))))
+                ((symbol-function 'ai-code-send-region)
+                 (lambda (&rest _args)
+                   (ert-fail "File-to insertion must not insert the region"))))
+        (ai-code-send-file-to)
+        (should (equal inserted '(("/tmp/current.el") t)))))))
+
+(ert-deftest test-ai-code-send--region-includes-location-and-code ()
+  "Region sends should include a file location and code block."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "first\nsecond\n")
+      (emacs-lisp-mode)
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (setq buffer-file-name "/tmp/example.el")
+      (cl-letf (((symbol-function 'ai-code--session-project-root)
+                 (lambda () "/tmp/"))
+                ((symbol-function 'ai-code-send--default-session)
+                 (lambda () 'session-buffer))
+                ((symbol-function 'ai-code-backends-infra-insert-string)
+                 (lambda (text buffer)
+                   (setq inserted (list text buffer)))))
+        (ai-code-send-region nil)
+        (should (eq (cadr inserted) 'session-buffer))
+        (should (string-match-p "@example.el#L1-L2" (car inserted)))
+        (should (string-match-p "```emacs-lisp" (car inserted)))
+        (should (string-match-p "first\nsecond" (car inserted)))))))
+
+(ert-deftest test-ai-code-send--region-available-p-requires-nonblank-text ()
+  "Region availability should reject empty and whitespace-only selections."
+  (with-temp-buffer
+    (setq-local transient-mark-mode t)
+    (let ((use-empty-active-region t))
+      (set-mark (point))
+      (activate-mark)
+      (should-not (ai-code-send--region-available-p))
+      (insert " \n\t")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (should-not (ai-code-send--region-available-p))
+      (erase-buffer)
+      (insert "selected text")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (should (ai-code-send--region-available-p)))))
+
+(ert-deftest test-ai-code-send--dispatch-selects-session-before-insert ()
+  "A pick-session insert should write to the selected session buffer."
+  (let (inserted selected)
+    (cl-letf (((symbol-function 'ai-code-send--select-session)
+               (lambda () (setq selected 'session-buffer)
+                 selected))
+              ((symbol-function 'ai-code-backends-infra-insert-string)
+               (lambda (text buffer)
+                 (setq inserted (list text buffer)))))
+      (ai-code-send--dispatch "hello" t)
+      (should (equal selected 'session-buffer))
+      (should (equal inserted '("\n\nhello\n\n" session-buffer))))))
+
+(ert-deftest test-ai-code-send--dispatch-survives-partial-upgrade ()
+  "Session insertion should not depend on a newly introduced variable."
+  (let ((was-bound (boundp 'ai-code-send--separator))
+        (old-value (and (boundp 'ai-code-send--separator)
+                        (symbol-value 'ai-code-send--separator)))
+        inserted)
+    (unwind-protect
+        (progn
+          (makunbound 'ai-code-send--separator)
+          (cl-letf (((symbol-function 'ai-code-backends-infra-insert-string)
+                     (lambda (text buffer)
+                       (setq inserted (list text buffer)))))
+            (ai-code-send--insert-at-destination
+             '(:buffer session-buffer :viewport nil :root nil)
+             "hello")
+            (should (equal inserted
+                           '("\n\nhello\n\n" session-buffer)))))
+      (if was-bound
+          (set-default-toplevel-value 'ai-code-send--separator old-value)
+        (makunbound 'ai-code-send--separator)))))
+
+(ert-deftest test-ai-code-send--insert-into-session-omits-return ()
+  "A multiline insert should use terminal paste and never send Return."
+  (let (sent displayed)
+    (with-temp-buffer
+      (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+      (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-send-string)
+                 (lambda (text &optional paste)
+                   (setq sent (list text paste))))
+                ((symbol-function 'ai-code-backends-infra--terminal-send-return)
+                 (lambda ()
+                   (ert-fail "Insert commands must not send Return")))
+                ((symbol-function
+                  'ai-code-backends-infra--display-buffer-in-side-window)
+                 (lambda (buffer)
+                   (setq displayed buffer)))
+                ((symbol-function 'get-buffer-process)
+                 (lambda (_buffer) 'session-process))
+                ((symbol-function 'process-live-p)
+                 (lambda (process) (eq process 'session-process))))
+        (ai-code-backends-infra-insert-string
+         "first\nsecond" (current-buffer))
+        (should (equal sent '("first\nsecond" t)))
+        (should (eq displayed (current-buffer)))))))
+
+(ert-deftest test-ai-code-send--dispatch-errors-without-destination ()
+  "An insert should fail clearly when there is no destination."
+  (cl-letf (((symbol-function 'ai-code-send--viewport-buffer)
+             (lambda (&optional _session) nil))
+            ((symbol-function
+              'ai-code-backends-infra-current-buffer-session)
+             (lambda (&optional _buffer) nil)))
+    (should-error (ai-code-send--dispatch "hello") :type 'user-error)))
+
+(ert-deftest test-ai-code-send--default-session-uses-current-buffer-session ()
+  "The default destination should be the session attached to this buffer."
+  (let ((session (generate-new-buffer " *ai-code-current-session*")))
+    (unwind-protect
+        (cl-letf (((symbol-function
+                    'ai-code-backends-infra-current-buffer-session)
+                   (lambda (&optional _buffer) session)))
+          (should (eq (ai-code-send--default-session) session)))
+      (kill-buffer session))))
+
+(ert-deftest test-ai-code-send--default-session-reports-other-project-only ()
+  "An unattached buffer should report that only another project has a session."
+  (cl-letf (((symbol-function
+              'ai-code-backends-infra-current-buffer-session)
+             (lambda (&optional _buffer) nil))
+            ((symbol-function 'ai-code-backends-infra-session-buffers)
+             (lambda () '(other-project-session))))
+    (let ((result (should-error (ai-code-send--default-session)
+                                :type 'user-error)))
+      (should (equal (cadr result) "No AI session for this project")))))
+
+(ert-deftest test-ai-code-send--default-session-reports-no-global-session ()
+  "An unattached buffer should distinguish the absence of all sessions."
+  (cl-letf (((symbol-function
+              'ai-code-backends-infra-current-buffer-session)
+             (lambda (&optional _buffer) nil))
+            ((symbol-function 'ai-code-backends-infra-session-buffers)
+             (lambda () nil)))
+    (let ((result (should-error (ai-code-send--default-session)
+                                :type 'user-error)))
+      (should (equal (cadr result)
+                     "No AI sessions are running; start one first")))))
+
+(ert-deftest test-ai-code-send--prepare-menu-reports-other-project-session ()
+  "Preparing Insert should report when only another project has a session."
+  (let (message-text)
+    (cl-letf (((symbol-function 'ai-code-send--default-destination-p)
+               (lambda () nil))
+              ((symbol-function 'ai-code-backends-infra-session-buffers)
+               (lambda () '(other-project-session)))
+              ((symbol-function 'message)
+               (lambda (format-string &rest arguments)
+                 (setq message-text
+                       (apply #'format format-string arguments)))))
+      (should (ai-code-send-prepare-menu))
+      (should (equal message-text "No AI session for this project")))))
+
+(ert-deftest test-ai-code-send--prepare-menu-reports-no-global-session ()
+  "Preparing Insert should fail clearly when no session is running."
+  (cl-letf (((symbol-function 'ai-code-send--default-destination-p)
+             (lambda () nil))
+            ((symbol-function 'ai-code-backends-infra-session-buffers)
+             (lambda () nil)))
+    (let ((error-data (should-error (ai-code-send-prepare-menu)
+                                    :type 'user-error)))
+      (should (equal (cadr error-data)
+                     "No AI sessions are running; start one first")))))
+
+(ert-deftest test-ai-code-send--prepare-menu-rejects-orphaned-viewport ()
+  "A viewport without a running source session should not be a destination."
+  (let ((source (generate-new-buffer " *ai-code-stopped-source*")))
+    (unwind-protect
+        (with-temp-buffer
+          (setq-local ai-code-editor-viewport-mode t)
+          (setq-local ai-code-editor-viewport--source-buffer source)
+          (cl-letf (((symbol-function
+                      'ai-code-backends-infra-session-buffers)
+                     (lambda () nil)))
+            (let ((error-data (should-error (ai-code-send-prepare-menu)
+                                            :type 'user-error)))
+              (should (equal (cadr error-data)
+                             "No AI sessions are running; start one first")))))
+      (kill-buffer source))))
+
+(ert-deftest test-ai-code-send--select-session-offers-global-sessions ()
+  "Explicit selection should offer sessions outside the current project."
+  (let ((session (generate-new-buffer " *ai-code-other-project-session*"))
+        candidates)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-backends-infra-session-buffers)
+                   (lambda () (list session)))
+                  ((symbol-function 'completing-read)
+                   (lambda (_prompt collection &rest _args)
+                     (setq candidates collection)
+                     (car collection))))
+          (should (eq (ai-code-send--select-session) session))
+          (should (equal candidates (list (buffer-name session)))))
+      (kill-buffer session))))
+
+(ert-deftest test-ai-code-send--select-session-reports-no-global-sessions ()
+  "Explicit selection should report when no sessions are running."
+  (cl-letf (((symbol-function 'ai-code-backends-infra-session-buffers)
+             (lambda () nil)))
+    (let ((result (should-error (ai-code-send--select-session)
+                                :type 'user-error)))
+      (should (equal (cadr result)
+                     "No AI sessions are running; start one first")))))
+
+(ert-deftest test-ai-code-send--select-session-rejects-stopped-selection ()
+  "Explicit selection should reject a session that stops during completion."
+  (let ((session (generate-new-buffer " *ai-code-stopping-session*"))
+        (lookup-count 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-backends-infra-session-buffers)
+                   (lambda ()
+                     (setq lookup-count (1+ lookup-count))
+                     (and (= lookup-count 1) (list session))))
+                  ((symbol-function 'completing-read)
+                   (lambda (_prompt collection &rest _arguments)
+                     (car collection))))
+          (let ((error-data (should-error (ai-code-send--select-session)
+                                          :type 'user-error)))
+            (should (equal (cadr error-data)
+                           "AI session is no longer available"))))
+      (kill-buffer session))))
+
+(ert-deftest test-ai-code-send--dispatch-prefers-open-viewport ()
+  "Sending should insert into an open viewport instead of a session."
+  (let ((source (generate-new-buffer " *ai-code-live-viewport-source*")))
+    (unwind-protect
+        (with-temp-buffer
+          (setq-local ai-code-editor-viewport-mode t)
+          (setq-local ai-code-editor-viewport--source-buffer source)
+          (cl-letf (((symbol-function
+                      'ai-code-backends-infra-session-buffers)
+                     (lambda () (list source)))
+                    ((symbol-function 'ai-code-backends-infra-insert-string)
+                     (lambda (&rest _args)
+                       (ert-fail
+                        "The TUI session should not receive viewport text"))))
+            (ai-code-send--dispatch "hello")
+            (should (equal (buffer-string) "hello\n\n"))))
+      (kill-buffer source))))
+
+(ert-deftest test-ai-code-send--file-appends-viewport-attachment-separator ()
+  "File sends should separate nonempty viewports and append a separator."
+  (dolist (case '(("" . "[attachment]\n\n")
+                  ("draft" . "draft\n\n[attachment]\n\n")))
+    (let ((source (generate-new-buffer " *ai-code-file-viewport-source*"))
+          inserted)
+      (unwind-protect
+          (with-temp-buffer
+            (insert (car case))
+            (setq-local ai-code-editor-viewport-mode t)
+            (setq-local ai-code-editor-viewport--source-buffer source)
+            (cl-letf (((symbol-function
+                        'ai-code-backends-infra-session-buffers)
+                       (lambda () (list source)))
+                      ((symbol-function 'ai-code-send--files)
+                       (lambda (&optional _prompt-for-file)
+                         '("/tmp/example.png")))
+                      ((symbol-function 'ai-code-editor-viewport-insert-files)
+                       (lambda (files)
+                         (setq inserted files)
+                         (insert "[attachment]")))
+                      ((symbol-function 'ai-code-send--dispatch)
+                       (lambda (&rest _args)
+                         (ert-fail
+                          "The TUI session should not receive viewport files"))))
+              (ai-code-send-file)
+              (should (equal inserted '("/tmp/example.png")))
+              (should (equal (buffer-string) (cdr case)))))
+        (kill-buffer source)))))
+
+(ert-deftest test-ai-code-send--explicit-target-uses-selected-session-viewport ()
+  "An explicit target should use the viewport belonging to that session."
+  (let ((session-a (generate-new-buffer " *ai-code-session-a*"))
+        (session-b (generate-new-buffer " *ai-code-session-b*"))
+        (viewport-b (generate-new-buffer " *ai-code-viewport-b*"))
+        (viewport-a (generate-new-buffer " *ai-code-viewport-a*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer viewport-a
+            (insert "draft")
+            (setq-local ai-code-editor-viewport-mode t)
+            (setq-local ai-code-editor-viewport--source-buffer session-a))
+          (with-current-buffer viewport-b
+            (setq-local ai-code-editor-viewport-mode t)
+            (setq-local ai-code-editor-viewport--source-buffer session-b))
+          (cl-letf (((symbol-function 'ai-code-send--select-session)
+                     (lambda () session-a))
+                    ((symbol-function 'ai-code-backends-infra-insert-string)
+                     (lambda (&rest _args)
+                       (ert-fail "The selected session viewport should win"))))
+            (with-temp-buffer
+              (ai-code-send--dispatch "selected" t)))
+          (should (equal
+                   (with-current-buffer viewport-a (buffer-string))
+                   "draft\n\nselected\n\n"))
+          (should (string-empty-p
+                   (with-current-buffer viewport-b (buffer-string)))))
+      (dolist (buffer (list session-a session-b viewport-a viewport-b))
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-send--unrelated-viewport-does-not-hijack-normal-send ()
+  "A viewport for another session should not become an implicit destination."
+  (let ((other-session (generate-new-buffer " *ai-code-other-session*"))
+        (other-viewport (generate-new-buffer " *ai-code-other-viewport*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer other-viewport
+            (setq-local ai-code-editor-viewport-mode t)
+            (setq-local ai-code-editor-viewport--source-buffer other-session))
+          (cl-letf (((symbol-function
+                      'ai-code-backends-infra-current-buffer-session)
+                     (lambda (&optional _buffer) nil))
+                    ((symbol-function 'ai-code-backends-infra-session-buffers)
+                     (lambda () (list other-session))))
+            (with-temp-buffer
+              (should-error (ai-code-send--dispatch "local")
+                            :type 'user-error)))
+          (should (string-empty-p
+                   (with-current-buffer other-viewport (buffer-string)))))
+      (kill-buffer other-session)
+      (kill-buffer other-viewport))))
+
+(ert-deftest test-ai-code-send--viewport-buffer-finds-session-viewport ()
+  "Viewport lookup should find the editor associated with a session."
+  (let ((session (generate-new-buffer " *ai-code-hidden-session*"))
+        (viewport (generate-new-buffer " *ai-code-hidden-viewport*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer viewport
+            (setq-local ai-code-editor-viewport-mode t)
+            (setq-local ai-code-editor-viewport--source-buffer session))
+          (should (eq (ai-code-send--viewport-buffer session) viewport)))
+      (kill-buffer session)
+      (kill-buffer viewport))))
+
+(ert-deftest test-ai-code-send--diagnostic-text-includes-all-messages ()
+  "Diagnostic insertion should retain every diagnostic at point."
+  (with-temp-buffer
+    (insert "current line")
+    (cl-letf (((symbol-function 'ai-code-send--diagnostic-messages)
+               (lambda () '("first problem" "second problem"))))
+      (let ((text (ai-code-send--diagnostic-text)))
+        (should (string-match-p "first problem" text))
+        (should (string-match-p "second problem" text))))))
+
+(ert-deftest test-ai-code-send--diagnostic-text-uses-destination-root ()
+  "Cross-project diagnostics should use an absolute source location."
+  (let* ((source-root (make-temp-file "ai-code-send-source-" t))
+         (target-root (make-temp-file "ai-code-send-target-" t))
+         (file (expand-file-name "src/main.el" source-root)))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "current line")
+          (setq buffer-file-name file
+                default-directory source-root)
+          (cl-letf (((symbol-function 'ai-code-send--diagnostic-messages)
+                     (lambda () '("problem"))))
+            (should
+             (string-prefix-p
+              (format "Diagnostics at @%s#L1" file)
+              (ai-code-send--diagnostic-text target-root)))))
+      (delete-directory source-root t)
+      (delete-directory target-root t))))
+
+(ert-deftest test-ai-code-send--dwim-prefix-keeps-implicit-session ()
+  "A prefix should not retarget the normal DWIM command globally."
+  (let (pick-session)
+    (cl-letf (((symbol-function 'ai-code-send--dispatch)
+               (lambda (_content pick)
+                 (setq pick-session pick))))
+      (with-temp-buffer
+        (insert "current line")
+        (let ((current-prefix-arg '(4)))
+          (call-interactively #'ai-code-send-dwim)))
+      (should-not pick-session))))
+
+(ert-deftest test-ai-code-send--dwim-to-selects-session ()
+  "The DWIM to command should explicitly select a destination session."
+  (let (pick-session)
+    (cl-letf (((symbol-function 'ai-code-send--dispatch)
+               (lambda (_content pick)
+                 (setq pick-session pick))))
+      (with-temp-buffer
+        (insert "current line")
+        (ai-code-send-dwim-to))
+      (should pick-session))))
+
+(ert-deftest test-ai-code-send--dwim-prefers-region-over-diagnostic ()
+  "DWIM should preserve an explicit region even when point has diagnostics."
+  (let (inserted)
+    (with-temp-buffer
+      (insert "selected text")
+      (set-mark (point-min))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--region-text)
+                 (lambda (&optional _root) "region selection"))
+                ((symbol-function 'ai-code-send--diagnostic-text)
+                 (lambda (&optional _root) "diagnostic details"))
+                ((symbol-function 'ai-code-send--dispatch)
+                 (lambda (content pick-session)
+                   (setq inserted
+                         (list (ai-code-send--content-text content "/target/")
+                               pick-session)))))
+        (ai-code-send-dwim)
+        (should (equal inserted '("region selection" nil)))))))
+
+(ert-deftest test-ai-code-send--dwim-ignores-blank-region ()
+  "DWIM should fall through to editor input when the region is blank."
+  (let (inserted)
+    (with-temp-buffer
+      (insert " \n\t")
+      (goto-char (point-min))
+      (set-mark (point-max))
+      (activate-mark)
+      (cl-letf (((symbol-function 'ai-code-send--region-text)
+                 (lambda (&optional _root)
+                   (ert-fail "Blank regions must not be inserted")))
+                ((symbol-function 'ai-code-send--diagnostic-text)
+                 (lambda (&optional _root) nil))
+                ((symbol-function 'ai-code-send--point-text)
+                 (lambda (&optional _root) "current line"))
+                ((symbol-function 'ai-code-send--dispatch)
+                 (lambda (content pick-session)
+                   (setq inserted
+                         (list (ai-code-send--content-text content "/target/")
+                               pick-session)))))
+        (ai-code-send-dwim)
+        (should (equal inserted '("current line" nil)))))))
+
+(ert-deftest test-ai-code-send--clipboard-prefix-keeps-implicit-session ()
+  "A prefix should not retarget the normal clipboard image command globally."
+  (let (pick-session)
+    (cl-letf (((symbol-function 'ai-code-send--dispatch-generated-file)
+               (lambda (_producer pick)
+                 (setq pick-session pick))))
+      (let ((current-prefix-arg '(4)))
+        (call-interactively #'ai-code-send-clipboard-image))
+      (should-not pick-session))))
+
+(ert-deftest test-ai-code-send--clipboard-image-to-selects-session ()
+  "The clipboard-image-to command should select a destination session."
+  (let (pick-session)
+    (cl-letf (((symbol-function 'ai-code-send--dispatch-generated-file)
+               (lambda (_producer pick)
+                 (setq pick-session pick))))
+      (ai-code-send-clipboard-image-to)
+      (should pick-session))))
+
+(ert-deftest test-ai-code-send--clipboard-image-supports-terminal-emacs ()
+  "Clipboard images should use configured handlers in terminal Emacs."
+  (let (producer)
+    (cl-letf (((symbol-function 'window-system) (lambda () nil))
+              ((symbol-function 'ai-code-send--dispatch-generated-file)
+               (lambda (file-producer _pick-session)
+                 (setq producer file-producer))))
+      (ai-code-send-clipboard-image)
+      (should (eq producer
+                  #'ai-code-editor-viewport-save-clipboard-image)))))
+
+(ert-deftest test-ai-code-send--dwim-inserts-dired-files ()
+  "DWIM should insert selected Dired files before considering buffer text."
+  (let (inserted)
+    (cl-letf (((symbol-function 'derived-mode-p)
+               (lambda (&rest _modes) t))
+              ((symbol-function 'ai-code-send--buffer-files)
+               (lambda () '("/tmp/first.el" "/tmp/second.el")))
+              ((symbol-function 'ai-code-send--dispatch-files)
+               (lambda (files pick-session)
+                 (setq inserted (list files pick-session))))
+              ((symbol-function 'ai-code-send--dispatch)
+               (lambda (&rest _args)
+                 (ert-fail "Dired DWIM should dispatch files"))))
+      (ai-code-send-dwim)
+      (should (equal inserted
+                     '(("/tmp/first.el" "/tmp/second.el") nil))))))
+
+(ert-deftest test-ai-code-send--dired-region-files-returns-region-files ()
+  "A Dired region should select the files displayed in that region."
+  (let* ((root (make-temp-file "ai-code-send-dired-" t))
+         (first (expand-file-name "first.el" root))
+         (second (expand-file-name "second.el" root)))
+    (unwind-protect
+        (progn
+          (with-temp-file first (insert "first"))
+          (with-temp-file second (insert "second"))
+          (with-current-buffer (dired-noselect root)
+            (dired-goto-file first)
+            (let ((start (line-beginning-position)))
+              (dired-goto-file second)
+              (let ((end (line-end-position)))
+                (goto-char start)
+                (set-mark end)
+                (activate-mark)
+                (should (equal (ai-code-send--dired-region-files)
+                               (list first second)))))))
+      (delete-directory root t))))
+
+(ert-deftest test-ai-code-send--point-text-includes-current-line ()
+  "Point sends should include the current file location and line."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (insert "(message \"hello\")\n")
+    (goto-char (point-min))
+    (setq buffer-file-name "/tmp/example.el")
+    (cl-letf (((symbol-function 'ai-code--session-project-root)
+               (lambda () "/tmp/")))
+      (let ((text (ai-code-send--point-text)))
+        (should (string-match-p "@example.el#L1" text))
+        (should (string-match-p "```emacs-lisp" text))
+        (should (string-match-p "message" text))))))
+
+(ert-deftest test-ai-code-send--capture-screenshot-creates-destination ()
+  "Screenshot capture should append a destination path and verify it exists."
+  (let* ((directory (make-temp-file "ai-code-send-screenshot-" t))
+         (ai-code-send-screenshot-command '("mock-capture" "--select"))
+         captured-file)
+    (unwind-protect
+        (cl-letf (((symbol-function
+                    'ai-code-editor-viewport-ensure-attachment-directory)
+                   (lambda () directory))
+                  ((symbol-function 'executable-find)
+                   (lambda (program)
+                     (when (string= program "mock-capture") program)))
+                  ((symbol-function 'call-process)
+                   (lambda (_program _in _out _display &rest args)
+                     (setq captured-file (car (last args)))
+                     (with-temp-file captured-file (insert "png"))
+                     0)))
+          (let ((file (ai-code-send--capture-screenshot)))
+            (should (file-in-directory-p file directory))
+            (should-not (equal file captured-file))
+            (should (file-exists-p file))
+            (should-not (file-exists-p captured-file))))
+      (delete-directory directory t))))
+
+(ert-deftest test-ai-code-send--capture-screenshot-stages-locally-for-tramp ()
+  "Screenshot capture should copy a local image to a remote destination."
+  (let* ((remote-directory "/ssh:example:/project/.ai.code.files/")
+         (remote-file (concat remote-directory "screenshot.png"))
+         (ai-code-send-screenshot-command '("mock-capture"))
+         (make-temp-file-function (symbol-function 'make-temp-file))
+         (call-process-function (symbol-function 'call-process))
+         local-file
+         process-file
+         copied)
+    (cl-letf (((symbol-function
+                'ai-code-editor-viewport-ensure-attachment-directory)
+               (lambda () remote-directory))
+              ((symbol-function 'make-temp-file)
+               (lambda (prefix &rest arguments)
+                 (if (file-remote-p prefix)
+                     remote-file
+                   (setq local-file
+                         (apply make-temp-file-function prefix arguments)))))
+              ((symbol-function 'executable-find)
+               (lambda (program) program))
+              ((symbol-function 'call-process)
+               (lambda (program input output display &rest arguments)
+                 (if (string= program "mock-capture")
+                     (progn
+                       (setq process-file (car (last arguments)))
+                       (when (file-remote-p process-file)
+                         (ert-fail
+                          "Local capture commands cannot write TRAMP paths"))
+                       (with-temp-file process-file (insert "png"))
+                       0)
+                   (apply call-process-function
+                          program input output display arguments))))
+              ((symbol-function 'copy-file)
+               (lambda (source destination &rest _arguments)
+                 (setq copied (list source destination)))))
+      (should (equal (ai-code-send--capture-screenshot) remote-file))
+      (should (equal process-file local-file))
+      (should (equal copied (list local-file remote-file)))
+      (should-not (file-exists-p local-file)))))
+
+(ert-deftest test-ai-code-send--screenshot-to-selects-before-capture ()
+  "Canceling session selection should not create a screenshot."
+  (let (captured)
+    (cl-letf (((symbol-function 'ai-code-send--select-session)
+               (lambda () (signal 'quit nil)))
+              ((symbol-function 'ai-code-send--capture-screenshot)
+               (lambda ()
+                 (setq captured t)
+                 "/tmp/unexpected-screenshot.png")))
+      (should-not
+       (condition-case nil
+           (progn (ai-code-send-screenshot-to) t)
+         (quit nil)))
+      (should-not captured))))
+
+(ert-deftest test-ai-code-send--generated-file-is-removed-on-insert-failure ()
+  "A newly generated attachment should be removed if insertion fails."
+  (let ((file (make-temp-file "ai-code-send-generated-" nil ".png"))
+        (destination-buffer (generate-new-buffer
+                             " *ai-code-generated-destination*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-send--capture-screenshot)
+                   (lambda () file))
+                  ((symbol-function 'ai-code-send--resolve-destination)
+                   (lambda (&optional _pick-session)
+                     (list :buffer destination-buffer)))
+                  ((symbol-function 'ai-code-send--insert-at-destination)
+                   (lambda (&rest _arguments)
+                     (user-error "Insertion failed"))))
+          (should-error (ai-code-send-screenshot) :type 'user-error)
+          (should-not (file-exists-p file)))
+      (when (buffer-live-p destination-buffer)
+        (kill-buffer destination-buffer))
+      (when (file-exists-p file)
+        (delete-file file)))))
+
+(ert-deftest test-ai-code-send--screenshot-to-uses-target-session-directory ()
+  "A selected session should own the generated screenshot attachment."
+  (let* ((source-directory (make-temp-file "ai-code-send-source-" t))
+         (target-directory (make-temp-file "ai-code-send-target-" t))
+         (session (generate-new-buffer " *ai-code-screenshot-target*"))
+         (ai-code-send-screenshot-command '("mock-capture"))
+         captured-file)
+    (unwind-protect
+        (progn
+          (with-current-buffer session
+            (setq default-directory target-directory))
+          (with-temp-buffer
+            (setq default-directory source-directory)
+            (cl-letf (((symbol-function 'ai-code-send--select-session)
+                       (lambda () session))
+                      ((symbol-function 'ai-code-send--viewport-buffer)
+                       (lambda (&optional _session) nil))
+                      ((symbol-function
+                        'ai-code-backends-infra-session-directory)
+                       (lambda (_buffer) target-directory))
+                      ((symbol-function 'executable-find)
+                       (lambda (program) program))
+                      ((symbol-function 'call-process)
+                       (lambda (_program _in _out _display &rest arguments)
+                         (setq captured-file (car (last arguments)))
+                         (with-temp-file captured-file
+                           (insert "png"))
+                         0))
+                      ((symbol-function 'ai-code-backends-infra-insert-string)
+                       (lambda (&rest _arguments) nil)))
+              (ai-code-send-screenshot-to)
+              (let ((files
+                     (directory-files-recursively target-directory
+                                                  "\\.png\\'")))
+                (should (length= files 1))
+                (should (file-in-directory-p (car files)
+                                             target-directory))
+                (should-not (file-exists-p captured-file))))))
+      (when (buffer-live-p session)
+        (kill-buffer session))
+      (delete-directory source-directory t)
+      (delete-directory target-directory t))))
+
+(provide 'test_ai-code-send)
+
+;;; test_ai-code-send.el ends here

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -288,6 +288,97 @@
   (should-error (transient-get-suffix 'ai-code--menu-actions-with-context "o")
                 :type 'error))
 
+(ert-deftest test-ai-code--menu-actions-with-context-opens-insert-menu ()
+  "Test that the actions menu opens the independent Insert menu."
+  (let ((suffix (transient-get-suffix 'ai-code--menu-actions-with-context "I")))
+    (should suffix)
+    (should (eq (plist-get (cdr suffix) :command)
+                'ai-code-insert-menu))))
+
+(defun ai-code-test--call-with-menu-state (prefix function)
+  "Call FUNCTION with PREFIX's initialized suffixes and keymap."
+  (let* ((transient--prefix (transient--init-prefix prefix nil))
+         (layout (transient--init-suffixes prefix))
+         (transient--suffixes (transient--flatten-suffixes layout)))
+    (funcall function transient--suffixes
+             (transient--make-transient-map))))
+
+(ert-deftest test-ai-code--insert-menu-entry-remains-active-without-destination ()
+  "The top-level Insert entry should remain visible and active."
+  (dolist (prefix '(ai-code-menu-default ai-code-menu-2-columns))
+    (pcase-let
+        ((`(,inapt ,binding ,pre-command)
+          (ai-code-test--call-with-menu-state
+           prefix
+           (lambda (suffixes map)
+             (let ((suffix
+                    (seq-find
+                     (lambda (item)
+                       (eq (oref item command) 'ai-code-insert-menu))
+                     suffixes)))
+               (list
+                (and suffix (oref suffix inapt))
+                (lookup-key map (kbd "I"))
+                (lookup-key (transient--make-predicate-map)
+                            [ai-code-insert-menu])))))))
+      (should (eq binding 'ai-code-insert-menu))
+      (should-not inapt)
+      (should-not (eq pre-command 'transient--do-warn-inapt)))))
+
+(ert-deftest test-ai-code--insert-menu-checks-session-before-setup ()
+  "Pressing Insert should check session availability before menu setup."
+  (let (calls)
+    (cl-letf (((symbol-function 'ai-code-send-prepare-menu)
+               (lambda () (push 'prepare calls)))
+              ((symbol-function 'transient-setup)
+               (lambda (&rest _arguments) (push 'setup calls))))
+      (call-interactively #'ai-code-insert-menu)
+      (should (equal (nreverse calls) '(prepare setup))))))
+
+(ert-deftest test-ai-code--insert-menu-includes-all-send-variants ()
+  "Test that the independent Insert menu exposes every send variant."
+  (dolist (entry '("f" "F" "c" "o" "r" "R" "d" "D"
+                   "s" "S" "i" "I"))
+    (should (transient-get-suffix 'ai-code-insert-menu entry))))
+
+(defun ai-code-test--active-insert-menu-keys ()
+  "Return active Insert suffix keys, excluding common Transient commands."
+  (ai-code-test--call-with-menu-state
+   'ai-code-insert-menu
+   (lambda (suffixes _map)
+     (sort
+      (seq-filter
+       (lambda (key)
+         (member key '("f" "F" "c" "o" "r" "R" "d" "D"
+                       "s" "S" "i" "I")))
+       (mapcar (lambda (suffix) (oref suffix key)) suffixes))
+      #'string<))))
+
+(ert-deftest test-ai-code--insert-menu-filters-destination-and-region-commands ()
+  "The active Insert keymap should expose only usable commands."
+  (dolist (case '((nil nil ("D" "F" "I" "S"))
+                  (nil t ("D" "F" "I" "R" "S"))
+                  (t nil ("D" "F" "I" "S" "c" "d" "f" "i" "o" "s"))
+                  (t t ("D" "F" "I" "R" "S" "c" "d" "f" "i" "o" "r" "s"))))
+    (pcase-let ((`(,destination ,region ,expected) case))
+      (cl-letf (((symbol-function 'ai-code-send--default-destination-p)
+                 (lambda () destination))
+                ((symbol-function 'ai-code-send--region-available-p)
+                 (lambda () region)))
+        (should (equal (ai-code-test--active-insert-menu-keys)
+                       expected))))))
+
+(ert-deftest test-ai-code--insert-menu-allows-targeting-other-project-session ()
+  "A global session should enable only explicit targets without a default."
+  (cl-letf (((symbol-function 'ai-code-send--default-destination-p)
+             (lambda () nil))
+            ((symbol-function 'ai-code-backends-infra-session-buffers)
+             (lambda () '(other-project-session)))
+            ((symbol-function 'ai-code-send--region-available-p)
+             (lambda () nil)))
+    (should (equal (ai-code-test--active-insert-menu-keys)
+                   '("D" "F" "I" "S")))))
+
 (ert-deftest ai-code-test-menu-ai-cli-session-includes-session-dashboard-entry ()
   "Test that the AI CLI session menu exposes the session dashboard."
   (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "j")))


### PR DESCRIPTION
## Summary

- Add an `Insert to session...` submenu for files, regions, DWIM input, screenshots, and clipboard images.
- Insert into the destination session’s editor viewport when it is open; otherwise insert into the TUI input without submitting.
- Keep normal commands scoped to the current project and provide `to...` variants for selecting any running session.
- Document platform-specific screenshot capture setup.

## Menu behavior

- The top-level `I` entry is always available.
- When no session is running, opening the submenu reports that state.
- When only sessions for other projects exist, show only the explicit `to...` actions.
- Hide region actions when there is no non-empty region.

## Testing

- 1186 ERT tests: 1173 passed, 13 skipped, 0 failed.
- Byte compilation and checkdoc passed for all touched Emacs Lisp files.
