### PR TITLE
Fix editor viewport status validation after temp directory changes

### DIFF
--- a/ai-code-editor-viewport-transport.el
+++ b/ai-code-editor-viewport-transport.el
@@ -66,6 +66,9 @@
 (defvar ai-code-editor-viewport--helper-file nil
   "Path to the generated CLI editor helper.")
 
+(defvar ai-code-editor-viewport--helper-status-directory nil
+  "Canonical status directory used by the generated editor helper.")
+
 ;;;; Terminal transport
 
 (defun ai-code-editor-viewport--frame-prefix ()
@@ -213,11 +216,13 @@ When TOKEN is nil, discard any pending token."
     (ai-code-editor-viewport--dispatch-payload
      source-buffer payload))))
 
-(defun ai-code-editor-viewport--helper-content ()
-  "Return the terminal editor helper script content."
+(defun ai-code-editor-viewport--helper-content (&optional status-directory)
+  "Return the terminal editor helper script content.
+STATUS-DIRECTORY is where the helper creates its response files."
   (let ((status-template
          (expand-file-name "ai-code-editor-status-XXXXXX"
-                           temporary-file-directory)))
+                           (or status-directory
+                               temporary-file-directory))))
     (concat
      "#!/bin/sh\n"
      "submit=0\n"
@@ -284,22 +289,35 @@ When TOKEN is nil, discard any pending token."
   (when (and ai-code-editor-viewport--helper-file
              (file-exists-p ai-code-editor-viewport--helper-file))
     (delete-file ai-code-editor-viewport--helper-file))
-  (setq ai-code-editor-viewport--helper-file nil))
+  (setq ai-code-editor-viewport--helper-file nil
+        ai-code-editor-viewport--helper-status-directory nil))
 
 (defun ai-code-editor-viewport--ensure-helper ()
   "Return the executable used as the CLI editor command."
-  (let ((content (ai-code-editor-viewport--helper-content)))
+  (let* ((status-directory
+          (or (and ai-code-editor-viewport--helper-status-directory
+                   (file-directory-p
+                    ai-code-editor-viewport--helper-status-directory)
+                   ai-code-editor-viewport--helper-status-directory)
+              (file-name-as-directory
+               (file-truename temporary-file-directory))))
+         (content
+          (ai-code-editor-viewport--helper-content status-directory)))
     (unless (and ai-code-editor-viewport--helper-file
                  (file-executable-p ai-code-editor-viewport--helper-file)
                  (with-temp-buffer
                    (insert-file-contents ai-code-editor-viewport--helper-file)
                    (equal (buffer-string) content)))
       (ai-code-editor-viewport--cleanup-helper)
+      (setq ai-code-editor-viewport--helper-status-directory
+            status-directory)
       (setq ai-code-editor-viewport--helper-file
             (make-temp-file "ai-code-editor-"))
       (with-temp-file ai-code-editor-viewport--helper-file
         (insert content))
       (set-file-modes ai-code-editor-viewport--helper-file #o700))
+    (setq ai-code-editor-viewport--helper-status-directory
+          status-directory)
     ai-code-editor-viewport--helper-file))
 
 (add-hook 'kill-emacs-hook #'ai-code-editor-viewport--cleanup-helper)

--- a/ai-code-editor-viewport.el
+++ b/ai-code-editor-viewport.el
@@ -681,16 +681,19 @@ The plist records the response file, directory, submit intent, and arguments."
 
 (defun ai-code-editor-viewport--valid-status-file-p (file)
   "Return non-nil when FILE is a helper-created response file."
-  (and (stringp file)
-       (file-name-absolute-p file)
-       (file-regular-p file)
-       (not (file-symlink-p file))
-       (string-prefix-p "ai-code-editor-status-"
-                        (file-name-nondirectory file))
-       (file-in-directory-p
-        (file-truename file)
-        (file-name-as-directory
-         (file-truename temporary-file-directory)))))
+  (let ((status-directory
+         (or ai-code-editor-viewport--helper-status-directory
+             temporary-file-directory)))
+    (and (stringp file)
+         (file-name-absolute-p file)
+         (file-regular-p file)
+         (not (file-symlink-p file))
+         (string-prefix-p "ai-code-editor-status-"
+                          (file-name-nondirectory file))
+         (file-in-directory-p
+          (file-truename file)
+          (file-name-as-directory
+           (file-truename status-directory))))))
 
 (defun ai-code-editor-viewport--write-status
     (file status &optional submit-token)

--- a/test/test_ai-code-editor-viewport-transport.el
+++ b/test/test_ai-code-editor-viewport-transport.el
@@ -198,6 +198,7 @@
          (temporary-file-directory directory)
          (ai-code-editor-viewport-enabled t)
          (ai-code-editor-viewport--helper-file nil)
+         (ai-code-editor-viewport--helper-status-directory nil)
          environment
          editor)
     (unwind-protect
@@ -238,6 +239,7 @@
     (let* ((directory (make-temp-file "ai-code-editor-pty-" t))
            (temporary-file-directory directory)
            (ai-code-editor-viewport--helper-file nil)
+           (ai-code-editor-viewport--helper-status-directory nil)
            (environment (ai-code-editor-viewport-environment nil))
            (editor-command
             (split-string-shell-command
@@ -301,6 +303,7 @@
            (file (expand-file-name "draft.md" directory))
            (pid-file (expand-file-name "helper.pid" directory))
            (ai-code-editor-viewport--helper-file nil)
+           (ai-code-editor-viewport--helper-status-directory nil)
            (original-helper-content
             (symbol-function 'ai-code-editor-viewport--helper-content))
            environment
@@ -316,11 +319,12 @@
               (insert "draft"))
             (cl-letf (((symbol-function
                         'ai-code-editor-viewport--helper-content)
-                       (lambda ()
+                       (lambda (&optional status-directory)
                          (string-replace
                           "fi\nexit 0\n"
                           "fi\nsleep 1\nexit 0\n"
-                          (funcall original-helper-content)))))
+                          (funcall original-helper-content
+                                   status-directory)))))
               (setq environment (ai-code-editor-viewport-environment nil)))
             (setq editor-command
                   (split-string-shell-command

--- a/test/test_ai-code-editor-viewport.el
+++ b/test/test_ai-code-editor-viewport.el
@@ -634,10 +634,11 @@
         (delete-directory directory t)))))
 
 (ert-deftest test-ai-code-editor-viewport--valid-status-file-p-is-scoped ()
-  "Only regular helper status files in Emacs's temp directory are valid."
+  "Only regular files in the helper status directory should be valid."
   (let* ((directory (make-temp-file "ai-code-editor-status-dir-" t))
          (other-directory (make-temp-file "ai-code-editor-other-dir-" t))
          (temporary-file-directory directory)
+         (ai-code-editor-viewport--helper-status-directory directory)
          (valid-file (make-temp-file "ai-code-editor-status-"))
          (wrong-name (make-temp-file "unrelated-status-"))
          (outside-file
@@ -652,6 +653,32 @@
           (should-not
            (ai-code-editor-viewport--valid-status-file-p outside-file)))
       (delete-directory directory t)
+      (delete-directory other-directory t))))
+
+(ert-deftest test-ai-code-editor-viewport--status-file-survives-temp-dir-change ()
+  "A helper status file should remain valid when the active temp dir changes."
+  (let* ((helper-directory
+          (make-temp-file "ai-code-editor-helper-dir-" t))
+         (other-directory
+          (make-temp-file "ai-code-editor-other-dir-" t))
+         (ai-code-editor-viewport--helper-file nil)
+         (ai-code-editor-viewport--helper-status-directory nil)
+         helper-file
+         status-file)
+    (unwind-protect
+        (progn
+          (let ((temporary-file-directory helper-directory))
+            (setq helper-file (ai-code-editor-viewport--ensure-helper))
+            (setq status-file (make-temp-file "ai-code-editor-status-")))
+          (let ((temporary-file-directory other-directory))
+            (should (equal (ai-code-editor-viewport--ensure-helper)
+                           helper-file))
+            (ai-code-editor-viewport--write-status status-file 0))
+          (with-temp-buffer
+            (insert-file-contents status-file)
+            (should (equal (buffer-string) "0\n"))))
+      (ai-code-editor-viewport--cleanup-helper)
+      (delete-directory helper-directory t)
       (delete-directory other-directory t))))
 
 (ert-deftest test-ai-code-editor-viewport--display-defaults-below-source-window ()


### PR DESCRIPTION
## Summary

- keep the generated editor helper's status directory stable for its lifetime;
- validate response files against that helper-owned directory instead of the dynamically active `temporary-file-directory`;
- preserve the existing absolute-path, regular-file, filename-prefix, directory-scope, and non-symlink checks;
- add a regression test that changes the active temporary directory between helper creation and viewport submission.

## Root cause

The generated `$EDITOR` helper embeds a `mktemp` template using the value of `temporary-file-directory` at helper creation time. The helper is cached, but response validation previously read `temporary-file-directory` again when the viewport was submitted.

If that dynamically scoped value changed in the meantime, the helper still created a legitimate `ai-code-editor-status-*` file in its original directory while Emacs validated it against a different directory. Emacs then reported:

```text
AI Code editor response failed: Unsafe AI Code editor response file: .../ai-code-editor-status-*
```

The edited draft had already been saved, but the status response was not written, so the TUI treated the external editor as failed and did not restore the submitted text.

## Fix

`ai-code-editor-viewport--ensure-helper` now records the canonical status directory used to generate the cached helper. Both helper generation and response validation use that same directory until the helper is cleaned up. A missing stale directory is detected and rebuilt from the current temporary directory.

This changes only which trusted root is consulted; it does not relax the response-file safety checks.

## Verification

- regression test failed before the fix with the reported `Unsafe AI Code editor response file` error and passes after the fix;
- 1125 ERT tests: 1112 passed, 13 skipped, 0 unexpected;
- 47 focused viewport and transport tests passed, including real PTY round-trip and auto-submit lifecycle coverage;
- generated helper passed `/bin/sh -n` and ShellCheck;
- touched source files byte-compiled without new warnings;
- touched Lisp files passed checkdoc;
- `git diff --check` passed.

Follow-up to #440.
