### PR TITLE
Fix editor viewport placement and temporary recentf entries

### DIFF
--- a/ai-code-editor-viewport-transport.el
+++ b/ai-code-editor-viewport-transport.el
@@ -16,7 +16,8 @@
 (require 'subr-x)
 
 (declare-function ai-code-editor-viewport--open-request
-                  "ai-code-editor-viewport" (source-buffer payload))
+                  "ai-code-editor-viewport"
+                  (source-buffer payload &optional origin-frame))
 (declare-function ai-code-editor-viewport--schedule-submit
                   "ai-code-editor-viewport" (source-buffer))
 
@@ -42,6 +43,10 @@
 
 (defconst ai-code-editor-viewport--submit-ready-prefix "submit-ready:"
   "Prefix for completion payloads emitted after a helper is reaped.")
+
+(defconst ai-code-editor-viewport--request-version
+  "ai-code-editor-viewport-v1"
+  "Version marker for editor request payloads with explicit request kinds.")
 
 (defconst ai-code-editor-viewport--frame-prefix-environment-variable
   "AI_CODE_EDITOR_VIEWPORT_FRAME_PREFIX"
@@ -178,9 +183,10 @@ When TOKEN is nil, discard any pending token."
     (if (string-prefix-p ai-code-editor-viewport--submit-ready-prefix payload)
         (ai-code-editor-viewport--consume-submit-ready source-buffer payload)
       (ai-code-editor-viewport--discard-submit-token source-buffer)
-      (run-at-time 0 nil
-                   #'ai-code-editor-viewport--open-request
-                   source-buffer payload)
+      (let ((origin-frame (selected-frame)))
+        (run-at-time 0 nil
+                     #'ai-code-editor-viewport--open-request
+                     source-buffer payload origin-frame))
       t)))
 
 (defun ai-code-editor-viewport-filter-output (process output)
@@ -225,6 +231,9 @@ STATUS-DIRECTORY is where the helper creates its response files."
                                temporary-file-directory))))
     (concat
      "#!/bin/sh\n"
+     "request_kind=regular\n"
+     "[ \"${1-}\" = \"--ai-code-staging\" ]"
+     " && request_kind=staging && shift\n"
      "submit=0\n"
      "[ \"${1-}\" = \"--ai-code-submit\" ] && submit=1 && shift\n"
      "[ \"$#\" -gt 0 ] || exit 1\n"
@@ -239,6 +248,10 @@ STATUS-DIRECTORY is where the helper creates its response files."
      "    printf '%s\\0' \"$status_file\"\n"
      "    printf '%s\\0' \"${PWD-}\"\n"
      "    printf '%s\\0' \"$submit\"\n"
+     "    printf '%s\\0' \""
+     ai-code-editor-viewport--request-version
+     "\"\n"
+     "    printf '%s\\0' \"$request_kind\"\n"
      "    printf '%s\\0' \"$@\"\n"
      "  } | base64 | tr -d '\\r\\n'\n"
      ") || exit 1\n"
@@ -341,17 +354,18 @@ STATUS-DIRECTORY is where the helper creates its response files."
   "Return ENVIRONMENT configured to edit through a terminal viewport.
 FRAME-PREFIX, when non-nil, selects an adapter-specific terminal frame.
 General editor requests submit restored input when
-`ai-code-editor-viewport-auto-submit' is non-nil.  Git editor requests only
-save."
+`ai-code-editor-viewport-auto-submit' is non-nil.  They are marked as staging
+requests independently of submission.  Git editor requests only save."
   (if (or (not ai-code-editor-viewport-enabled)
           (not (ai-code-editor-viewport--supported-p)))
       environment
     (let* ((helper (ai-code-editor-viewport--ensure-helper))
            (helper-command (shell-quote-argument helper))
-           (submit-command (concat helper-command " --ai-code-submit"))
+           (staging-command (concat helper-command " --ai-code-staging"))
+           (submit-command (concat staging-command " --ai-code-submit"))
            (editor-command (if ai-code-editor-viewport-auto-submit
                                submit-command
-                             helper-command))
+                             staging-command))
            (prefix (or frame-prefix
                        (ai-code-editor-viewport--frame-prefix))))
       (append

--- a/ai-code-editor-viewport.el
+++ b/ai-code-editor-viewport.el
@@ -32,12 +32,33 @@
 
 (defcustom ai-code-editor-viewport-window-placement 'below
   "Where to display an editor viewport relative to its originating session.
-Use `below' to keep the session visible above the viewport.  Use `replace' to
-show the viewport in the originating session window.  If `below' cannot make
-room for another window, the editor request fails instead of replacing the
-session window."
-  :type '(choice (const :tag "Below the current window" below)
+Use `below' to prefer a viewport below the session.  When that is impossible,
+try a viewport on the right, then on the left, and temporarily replace the
+session window only as a last resort.  Use `replace' to always show the
+viewport in the session window."
+  :type '(choice (const :tag "Below, right/left, then replace" below)
                  (const :tag "Replace the session window" replace))
+  :group 'ai-code)
+
+(defcustom ai-code-editor-viewport-window-height 12
+  "Target total height of an editor viewport displayed below its session.
+Below placement is attempted only when the originating window is at least
+twice this many lines high."
+  :type 'integer
+  :group 'ai-code)
+
+(defcustom ai-code-editor-viewport-min-height 8
+  "Minimum acceptable total height of a viewport displayed below.
+If the resulting editor viewport is shorter than this many lines, restore the
+window layout and try a side placement instead."
+  :type 'integer
+  :group 'ai-code)
+
+(defcustom ai-code-editor-viewport-min-width 24
+  "Minimum acceptable width of each window in a side-by-side layout.
+If either the editor viewport or its originating session is narrower than this
+many columns, restore the window layout and try the next placement instead."
+  :type 'integer
   :group 'ai-code)
 
 (defcustom ai-code-editor-viewport-submit-delay 0.2
@@ -74,6 +95,8 @@ the input view before AI Code sends the return key."
 
 (defvar-local ai-code-editor-viewport-source-cursor-function nil
   "Function returning the live terminal cursor position for this source.")
+
+(defvar recentf-exclude)
 
 (defun ai-code-editor-viewport-source-buffer (&optional viewport)
   "Return VIEWPORT's associated live CLI session buffer.
@@ -224,10 +247,11 @@ column.  Return the source column where the draft line begins."
         match-column))))
 
 (defun ai-code-editor-viewport--disable-source-input
-    (source-buffer &optional draft cursor-offset)
+    (source-buffer &optional draft cursor-offset placement)
   "Visually disable the current input line in SOURCE-BUFFER.
 When DRAFT and CURSOR-OFFSET are available, use them to find the input
-boundary without assuming a particular TUI prompt format.
+boundary without assuming a particular TUI prompt format.  PLACEMENT is the
+actual viewport placement used for this edit.
 Return the temporary overlay, or nil when SOURCE-BUFFER is no longer live."
   (when (buffer-live-p source-buffer)
     (with-current-buffer source-buffer
@@ -297,11 +321,13 @@ Return the temporary overlay, or nil when SOURCE-BUFFER is no longer live."
                   (list 'ai-code-editor-viewport-source-hint-face
                         source-face))))
                (message-text
-                (format (if (eq ai-code-editor-viewport-window-placement
-                                'replace)
-                            " Editing in current window — %s"
-                          " Editing in viewport below — %s")
-                        (ai-code-editor-viewport--source-hint-message)))
+                (format
+                 (pcase (or placement
+                            ai-code-editor-viewport-window-placement)
+                   ('replace " Editing in current window — %s")
+                   ('side " Editing in viewport beside — %s")
+                   (_ " Editing in viewport below — %s"))
+                 (ai-code-editor-viewport--source-hint-message)))
                (message
                 (propertize
                  (concat message-text
@@ -346,84 +372,171 @@ Return the temporary overlay, or nil when SOURCE-BUFFER is no longer live."
     (select-window window)
     (list :window window
           :previous-buffer previous-buffer
-          :created-window nil)))
+          :created-window nil
+          :placement 'replace)))
 
-(defun ai-code-editor-viewport--next-side-slot (anchor-window)
-  "Return a side-window slot geometrically below ANCHOR-WINDOW."
-  (let* ((frame (window-frame anchor-window))
-         (side (window-parameter anchor-window 'window-side))
-         (anchor-slot (window-parameter anchor-window 'window-slot))
-         (slots
-          (seq-keep
-           (lambda (window)
-             (when (eq (window-parameter window 'window-side) side)
-               (let ((slot (window-parameter window 'window-slot)))
-                 (and (numberp slot) slot))))
-           (window-list frame 'nomini))))
-    (1+ (apply #'max (cons (if (numberp anchor-slot) anchor-slot 0)
-                           slots)))))
+(defun ai-code-editor-viewport--run-display-action
+    (buffer anchor-window action &optional alist)
+  "Run ACTION for BUFFER from ANCHOR-WINDOW using only ALIST.
+Use a fully local `display-buffer' action chain so external actions and alists
+cannot alter the placement or use another frame.  Return the resulting window,
+or nil when ACTION cannot display BUFFER."
+  (with-selected-window anchor-window
+    (let ((display-buffer-alist nil)
+          (display-buffer-base-action nil)
+          (display-buffer-fallback-action nil)
+          (display-buffer-overriding-action
+           (cons
+            (list action #'display-buffer-no-window)
+            (append alist
+                    '((allow-no-window . t)
+                      (inhibit-same-window . t))))))
+      (display-buffer buffer nil (window-frame anchor-window)))))
+
+(defun ai-code-editor-viewport--split-normal-window
+    (buffer anchor-window size direction)
+  "Split ANCHOR-WINDOW by SIZE in DIRECTION and display BUFFER normally."
+  (let* ((ignore-window-parameters t)
+         (window (split-window anchor-window size direction)))
+    (set-window-buffer window buffer)
+    window))
 
 (defun ai-code-editor-viewport--display-below-action (buffer anchor-window)
-  "Display BUFFER below ANCHOR-WINDOW and return the resulting window."
-  (let ((side (window-parameter anchor-window 'window-side)))
-    (with-selected-window anchor-window
-      (if (memq side '(left right))
-          (display-buffer
-           buffer
-           `((display-buffer-in-side-window)
-             (side . ,side)
-             (slot . ,(ai-code-editor-viewport--next-side-slot
-                       anchor-window))
-             (inhibit-same-window . t)))
-        (display-buffer
-         buffer
-         '((display-buffer-below-selected)
-           (inhibit-same-window . t)))))))
+  "Display BUFFER below ANCHOR-WINDOW and return the resulting window.
+Split lateral side windows directly so the new viewport is a normal window,
+not another same-side sibling that layout transposition can detach."
+  (if (memq (window-parameter anchor-window 'window-side) '(left right))
+      (ai-code-editor-viewport--split-normal-window
+       buffer anchor-window (- ai-code-editor-viewport-window-height) 'below)
+    (ai-code-editor-viewport--run-display-action
+     buffer anchor-window #'display-buffer-below-selected
+     `((window-height . ,ai-code-editor-viewport-window-height)
+       (window-min-height . ,ai-code-editor-viewport-min-height)))))
 
-(defun ai-code-editor-viewport--display-below (buffer anchor-window)
-  "Display BUFFER below ANCHOR-WINDOW and return its display state."
-  (let* ((windows-before
+(defun ai-code-editor-viewport--display-side-action
+    (direction buffer anchor-window)
+  "Display BUFFER from ANCHOR-WINDOW in DIRECTION and return its window.
+Use a normal directional window rather than another window with the same
+`window-side', since layout transposition can detach same-side siblings from
+their required common parent.  Let Emacs split available space evenly instead
+of forcing the viewport to its minimum acceptable width."
+  (let ((anchor-side (window-parameter anchor-window 'window-side)))
+    (if (memq anchor-side '(top bottom left right))
+        (ai-code-editor-viewport--split-normal-window
+         buffer anchor-window nil direction)
+      (ai-code-editor-viewport--run-display-action
+       buffer anchor-window #'display-buffer-in-direction
+       `((direction . ,direction)
+         (window-min-width . ,ai-code-editor-viewport-min-width))))))
+
+(defun ai-code-editor-viewport--window-below-p (window anchor-window)
+  "Return non-nil when WINDOW fits below ANCHOR-WINDOW."
+  (and (>= (nth 1 (window-edges window))
+           (nth 3 (window-edges anchor-window)))
+       (>= (window-total-height window)
+           ai-code-editor-viewport-min-height)
+       (>= (window-total-height anchor-window)
+           ai-code-editor-viewport-min-height)))
+
+(defun ai-code-editor-viewport--side-windows-usable-p (window anchor-window)
+  "Return non-nil when WINDOW and ANCHOR-WINDOW are both wide enough."
+  (and (>= (window-total-width window)
+           ai-code-editor-viewport-min-width)
+       (>= (window-total-width anchor-window)
+           ai-code-editor-viewport-min-width)))
+
+(defun ai-code-editor-viewport--window-right-p (window anchor-window)
+  "Return non-nil when WINDOW fits right of a usable ANCHOR-WINDOW."
+  (and (>= (nth 0 (window-edges window))
+           (nth 2 (window-edges anchor-window)))
+       (ai-code-editor-viewport--side-windows-usable-p
+        window anchor-window)))
+
+(defun ai-code-editor-viewport--window-left-p (window anchor-window)
+  "Return non-nil when WINDOW fits left of a usable ANCHOR-WINDOW."
+  (and (<= (nth 2 (window-edges window))
+           (nth 0 (window-edges anchor-window)))
+       (ai-code-editor-viewport--side-windows-usable-p
+        window anchor-window)))
+
+(defun ai-code-editor-viewport--try-display
+    (buffer anchor-window action placement geometry-predicate)
+  "Try displaying BUFFER from ANCHOR-WINDOW with ACTION.
+PLACEMENT identifies the attempted placement.  GEOMETRY-PREDICATE must accept
+the resulting window and ANCHOR-WINDOW and confirm the requested geometry.
+Return display state on success, or nil after undoing a failed attempt."
+  (let* ((window-configuration
+          (current-window-configuration (window-frame anchor-window)))
+         (windows-before
           (mapcar
            (lambda (window)
              (cons window (window-buffer window)))
            (window-list (window-frame anchor-window) 'nomini)))
-         (viewport-window
-          (ai-code-editor-viewport--display-below-action
-           buffer anchor-window)))
+         viewport-window)
+    (condition-case nil
+        (setq viewport-window (funcall action buffer anchor-window))
+      (error
+       (set-window-configuration window-configuration)))
     (let ((previous (and (window-live-p viewport-window)
                          (assq viewport-window windows-before))))
       (if (and (window-live-p viewport-window)
                (not (eq viewport-window anchor-window))
                (eq (window-frame viewport-window)
                    (window-frame anchor-window))
-               (>= (nth 1 (window-edges viewport-window))
-                   (nth 3 (window-edges anchor-window))))
+               (eq (window-buffer viewport-window) buffer)
+               (or (not (eq placement 'side))
+                   (not previous))
+               (or (not (eq placement 'side))
+                   (<= (abs (- (window-total-width viewport-window)
+                               (window-total-width anchor-window)))
+                       1))
+               (funcall geometry-predicate viewport-window anchor-window))
           (progn
             (select-window viewport-window)
             (list :window viewport-window
                   :previous-buffer (cdr previous)
-                  :created-window (not previous)))
-        (when (and (window-live-p viewport-window)
-                   (eq (window-frame viewport-window)
-                       (window-frame anchor-window))
-                   (eq (window-buffer viewport-window) buffer))
-          (if previous
-              (set-window-buffer viewport-window (cdr previous))
-            (quit-window nil viewport-window)))
-        (user-error
-         "Cannot display AI Code editor viewport below the current window")))))
+                  :created-window (not previous)
+                  :placement placement))
+        (set-window-configuration window-configuration)
+        nil))))
 
-(defun ai-code-editor-viewport--display (buffer source-buffer)
+(defun ai-code-editor-viewport--display-with-fallbacks (buffer anchor-window)
+  "Display BUFFER from ANCHOR-WINDOW using the default fallback chain."
+  (or (and (>= (window-total-height anchor-window)
+               (* 2 ai-code-editor-viewport-window-height))
+           (ai-code-editor-viewport--try-display
+            buffer anchor-window
+            #'ai-code-editor-viewport--display-below-action
+            'below #'ai-code-editor-viewport--window-below-p))
+      (ai-code-editor-viewport--try-display
+       buffer anchor-window
+       (apply-partially
+        #'ai-code-editor-viewport--display-side-action 'right)
+       'side #'ai-code-editor-viewport--window-right-p)
+      (ai-code-editor-viewport--try-display
+       buffer anchor-window
+       (apply-partially
+        #'ai-code-editor-viewport--display-side-action 'left)
+       'side #'ai-code-editor-viewport--window-left-p)
+      (ai-code-editor-viewport--replace-window buffer anchor-window)))
+
+(defun ai-code-editor-viewport--display
+    (buffer source-buffer &optional origin-frame)
   "Display BUFFER as a viewport associated with SOURCE-BUFFER.
+ORIGIN-FRAME is the frame selected when the editor request was dispatched.
 Return a plist that records the window and its previous buffer."
-  (let* ((source-window (and (buffer-live-p source-buffer)
-                             (get-buffer-window source-buffer t)))
+  (let* ((origin-frame (if (frame-live-p origin-frame)
+                           origin-frame
+                         (selected-frame)))
+         (source-window (and (buffer-live-p source-buffer)
+                             (get-buffer-window source-buffer origin-frame)))
          (anchor-window (if (window-live-p source-window)
                             source-window
-                          (selected-window))))
+                          (frame-selected-window origin-frame))))
     (pcase ai-code-editor-viewport-window-placement
       ('below
-       (ai-code-editor-viewport--display-below buffer anchor-window))
+       (ai-code-editor-viewport--display-with-fallbacks
+        buffer anchor-window))
       ('replace
        (ai-code-editor-viewport--replace-window buffer anchor-window))
       (_
@@ -439,11 +552,16 @@ Return a plist that records the window and its previous buffer."
                (eq (window-buffer window) buffer))
       (cond
        (created-window
-       (quit-window nil window))
+        ;; Delete the exact viewport even after layout transposition moves it
+        ;; beside a side window, where `quit-window' may only change its buffer.
+        (let ((ignore-window-parameters t))
+          (if (eq (window-deletable-p window) t)
+              (delete-window window)
+            (quit-window nil window))))
        ((buffer-live-p previous-buffer)
         (set-window-buffer window previous-buffer))
-        (t
-         (quit-window nil window))))))
+       (t
+        (quit-window nil window))))))
 
 (defun ai-code-editor-viewport--buffer-text (buffer)
   "Return BUFFER's accessible text without properties."
@@ -538,10 +656,30 @@ Return a plist that records the window and its previous buffer."
               (ai-code-editor-viewport--draft-cursor-offset-at-source
                visible-draft cursor-position))))))))
 
-(defun ai-code-editor-viewport--make-buffer (file source-buffer)
-  "Return per-request editing state for FILE and SOURCE-BUFFER."
+(defmacro ai-code-editor-viewport--without-recentf-file (file &rest body)
+  "Run BODY without allowing `recentf' to record FILE."
+  (declare (indent 1) (debug (form body)))
+  (let ((excluded-file (make-symbol "excluded-file"))
+        (candidate (make-symbol "candidate")))
+    `(let* ((,excluded-file ,file)
+            (recentf-exclude
+             (cons
+              (lambda (,candidate)
+                (file-equal-p ,candidate ,excluded-file))
+              (and (boundp 'recentf-exclude) recentf-exclude))))
+       ,@body)))
+
+(defun ai-code-editor-viewport--make-buffer
+    (file source-buffer &optional staging-file-p)
+  "Return per-request editing state for FILE and SOURCE-BUFFER.
+When STAGING-FILE-P is non-nil, keep FILE out of `recentf'."
   (let* ((existing-base-buffer (find-buffer-visiting file))
-         (base-buffer (or existing-base-buffer (find-file-noselect file)))
+         (base-buffer
+          (or existing-base-buffer
+              (if staging-file-p
+                  (ai-code-editor-viewport--without-recentf-file file
+                    (find-file-noselect file))
+                (find-file-noselect file))))
          (owned-base-buffer (unless existing-base-buffer base-buffer))
          (snapshot (ai-code-editor-viewport--buffer-text base-buffer))
          (name (generate-new-buffer-name
@@ -567,8 +705,9 @@ Return a plist that records the window and its previous buffer."
           :snapshot snapshot)))
 
 (defun ai-code-editor-viewport--commit-buffer
-    (base-buffer viewport-buffer snapshot)
-  "Save VIEWPORT-BUFFER changes to BASE-BUFFER if it still matches SNAPSHOT."
+    (base-buffer viewport-buffer snapshot &optional staging-file-p)
+  "Save VIEWPORT-BUFFER changes to BASE-BUFFER if it still matches SNAPSHOT.
+When STAGING-FILE-P is non-nil, keep the saved file out of `recentf'."
   (unless (buffer-live-p base-buffer)
     (user-error "The file buffer was closed while its viewport was active"))
   (unless (equal snapshot
@@ -587,16 +726,23 @@ Return a plist that records the window and its previous buffer."
               (widen)
               (erase-buffer)
               (insert contents))
-            (save-buffer)
+            (if staging-file-p
+                (ai-code-editor-viewport--without-recentf-file buffer-file-name
+                  (save-buffer))
+              (save-buffer))
             (accept-change-group change-group)
             (setq change-group nil))
         (when change-group
           (cancel-change-group change-group))))))
 
-(defun ai-code-editor-viewport--edit-file (file source-buffer &optional line column)
+(defun ai-code-editor-viewport--edit-file
+    (file source-buffer &optional line column origin-frame staging-file-p)
   "Edit FILE in a viewport associated with SOURCE-BUFFER.
-LINE is one-based and COLUMN is zero-based, matching editor arguments."
-  (let* ((state (ai-code-editor-viewport--make-buffer file source-buffer))
+LINE is one-based and COLUMN is zero-based, matching editor arguments.
+ORIGIN-FRAME preserves the request's frame across deferred handling.  When
+STAGING-FILE-P is non-nil, keep FILE out of `recentf'."
+  (let* ((state (ai-code-editor-viewport--make-buffer
+                 file source-buffer staging-file-p))
          (base-buffer (plist-get state :base-buffer))
          (owned-base-buffer (plist-get state :owned-base-buffer))
          (buffer (plist-get state :viewport-buffer))
@@ -622,16 +768,18 @@ LINE is one-based and COLUMN is zero-based, matching editor arguments."
              (min (point-max)
                   (+ (point-min) source-cursor-offset)))))
           (setq display-state
-                (ai-code-editor-viewport--display buffer source-buffer))
+                (ai-code-editor-viewport--display
+                 buffer source-buffer origin-frame))
           (unwind-protect
               (progn
                 (setq source-input-overlay
                       (ai-code-editor-viewport--disable-source-input
-                       source-buffer snapshot source-cursor-offset))
+                       source-buffer snapshot source-cursor-offset
+                       (plist-get display-state :placement)))
                 (recursive-edit)
                 (when (eq ai-code-editor-viewport--outcome 'finished)
                   (ai-code-editor-viewport--commit-buffer
-                   base-buffer buffer snapshot)
+                   base-buffer buffer snapshot staging-file-p)
                   (setq finished t)))
             (when (overlayp source-input-overlay)
               (delete-overlay source-input-overlay))
@@ -673,26 +821,37 @@ Return plists containing :file, :line, and :column entries."
               next-column nil))))
     (nreverse files)))
 
-(defun ai-code-editor-viewport--edit-files (source-buffer directory file-arguments)
+(defun ai-code-editor-viewport--edit-files
+    (source-buffer directory file-arguments
+                   &optional origin-frame staging-request-p)
   "Edit FILE-ARGUMENTS for SOURCE-BUFFER relative to DIRECTORY.
+ORIGIN-FRAME preserves the request's frame across deferred handling.  When
+STAGING-REQUEST-P is non-nil, keep only requested files inside the directory
+named by variable `temporary-file-directory' out of `recentf'.
 Return non-nil only when every file was saved and finished."
   (when-let* ((files
                (ai-code-editor-viewport--parse-file-arguments
                 directory file-arguments)))
     (cl-every
      (lambda (file-request)
-       (ai-code-editor-viewport--edit-file
-        (plist-get file-request :file)
-        source-buffer
-        (plist-get file-request :line)
-        (plist-get file-request :column)))
+       (let* ((file (plist-get file-request :file))
+              (staging-file-p
+               (and staging-request-p
+                    (file-in-directory-p
+                     file temporary-file-directory))))
+         (ai-code-editor-viewport--edit-file
+          file source-buffer
+          (plist-get file-request :line)
+          (plist-get file-request :column)
+          origin-frame staging-file-p)))
      files)))
 
 ;;;; Terminal request protocol
 
 (defun ai-code-editor-viewport--decode-request (payload)
   "Decode terminal editor PAYLOAD into a request plist.
-The plist records the response file, directory, submit intent, and arguments."
+The plist records the response file, directory, submit and staging intent,
+and editor arguments."
   (let* ((decoded
           (decode-coding-string
            (base64-decode-string payload)
@@ -705,10 +864,25 @@ The plist records the response file, directory, submit intent, and arguments."
       (error "Malformed AI Code editor request"))
     (unless (member (nth 2 fields) '("0" "1"))
       (error "Invalid AI Code editor submit intent"))
-    (list :status-file (nth 0 fields)
-          :directory (nth 1 fields)
-          :submit-p (string= (nth 2 fields) "1")
-          :arguments (nthcdr 3 fields))))
+    (let* ((versioned-request-p
+            (equal (nth 3 fields)
+                   ai-code-editor-viewport--request-version))
+           (request-kind (and versioned-request-p (nth 4 fields))))
+      (when (and versioned-request-p
+                 (not (member request-kind '("regular" "staging"))))
+        (error "Invalid AI Code editor request kind"))
+      (list :status-file (nth 0 fields)
+            :directory (nth 1 fields)
+            :submit-p (string= (nth 2 fields) "1")
+            :staging-request-p
+            (if versioned-request-p
+                (equal request-kind "staging")
+              ;; Old helpers only distinguished general editor requests by
+              ;; their submit intent; preserve staging hygiene for those.
+              (string= (nth 2 fields) "1"))
+            ;; Accept payloads from helpers generated before versioned request
+            ;; kinds were added.  Newly generated helpers are explicit.
+            :arguments (nthcdr (if versioned-request-p 5 3) fields)))))
 
 (defun ai-code-editor-viewport--valid-status-file-p (file)
   "Return non-nil when FILE is a helper-created response file."
@@ -775,10 +949,11 @@ The plist records the response file, directory, submit intent, and arguments."
                  #'ai-code-editor-viewport--submit-source-buffer
                  source-buffer)))
 
-(defun ai-code-editor-viewport--open-request (source-buffer payload)
+(defun ai-code-editor-viewport--open-request
+    (source-buffer payload &optional origin-frame)
   "Open terminal editor PAYLOAD for SOURCE-BUFFER in a viewport.
 PAYLOAD contains a response file, working directory, submit intent, and
-editor arguments.
+editor arguments.  ORIGIN-FRAME is the frame selected at dispatch time.
 Return non-nil after saving every requested file."
   (let (status-file completed succeeded submit-p submit-token)
     (unwind-protect
@@ -794,7 +969,8 @@ Return non-nil after saving every requested file."
               (setq status-file (plist-get request :status-file))
               (setq succeeded
                     (ai-code-editor-viewport--edit-files
-                     source-buffer directory arguments))
+                     source-buffer directory arguments origin-frame
+                     (plist-get request :staging-request-p)))
               (setq submit-p
                     (and (plist-get request :submit-p)
                          succeeded

--- a/test/test_ai-code-editor-viewport-transport.el
+++ b/test/test_ai-code-editor-viewport-transport.el
@@ -35,8 +35,8 @@
         (ai-code-editor-viewport-environment
          '("TERM_PROGRAM=emacs" "EDITOR=vim" "VISUAL=nano"
            "GIT_EDITOR=vi" "GIT_SEQUENCE_EDITOR=vim"))
-        '("EDITOR=/tmp/ai-code-editor-helper --ai-code-submit"
-          "VISUAL=/tmp/ai-code-editor-helper --ai-code-submit"
+        '("EDITOR=/tmp/ai-code-editor-helper --ai-code-staging --ai-code-submit"
+          "VISUAL=/tmp/ai-code-editor-helper --ai-code-staging --ai-code-submit"
           "GIT_EDITOR=/tmp/ai-code-editor-helper"
           "GIT_SEQUENCE_EDITOR=/tmp/ai-code-editor-helper"
           "AI_CODE_EDITOR_VIEWPORT_FRAME_PREFIX=\e]6973;ai-code-editor;test-token;"
@@ -54,8 +54,8 @@
       (should
        (equal
         (seq-take (ai-code-editor-viewport-environment nil) 4)
-        '("EDITOR=/tmp/ai-code-editor-helper"
-          "VISUAL=/tmp/ai-code-editor-helper"
+        '("EDITOR=/tmp/ai-code-editor-helper --ai-code-staging"
+          "VISUAL=/tmp/ai-code-editor-helper --ai-code-staging"
           "GIT_EDITOR=/tmp/ai-code-editor-helper"
           "GIT_SEQUENCE_EDITOR=/tmp/ai-code-editor-helper"))))))
 
@@ -75,11 +75,26 @@
     (should
      (string-match-p
       (regexp-quote
+       "[ \"${1-}\" = \"--ai-code-staging\" ] && request_kind=staging && shift")
+      content))
+    (should
+     (string-match-p
+      (regexp-quote
        "[ \"${1-}\" = \"--ai-code-submit\" ] && submit=1 && shift")
       content))
     (should
      (string-match-p
       (regexp-quote "printf '%s\\0' \"$submit\"")
+      content))
+    (should
+     (string-match-p
+      (regexp-quote
+       (format "printf '%%s\\0' \"%s\""
+               ai-code-editor-viewport--request-version))
+      content))
+    (should
+     (string-match-p
+      (regexp-quote "printf '%s\\0' \"$request_kind\"")
       content))
     (should
      (string-match-p
@@ -128,6 +143,7 @@
   "Adapter requests should require the session token before opening a viewport."
   (with-temp-buffer
     (let ((source-buffer (current-buffer))
+          (origin-frame (selected-frame))
           (ai-code-editor-viewport--protocol-token "test-token")
           (ai-code-editor-viewport--pending-submit-token "old-submit-token")
           scheduled)
@@ -148,7 +164,7 @@
         (should
          (equal scheduled
                 `((ai-code-editor-viewport--open-request
-                   ,source-buffer "PAYLOAD"))))))))
+                   ,source-buffer "PAYLOAD" ,origin-frame))))))))
 
 (ert-deftest test-ai-code-editor-viewport-transport--handle-request-rejects-oversized-payload ()
   "Adapter requests over the protocol limit should not be scheduled."
@@ -250,11 +266,12 @@
            visible-output)
       (unwind-protect
           (cl-letf (((symbol-function 'ai-code-editor-viewport--open-request)
-                     (lambda (buffer payload)
+                     (lambda (buffer payload &optional origin-frame)
                        (setq request
                              (list buffer
                                    (ai-code-editor-viewport--decode-request
-                                    payload)))
+                                    payload)
+                                   origin-frame))
                        (ai-code-editor-viewport--write-status
                         (plist-get (cadr request) :status-file) 0)
                        t)))
@@ -279,7 +296,9 @@
             (should (eq (process-status process) 'exit))
             (should (= (process-exit-status process) 0))
             (should (eq (car request) source-buffer))
+            (should (eq (nth 2 request) (selected-frame)))
             (should (eq (plist-get (cadr request) :submit-p) t))
+            (should (eq (plist-get (cadr request) :staging-request-p) t))
             (should
              (equal
               (list (plist-get (cadr request) :directory)
@@ -389,6 +408,7 @@
   (with-temp-buffer
     (let ((ai-code-editor-viewport--protocol-token "test-token")
           (source-buffer (current-buffer))
+          (origin-frame (selected-frame))
           scheduled)
       (cl-letf (((symbol-function 'process-buffer)
                  (lambda (_process) source-buffer))
@@ -419,9 +439,9 @@
          (equal
           (nreverse scheduled)
           `((ai-code-editor-viewport--open-request
-             ,source-buffer "PAYLOAD")
+             ,source-buffer "PAYLOAD" ,origin-frame)
             (ai-code-editor-viewport--open-request
-             ,source-buffer "TWO"))))))))
+             ,source-buffer "TWO" ,origin-frame))))))))
 
 (ert-deftest test-ai-code-editor-viewport-transport--filter-output-discards-oversized-request ()
   "A complete editor request over the configured limit should not be opened."

--- a/test/test_ai-code-editor-viewport.el
+++ b/test/test_ai-code-editor-viewport.el
@@ -11,7 +11,10 @@
 
 (require 'ert)
 (require 'cl-lib)
+(require 'recentf)
 (require 'ai-code-editor-viewport)
+
+(declare-function window-layout-transpose "window-x" (&optional window))
 
 (cl-defmacro ai-code-editor-viewport-test--with-buffer
     ((buffer name) &rest body)
@@ -21,6 +24,42 @@
      (rename-buffer (generate-new-buffer-name ,name))
      (let ((,buffer (current-buffer)))
        ,@body)))
+
+(defun ai-code-editor-viewport-test--display-from-lateral-side
+    (side source-buffer viewport-buffer &optional width)
+  "Display VIEWPORT-BUFFER from a SIDE SOURCE-BUFFER fixture.
+Give the source side window WIDTH columns, defaulting to 40."
+  (let* ((ai-code-editor-viewport-window-placement 'below)
+         (window-sides-slots '(nil nil nil nil))
+         (source-window
+          (display-buffer-in-side-window
+           source-buffer
+           `((side . ,side)
+             (slot . 0)
+             (window-width . ,(or width 40))
+             (preserve-size . (t . nil))
+             (window-parameters
+              . ((no-delete-other-windows . t)
+                 (window-size-fixed . width))))))
+         (source-height (window-total-height source-window))
+         (source-width (window-total-width source-window))
+         (main-window (window-main-window))
+         (main-buffer (window-buffer main-window))
+         (display-state
+          (ai-code-editor-viewport--display viewport-buffer source-buffer)))
+    (list :source-window source-window
+          :source-height source-height
+          :source-width source-width
+          :main-window main-window
+          :main-buffer main-buffer
+          :display-state display-state
+          :viewport-window (plist-get display-state :window))))
+
+(defun ai-code-editor-viewport-test--transpose-parent-if-supported (window)
+  "Transpose WINDOW's parent when the current Emacs provides `window-x'."
+  (when (require 'window-x nil t)
+    (let ((ignore-window-parameters t))
+      (window-layout-transpose (window-parent window)))))
 
 (ert-deftest test-ai-code-editor-viewport--mode-uses-one-yank-key ()
   "Viewport users should paste every supported clipboard type with `C-y'."
@@ -224,6 +263,96 @@
           (kill-buffer buffer))
         (delete-directory directory t)))))
 
+(defun ai-code-editor-viewport-test--temporary-file-recorded-in-recentf-p
+    (finish-p staging-request-p &optional project-file-p)
+  "Return non-nil when an editor file enters `recentf'.
+When FINISH-P is non-nil, finish and save the edit; otherwise cancel it.
+STAGING-REQUEST-P is the request's explicit staging marker.  When
+PROJECT-FILE-P is non-nil, place the file outside the configured temporary
+directory."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-recentf-source*")
+    (let* ((root (make-temp-file "ai-code-editor-recentf-" t))
+           (staging-directory (expand-file-name "staging/" root))
+           (project-directory (expand-file-name "project/" root))
+           (_ (make-directory staging-directory))
+           (_ (make-directory project-directory))
+           (temporary-file-directory
+            (file-name-as-directory staging-directory))
+           (directory (if project-file-p
+                          project-directory
+                        staging-directory))
+           (file (expand-file-name ".tmpABC123.md" directory))
+           (recentf-list nil)
+           (find-file-hook
+            (cons #'recentf-track-opened-file find-file-hook))
+           (write-file-functions
+            (if finish-p
+                (cons #'recentf-track-opened-file write-file-functions)
+              write-file-functions)))
+      (unwind-protect
+          (progn
+            (with-temp-file file
+              (insert "draft"))
+            (cl-letf (((symbol-function 'ai-code-editor-viewport--display)
+                       (lambda (&rest _args) nil))
+                      ((symbol-function 'recursive-edit)
+                       (lambda ()
+                         (if finish-p
+                             (ai-code-editor-viewport-finish)
+                           (ai-code-editor-viewport-cancel))))
+                      ((symbol-function 'exit-recursive-edit)
+                       (lambda () nil)))
+              (should
+               (eq (not (null
+                         (ai-code-editor-viewport--edit-files
+                          source-buffer directory (list file)
+                          nil staging-request-p)))
+                   finish-p)))
+            (member (file-truename file)
+                    (mapcar #'file-truename recentf-list)))
+        (when-let* ((buffer (get-file-buffer file)))
+          (kill-buffer buffer))
+        (delete-directory root t)))))
+
+(ert-deftest test-ai-code-editor-viewport--edit-files-excludes-temporary-file-from-recentf ()
+  "Canceling a temporary editor file should not record it in `recentf'."
+  (should-not
+   (ai-code-editor-viewport-test--temporary-file-recorded-in-recentf-p
+    nil t)))
+
+(ert-deftest test-ai-code-editor-viewport--edit-files-keeps-saved-temporary-file-out-of-recentf ()
+  "Saving a temporary editor file should not record it in `recentf'."
+  (should-not
+   (ai-code-editor-viewport-test--temporary-file-recorded-in-recentf-p
+    t t)))
+
+(ert-deftest test-ai-code-editor-viewport--edit-files-records-normal-file-in-recentf ()
+  "A normal file opened through the viewport should still enter `recentf'."
+  (should
+   (ai-code-editor-viewport-test--temporary-file-recorded-in-recentf-p
+    nil nil)))
+
+(ert-deftest test-ai-code-editor-viewport--staging-request-records-project-file ()
+  "A project file should enter `recentf' even for a staging request."
+  (should
+   (ai-code-editor-viewport-test--temporary-file-recorded-in-recentf-p
+    nil t t)))
+
+(ert-deftest test-ai-code-editor-viewport--without-recentf-file-preserves-bindings ()
+  "The recentf guard should preserve caller bindings and exclusions."
+  (let* ((excluded-file 'caller-value)
+         (original-exclusions (list "keep-this-exclusion"))
+         (recentf-exclude original-exclusions)
+         exclusions-inside)
+    (should
+     (eq (ai-code-editor-viewport--without-recentf-file "ignored-file"
+           (setq exclusions-inside recentf-exclude)
+           excluded-file)
+         'caller-value))
+    (should (eq (cdr exclusions-inside) original-exclusions))
+    (should (eq recentf-exclude original-exclusions))))
+
 (ert-deftest test-ai-code-editor-viewport--edit-files-disables-source-input ()
   "An active viewport should replace the source input only visually."
   (ai-code-editor-viewport-test--with-buffer
@@ -339,6 +468,25 @@
                    " C-c C-c: submit, C-g/C-c C-k: cancel")))
         (delete-overlay overlay)))))
 
+(ert-deftest test-ai-code-editor-viewport--disable-source-input-describes-side-window ()
+  "The source hint should describe a viewport beside its source window."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*codex[side hint]*")
+    (insert "› prompt")
+    (goto-char (point-min))
+    (forward-char 2)
+    (let* ((overlay
+            (ai-code-editor-viewport--disable-source-input
+             source-buffer nil nil 'side))
+           (display (get-char-property (point) 'display)))
+      (unwind-protect
+          (should
+           (equal (substring-no-properties display)
+                  (concat
+                   " Editing in viewport beside —"
+                   " C-c C-c: submit, C-g/C-c C-k: cancel")))
+        (delete-overlay overlay)))))
+
 (ert-deftest test-ai-code-editor-viewport--disable-source-input-uses-current-bindings ()
   "The source hint should reflect the viewport mode's current bindings."
   (ai-code-editor-viewport-test--with-buffer
@@ -401,27 +549,68 @@
     (let* ((status-file (make-temp-file "ai-code-editor-status-"))
            (directory "/tmp/project with spaces/")
            (arguments '("+12:3" "draft's prompt.md"))
-           (fields (append (list status-file directory "1") arguments))
+           (fields
+            (append
+             (list status-file directory "1"
+                   ai-code-editor-viewport--request-version "staging")
+             arguments))
            (payload
             (base64-encode-string
              (concat (mapconcat #'identity fields "\0") "\0")
              t))
+           (origin-frame (selected-frame))
            captured)
       (unwind-protect
           (cl-letf (((symbol-function 'ai-code-editor-viewport--edit-files)
-                     (lambda (source seen-directory seen-arguments)
+                     (lambda (source seen-directory seen-arguments
+                              &optional seen-frame staging-request-p)
                        (setq captured
-                             (list source seen-directory seen-arguments))
+                             (list source seen-directory seen-arguments
+                                   seen-frame staging-request-p))
                        t)))
             (should (ai-code-editor-viewport--open-request
-                     source-buffer payload))
+                     source-buffer payload origin-frame))
             (should (equal captured
-                           (list source-buffer directory arguments)))
+                           (list source-buffer directory arguments
+                                 origin-frame t)))
             (with-temp-buffer
               (insert-file-contents status-file)
               (should (equal (buffer-string) "0\n"))))
         (when (file-exists-p status-file)
           (delete-file status-file))))))
+
+(ert-deftest test-ai-code-editor-viewport--decode-request-accepts-legacy-staging-name ()
+  "An old payload may use `staging' as an ordinary first file name."
+  (let* ((fields '("/tmp/status" "/tmp/project" "0" "staging"))
+         (payload
+          (base64-encode-string
+           (concat (mapconcat #'identity fields "\0") "\0") t))
+         (request (ai-code-editor-viewport--decode-request payload)))
+    (should-not (plist-get request :staging-request-p))
+    (should (equal (plist-get request :arguments) '("staging")))))
+
+(ert-deftest test-ai-code-editor-viewport--decode-request-preserves-legacy-staging ()
+  "An old submitting helper should retain staging-file hygiene."
+  (let* ((fields '("/tmp/status" "/tmp/project" "1" "prompt.md"))
+         (payload
+          (base64-encode-string
+           (concat (mapconcat #'identity fields "\0") "\0") t))
+         (request (ai-code-editor-viewport--decode-request payload)))
+    (should (plist-get request :staging-request-p))
+    (should (equal (plist-get request :arguments) '("prompt.md")))))
+
+(ert-deftest test-ai-code-editor-viewport--decode-request-rejects-invalid-kind ()
+  "A versioned payload should reject an unknown request kind."
+  (let* ((fields
+          (list "/tmp/status" "/tmp/project" "0"
+                ai-code-editor-viewport--request-version "unknown"
+                "prompt.md"))
+         (payload
+          (base64-encode-string
+           (concat (mapconcat #'identity fields "\0") "\0") t)))
+    (should-error
+     (ai-code-editor-viewport--decode-request payload)
+     :type 'error)))
 
 (ert-deftest test-ai-code-editor-viewport--open-request-finish-requests-submit ()
   "Finishing should tell the helper to submit after releasing the terminal."
@@ -681,70 +870,460 @@
       (delete-directory helper-directory t)
       (delete-directory other-directory t))))
 
+(ert-deftest test-ai-code-editor-viewport--try-display-rejects-reused-side-window ()
+  "Side placement should create a window instead of reusing a neighbor."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-reuse-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (neighbor-buffer "*ai-code-editor-reuse-neighbor*")
+      (ai-code-editor-viewport-test--with-buffer
+          (viewport-buffer "*ai-code-editor-reuse-viewport*")
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer source-buffer)
+          (let* ((anchor-window (selected-window))
+                 (neighbor-window (split-window-right)))
+            (set-window-buffer neighbor-window neighbor-buffer)
+            (should-not
+             (ai-code-editor-viewport--try-display
+              viewport-buffer anchor-window
+              (lambda (buffer _anchor)
+                (set-window-buffer neighbor-window buffer)
+                neighbor-window)
+              'side #'ai-code-editor-viewport--window-right-p))
+            (should (window-live-p neighbor-window))
+            (should (eq (window-buffer neighbor-window) neighbor-buffer))
+            (should-not (get-buffer-window viewport-buffer t))))))))
+
+(ert-deftest test-ai-code-editor-viewport--try-display-rejects-unbalanced-side-window ()
+  "Side placement should reject a newly split but unbalanced layout."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-unbalanced-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-unbalanced-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (switch-to-buffer source-buffer)
+        (let* ((anchor-window (selected-window))
+               (minimum-width ai-code-editor-viewport-min-width))
+          (should (>= (window-total-width anchor-window)
+                      (+ (* 2 minimum-width) 2)))
+          (should-not
+           (ai-code-editor-viewport--try-display
+            viewport-buffer anchor-window
+            (lambda (buffer anchor)
+              (ai-code-editor-viewport--split-normal-window
+               buffer anchor minimum-width 'right))
+            'side #'ai-code-editor-viewport--window-right-p))
+          (should (= (length (window-list)) 1))
+          (should (eq (window-buffer anchor-window) source-buffer))
+          (should-not (get-buffer-window viewport-buffer t)))))))
+
 (ert-deftest test-ai-code-editor-viewport--display-defaults-below-source-window ()
-  "A viewport should open below its visible source window by default."
+  "The default setup should prefer a viewport below the source window."
   (should (eq (default-value 'ai-code-editor-viewport-window-placement)
               'below))
   (ai-code-editor-viewport-test--with-buffer
       (source-buffer "*ai-code-editor-below-source*")
     (ai-code-editor-viewport-test--with-buffer
         (viewport-buffer "*ai-code-editor-below-viewport*")
+      (ai-code-editor-viewport-test--with-buffer
+          (other-buffer "*ai-code-editor-below-other*")
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer source-buffer)
+          (let* ((source-window (selected-window))
+                 (other-window (split-window-right))
+                 (source-height (window-total-height source-window)))
+            (set-window-buffer other-window other-buffer)
+            (let* ((ai-code-editor-viewport-window-height
+                    (/ source-height 2))
+                   (display-state
+                    (ai-code-editor-viewport--display
+                     viewport-buffer source-buffer))
+                   (viewport-window (plist-get display-state :window)))
+              (should (window-live-p viewport-window))
+              (should-not (eq viewport-window source-window))
+              (should (eq (plist-get display-state :placement) 'below))
+              (should (eq (window-buffer source-window) source-buffer))
+              (should (eq (window-buffer viewport-window) viewport-buffer))
+              (should (>= (window-total-height source-window)
+                          ai-code-editor-viewport-min-height))
+              (should (>= (window-total-height viewport-window)
+                          ai-code-editor-viewport-min-height))
+              (should (= (window-total-height viewport-window)
+                         ai-code-editor-viewport-window-height))
+              (should (>= (nth 1 (window-edges viewport-window))
+                          (nth 3 (window-edges source-window))))
+              (should (= (length (window-list)) 3))
+              (ai-code-editor-viewport--restore-window
+               display-state viewport-buffer)
+              (should (= (length (window-list)) 2))
+              (should (eq (window-buffer source-window) source-buffer))
+              (should (eq (window-buffer other-window) other-buffer))
+              (should (eq (selected-window) source-window))
+              (should-not (get-buffer-window viewport-buffer t)))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-defaults-to-usable-dimensions ()
+  "Viewport placement should default to usable minimum dimensions."
+  (should (= (default-value 'ai-code-editor-viewport-window-height) 12))
+  (should (= (* 2 (default-value 'ai-code-editor-viewport-window-height)) 24))
+  (should (= (default-value 'ai-code-editor-viewport-min-height) 8))
+  (should (= (default-value 'ai-code-editor-viewport-min-width) 24)))
+
+(ert-deftest test-ai-code-editor-viewport--display-accepts-eight-line-minimum ()
+  "Below placement should accept eight lines but reject seven."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-min-height-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-min-height-viewport*")
+      (dolist (height '(7 8))
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer source-buffer)
+          (let* ((source-height (window-total-height))
+                 (ai-code-editor-viewport-window-height
+                  (/ source-height 2))
+                 (ai-code-editor-viewport-min-width 20)
+                 display-state)
+            (cl-letf
+                (((symbol-function
+                   'ai-code-editor-viewport--display-below-action)
+                  (lambda (buffer anchor-window)
+                    (let ((window
+                           (split-window anchor-window (- height) 'below)))
+                      (set-window-buffer window buffer)
+                      window))))
+              (setq display-state
+                    (ai-code-editor-viewport--display
+                     viewport-buffer source-buffer)))
+            (if (= height 8)
+                (should (eq (plist-get display-state :placement) 'below))
+              (should-not (eq (plist-get display-state :placement) 'below)))
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-uses-side-for-short-window ()
+  "A ten-line source should preserve its height with a side viewport."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-short-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-short-viewport*")
+      (ai-code-editor-viewport-test--with-buffer
+          (other-buffer "*ai-code-editor-short-other*")
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer source-buffer)
+          (let* ((source-window (selected-window))
+                 (other-window (split-window source-window 10 'below)))
+            (set-window-buffer other-window other-buffer)
+            (should (= (window-total-height source-window) 10))
+            (let* ((display-state
+                    (ai-code-editor-viewport--display
+                     viewport-buffer source-buffer))
+                   (viewport-window (plist-get display-state :window)))
+              (should (eq (plist-get display-state :placement) 'side))
+              (should (>= (window-total-width source-window) 24))
+              (should (>= (window-total-width viewport-window) 24))
+              (should (<= (abs (- (window-total-width source-window)
+                                  (window-total-width viewport-window)))
+                          1))
+              (should (= (window-total-height source-window) 10))
+              (should (= (window-total-height viewport-window) 10))
+              (ai-code-editor-viewport--restore-window
+               display-state viewport-buffer)
+              (should (window-live-p source-window))
+              (should (window-live-p other-window))
+              (should-not (get-buffer-window viewport-buffer t)))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-replaces-narrow-source ()
+  "Side placement should not squeeze a narrow source to make the viewport fit."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-narrow-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-narrow-viewport*")
+      (ai-code-editor-viewport-test--with-buffer
+          (other-buffer "*ai-code-editor-narrow-other*")
+        (save-window-excursion
+          (delete-other-windows)
+          (switch-to-buffer source-buffer)
+          (let* ((source-window (selected-window))
+                 (right-window (split-window source-window 33 'right))
+                 (bottom-window (split-window source-window 10 'below)))
+            (set-window-buffer right-window other-buffer)
+            (set-window-buffer bottom-window other-buffer)
+            (let* ((display-state
+                    (ai-code-editor-viewport--display
+                     viewport-buffer source-buffer))
+                   (viewport-window (plist-get display-state :window)))
+              (should (eq (plist-get display-state :placement) 'replace))
+              (should (eq viewport-window source-window))
+              (should (= (window-total-width source-window) 33))
+              (should (eq (window-buffer source-window) viewport-buffer))
+              (should (eq (window-buffer right-window) other-buffer))
+              (should (eq (window-buffer bottom-window) other-buffer))
+              (ai-code-editor-viewport--restore-window
+               display-state viewport-buffer)
+              (should (eq (window-buffer source-window)
+                          source-buffer)))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-replaces-narrow-lateral-source ()
+  "Side placement should reject a usable viewport beside a narrow side source."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-narrow-side-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-narrow-side-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (let* ((ai-code-editor-viewport-window-height 13)
+               (fixture
+                (ai-code-editor-viewport-test--display-from-lateral-side
+                 'right source-buffer viewport-buffer 20))
+               (source-window (plist-get fixture :source-window))
+               (source-height (plist-get fixture :source-height))
+               (main-window (plist-get fixture :main-window))
+               (main-buffer (plist-get fixture :main-buffer))
+               (display-state (plist-get fixture :display-state))
+               (viewport-window (plist-get fixture :viewport-window)))
+          (should (< source-height
+                     (* 2 ai-code-editor-viewport-window-height)))
+          (should (= (window-total-width source-window) 20))
+          (should (eq (plist-get display-state :placement) 'replace))
+          (should (eq viewport-window source-window))
+          (ai-code-editor-viewport--restore-window
+           display-state viewport-buffer)
+          (should (eq (window-buffer source-window) source-buffer))
+          (should (eq (window-parameter source-window 'window-side) 'right))
+          (should (window-live-p main-window))
+          (should (eq (window-buffer main-window) main-buffer)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-side-from-wide-lateral-side-uses-normal-window ()
+  "A short wide lateral session should use a restorable normal side window."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-wide-lateral-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-wide-lateral-viewport*")
+      (dolist (side '(left right))
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((ai-code-editor-viewport-window-height 13)
+                 (fixture
+                  (ai-code-editor-viewport-test--display-from-lateral-side
+                   side source-buffer viewport-buffer 55))
+                 (source-window (plist-get fixture :source-window))
+                 (source-height (plist-get fixture :source-height))
+                 (source-width (plist-get fixture :source-width))
+                 (main-window (plist-get fixture :main-window))
+                 (main-buffer (plist-get fixture :main-buffer))
+                 (display-state (plist-get fixture :display-state))
+                 (viewport-window (plist-get fixture :viewport-window)))
+            (should (< source-height
+                       (* 2 ai-code-editor-viewport-window-height)))
+            (should (>= source-width
+                        (* 2 ai-code-editor-viewport-min-width)))
+            (should (eq (plist-get display-state :placement) 'side))
+            (should (window-live-p viewport-window))
+            (should-not (eq viewport-window source-window))
+            (should (eq (window-parameter source-window 'window-side) side))
+            (should-not (window-parameter viewport-window 'window-side))
+            (should (>= (window-total-width source-window)
+                        ai-code-editor-viewport-min-width))
+            (should (>= (window-total-width viewport-window)
+                        ai-code-editor-viewport-min-width))
+            (should (<= (abs (- (window-total-width source-window)
+                                (window-total-width viewport-window)))
+                        1))
+            (should (>= (nth 0 (window-edges viewport-window))
+                        (nth 2 (window-edges source-window))))
+            (window--check)
+            (ai-code-editor-viewport-test--transpose-parent-if-supported
+             viewport-window)
+            (window--check)
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)
+            (window--check)
+            (should (window-live-p source-window))
+            (should (eq (window-buffer source-window) source-buffer))
+            (should (eq (window-parameter source-window 'window-side) side))
+            (should (window-live-p main-window))
+            (should (eq (window-buffer main-window) main-buffer))
+            (should-not (get-buffer-window viewport-buffer t))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-uses-right-when-below-unavailable ()
+  "A viewport should use the right side when below placement is unavailable."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-right-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-right-viewport*")
       (save-window-excursion
         (delete-other-windows)
         (switch-to-buffer source-buffer)
-        (let* ((source-window (selected-window))
-               (display-state
-                (ai-code-editor-viewport--display
-                 viewport-buffer source-buffer))
-               (viewport-window (plist-get display-state :window)))
-          (should (window-live-p viewport-window))
-          (should-not (eq viewport-window source-window))
-          (should (eq (window-buffer source-window) source-buffer))
-          (should (eq (window-buffer viewport-window) viewport-buffer))
-          (should (>= (nth 1 (window-edges viewport-window))
-                      (nth 3 (window-edges source-window))))
-          (ai-code-editor-viewport--restore-window
-           display-state viewport-buffer)
-          (should (window-live-p source-window))
-          (should-not (window-live-p viewport-window)))))))
+        (let* ((ai-code-editor-viewport-window-placement 'below)
+               (source-window (selected-window))
+               display-state)
+          (cl-letf
+              (((symbol-function
+                 'ai-code-editor-viewport--display-below-action)
+                (lambda (&rest _args) nil)))
+            (setq display-state
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer)))
+          (let ((viewport-window (plist-get display-state :window)))
+            (should (eq (plist-get display-state :placement) 'side))
+            (should (window-live-p viewport-window))
+            (should (>= (window-total-width source-window)
+                        ai-code-editor-viewport-min-width))
+            (should (>= (window-total-width viewport-window)
+                        ai-code-editor-viewport-min-width))
+            (should (<= (abs (- (window-total-width source-window)
+                                (window-total-width viewport-window)))
+                        1))
+            (should (>= (nth 0 (window-edges viewport-window))
+                        (nth 2 (window-edges source-window))))
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)
+            (should (window-live-p source-window))
+            (should-not (get-buffer-window viewport-buffer t))))))))
 
-(ert-deftest test-ai-code-editor-viewport--display-opens-below-side-window ()
-  "A viewport should open below an AI session shown in a side window."
+(ert-deftest test-ai-code-editor-viewport--display-uses-below-for-tall-lateral-window ()
+  "A tall lateral side session should display its viewport below."
   (ai-code-editor-viewport-test--with-buffer
       (source-buffer "*ai-code-editor-side-source*")
     (ai-code-editor-viewport-test--with-buffer
         (viewport-buffer "*ai-code-editor-side-viewport*")
+      (dolist (side '(left right))
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((ai-code-editor-viewport-window-height 11)
+                 (fixture
+                  (ai-code-editor-viewport-test--display-from-lateral-side
+                   side source-buffer viewport-buffer))
+                 (source-window (plist-get fixture :source-window))
+                 (source-height (plist-get fixture :source-height))
+                 (main-window (plist-get fixture :main-window))
+                 (main-buffer (plist-get fixture :main-buffer))
+                 (display-state (plist-get fixture :display-state))
+                 (viewport-window (plist-get fixture :viewport-window)))
+            (should (>= source-height
+                        (* 2 ai-code-editor-viewport-window-height)))
+            (should (window-live-p viewport-window))
+            (should-not (eq viewport-window source-window))
+            (should (eq (plist-get display-state :placement) 'below))
+            (should (eq (window-buffer source-window) source-buffer))
+            (should (eq (window-buffer viewport-window) viewport-buffer))
+            (should (>= (window-total-height source-window)
+                        ai-code-editor-viewport-min-height))
+            (should (>= (window-total-height viewport-window)
+                        ai-code-editor-viewport-min-height))
+            (should (= (window-total-height viewport-window)
+                       ai-code-editor-viewport-window-height))
+            (should (= (nth 0 (window-edges viewport-window))
+                       (nth 0 (window-edges source-window))))
+            (should (= (nth 2 (window-edges viewport-window))
+                       (nth 2 (window-edges source-window))))
+            (should (>= (nth 1 (window-edges viewport-window))
+                        (nth 3 (window-edges source-window))))
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)
+            (should (window-live-p source-window))
+            (should (window-live-p main-window))
+            (should (eq (window-buffer main-window) main-buffer))
+            (should-not (get-buffer-window viewport-buffer t))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-replaces-narrow-lateral-window ()
+  "A short lateral session should replace when a balanced side cannot fit."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-short-side-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-short-side-viewport*")
+      (dolist (side '(left right))
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((ai-code-editor-viewport-window-height 13)
+                 (fixture
+                  (ai-code-editor-viewport-test--display-from-lateral-side
+                   side source-buffer viewport-buffer))
+                 (source-window (plist-get fixture :source-window))
+                 (source-height (plist-get fixture :source-height))
+                 (source-width (window-total-width source-window))
+                 (main-window (plist-get fixture :main-window))
+                 (main-buffer (plist-get fixture :main-buffer))
+                 (display-state (plist-get fixture :display-state))
+                 (viewport-window (plist-get fixture :viewport-window)))
+            (should (< source-height
+                       (* 2 ai-code-editor-viewport-window-height)))
+            (should (< source-width
+                       (* 2 ai-code-editor-viewport-min-width)))
+            (should (eq (plist-get display-state :placement) 'replace))
+            (should (eq viewport-window source-window))
+            (should (= (window-total-width source-window) source-width))
+            (should (eq (window-buffer source-window) viewport-buffer))
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)
+            (should (window-live-p source-window))
+            (should (eq (window-buffer source-window) source-buffer))
+            (should (eq (window-parameter source-window 'window-side) side))
+            (should (window-live-p main-window))
+            (should (eq (window-buffer main-window) main-buffer))
+            (should-not (get-buffer-window viewport-buffer t))))))))
+
+(ert-deftest test-ai-code-editor-viewport--restore-created-sole-window-hides-viewport ()
+  "Restoring a sole created window should hide the viewport without error."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-sole-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-sole-viewport*")
       (save-window-excursion
         (delete-other-windows)
-        (let* ((window-sides-slots '(nil nil nil nil))
-               (source-window
-                (display-buffer-in-side-window
-                 source-buffer
-                 '((side . right)
-                   (slot . 0)
-                   (window-width . 40)
-                   (preserve-size . (t . nil))
-                   (window-parameters
-                    . ((no-delete-other-windows . t)
-                       (window-size-fixed . width))))))
-               (display-state
+        (switch-to-buffer source-buffer)
+        (let* ((display-state
                 (ai-code-editor-viewport--display
                  viewport-buffer source-buffer))
                (viewport-window (plist-get display-state :window)))
-          (should (window-live-p viewport-window))
-          (should-not (eq viewport-window source-window))
-          (should (eq (window-buffer source-window) source-buffer))
-          (should (eq (window-buffer viewport-window) viewport-buffer))
-          (should (eq (window-parameter viewport-window 'window-side) 'right))
-          (should (>= (nth 1 (window-edges viewport-window))
-                      (nth 3 (window-edges source-window))))
+          (let ((ignore-window-parameters t))
+            (delete-other-windows viewport-window))
+          (should-not (eq (window-deletable-p viewport-window) t))
           (ai-code-editor-viewport--restore-window
            display-state viewport-buffer)
-          (should (window-live-p source-window))
-          (should-not (window-live-p viewport-window)))))))
+          (should-not (get-buffer-window viewport-buffer t)))))))
 
-(ert-deftest test-ai-code-editor-viewport--display-below-errors-without-space ()
-  "Below placement should never replace the source window as a fallback."
+(ert-deftest test-ai-code-editor-viewport--display-below-from-side-uses-normal-window ()
+  "A below-side layout should use a restorable normal viewport window."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-transpose-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-transpose-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (let* ((ai-code-editor-viewport-window-height 11)
+               (fixture
+                (ai-code-editor-viewport-test--display-from-lateral-side
+                 'right source-buffer viewport-buffer))
+               (source-window (plist-get fixture :source-window))
+               (main-window (plist-get fixture :main-window))
+               (main-buffer (plist-get fixture :main-buffer))
+               (display-state (plist-get fixture :display-state))
+               (viewport-window (plist-get fixture :viewport-window)))
+          (should (= (length (window-list)) 3))
+          (window--check)
+          (should (eq (window-parameter source-window 'window-side) 'right))
+          (should-not (window-parameter viewport-window 'window-side))
+          (ai-code-editor-viewport-test--transpose-parent-if-supported
+           viewport-window)
+          (window--check)
+          (should (eq (plist-get display-state :placement) 'below))
+          (ai-code-editor-viewport--restore-window
+           display-state viewport-buffer)
+          (window--check)
+          (should (= (length (window-list)) 2))
+          (should (window-live-p source-window))
+          (should (eq (window-parameter source-window 'window-side) 'right))
+          (should (window-live-p main-window))
+          (should (eq (window-buffer main-window) main-buffer))
+          (should-not (get-buffer-window viewport-buffer t)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-replaces-without-space ()
+  "Default placement should replace only after all placement attempts fail."
   (ai-code-editor-viewport-test--with-buffer
       (source-buffer "*ai-code-editor-no-space-source*")
     (ai-code-editor-viewport-test--with-buffer
@@ -752,14 +1331,254 @@
       (save-window-excursion
         (delete-other-windows)
         (switch-to-buffer source-buffer)
-        (let ((ai-code-editor-viewport-window-placement 'below))
+        (let ((ai-code-editor-viewport-window-placement 'below)
+              (source-window (selected-window))
+              display-state)
           (cl-letf (((symbol-function 'display-buffer)
                      (lambda (&rest _args) nil)))
-            (should-error
-             (ai-code-editor-viewport--display
-              viewport-buffer source-buffer)
-             :type 'user-error))
-          (should (eq (window-buffer (selected-window)) source-buffer)))))))
+            (setq display-state
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer)))
+          (should (eq (plist-get display-state :window) source-window))
+          (should (eq (plist-get display-state :placement) 'replace))
+          (should (eq (window-buffer source-window) viewport-buffer))
+          (ai-code-editor-viewport--restore-window
+           display-state viewport-buffer)
+          (should (eq (window-buffer source-window) source-buffer)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-fallback-order ()
+  "Default placement should try below, right, left, and replace in order."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-order-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-order-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (switch-to-buffer source-buffer)
+        (let ((ai-code-editor-viewport-window-placement 'below)
+              (ai-code-editor-viewport-window-height 11)
+              attempts)
+          (cl-letf
+              (((symbol-function
+                 'ai-code-editor-viewport--display-below-action)
+                (lambda (&rest _args)
+                  (push 'below attempts)
+                  nil))
+               ((symbol-function
+                 'ai-code-editor-viewport--display-side-action)
+                (lambda (direction &rest _args)
+                  (push direction attempts)
+                  nil))
+               ((symbol-function 'ai-code-editor-viewport--replace-window)
+                (lambda (_buffer window)
+                  (push 'replace attempts)
+                  (list :window window :placement 'replace))))
+            (should
+             (eq (plist-get
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer)
+                  :placement)
+                 'replace)))
+          (should
+           (equal (nreverse attempts) '(below right left replace))))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-never-runs-frame-actions ()
+  "Viewport placement should never delegate to a frame display action."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-no-frame-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-no-frame-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (switch-to-buffer source-buffer)
+        (let ((ai-code-editor-viewport-window-placement 'below)
+              (ai-code-editor-viewport-window-height 11)
+              (frames-before (frame-list))
+              frame-action-called
+              display-state)
+          (let ((display-buffer-overriding-action
+                 (list
+                  (list
+                   (lambda (&rest _args)
+                     (setq frame-action-called t)
+                     nil)))))
+            (setq display-state
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer)))
+          (should-not frame-action-called)
+          (should (equal (frame-list) frames-before))
+          (should (eq (plist-get display-state :placement) 'below)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-scopes-source-to-selected-frame ()
+  "Viewport placement should not look up its source on another frame."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-frame-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-frame-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (let ((ai-code-editor-viewport-window-placement 'replace)
+              (origin-frame (selected-frame))
+              requested-frame
+              display-state)
+          (cl-letf (((symbol-function 'get-buffer-window)
+                     (lambda (_buffer frame)
+                       (setq requested-frame frame)
+                       nil)))
+            (setq display-state
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer)))
+          (should (eq requested-frame origin-frame))
+          (should (eq (window-frame (plist-get display-state :window))
+                      origin-frame))
+          (ai-code-editor-viewport--restore-window
+           display-state viewport-buffer))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-uses-dispatch-frame ()
+  "Viewport placement should honor a live frame captured at dispatch time."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-captured-frame-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-captured-frame-viewport*")
+      (let ((ai-code-editor-viewport-window-placement 'replace)
+            (origin-frame 'origin-frame)
+            (later-frame 'later-frame)
+            (anchor-window 'origin-window)
+            requested-frame)
+        (cl-letf (((symbol-function 'frame-live-p)
+                   (lambda (frame) (eq frame origin-frame)))
+                  ((symbol-function 'selected-frame)
+                   (lambda () later-frame))
+                  ((symbol-function 'get-buffer-window)
+                   (lambda (_buffer frame)
+                     (setq requested-frame frame)
+                     nil))
+                  ((symbol-function 'frame-selected-window)
+                   (lambda (frame)
+                     (should (eq frame origin-frame))
+                     anchor-window))
+                  ((symbol-function 'ai-code-editor-viewport--replace-window)
+                   (lambda (_buffer window)
+                     (list :window window :placement 'replace))))
+          (should
+           (eq (plist-get
+                (ai-code-editor-viewport--display
+                 viewport-buffer source-buffer origin-frame)
+                :window)
+               anchor-window))
+          (should (eq requested-frame origin-frame)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-falls-back-from-deleted-frame ()
+  "A deleted dispatch frame should fall back to the selected frame."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-deleted-frame-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-deleted-frame-viewport*")
+      (let ((ai-code-editor-viewport-window-placement 'replace)
+            (deleted-frame 'deleted-frame)
+            (current-frame 'current-frame)
+            (anchor-window 'current-window)
+            requested-frame)
+        (cl-letf (((symbol-function 'frame-live-p) #'ignore)
+                  ((symbol-function 'selected-frame)
+                   (lambda () current-frame))
+                  ((symbol-function 'get-buffer-window)
+                   (lambda (_buffer frame)
+                     (setq requested-frame frame)
+                     nil))
+                  ((symbol-function 'frame-selected-window)
+                   (lambda (frame)
+                     (should (eq frame current-frame))
+                     anchor-window))
+                  ((symbol-function 'ai-code-editor-viewport--replace-window)
+                   (lambda (_buffer window)
+                     (list :window window :placement 'replace))))
+          (should
+           (eq (plist-get
+                (ai-code-editor-viewport--display
+                 viewport-buffer source-buffer deleted-frame)
+                :window)
+               anchor-window))
+          (should (eq requested-frame current-frame)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-ignores-external-action-alists ()
+  "Viewport placement should ignore external display action constraints."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-no-alist-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-no-alist-viewport*")
+      (save-window-excursion
+        (delete-other-windows)
+        (switch-to-buffer source-buffer)
+        (let ((ai-code-editor-viewport-window-placement 'below)
+              (ai-code-editor-viewport-window-height 11)
+              (display-buffer-alist
+               `((,(regexp-quote (buffer-name viewport-buffer))
+                  (window-min-height . 1000))))
+              (display-buffer-base-action
+               '((display-buffer-reuse-window)
+                 (window-min-height . 1000)))
+              (display-buffer-fallback-action
+               '((display-buffer-pop-up-frame)
+                 (window-min-height . 1000))))
+          (let ((display-state
+                 (ai-code-editor-viewport--display
+                  viewport-buffer source-buffer)))
+            (should (eq (plist-get display-state :placement) 'below))
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)))))))
+
+(ert-deftest test-ai-code-editor-viewport--display-side-from-horizontal-side-uses-normal-window ()
+  "A short top or bottom session should use a restorable normal side window."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-horizontal-side-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (viewport-buffer "*ai-code-editor-horizontal-side-viewport*")
+      (dolist (side '(top bottom))
+        (save-window-excursion
+          (delete-other-windows)
+          (let* ((ai-code-editor-viewport-window-placement 'below)
+                 (window-sides-slots '(nil nil nil nil))
+                 (source-window
+                  (display-buffer-in-side-window
+                   source-buffer
+                   `((side . ,side)
+                     (slot . 0)
+                     (window-height . 8)
+                     (preserve-size . (nil . t))
+                     (window-parameters
+                      . ((no-delete-other-windows . t)
+                         (window-size-fixed . height))))))
+                 (main-window (window-main-window))
+                 (main-buffer (window-buffer main-window))
+                 (display-state
+                  (ai-code-editor-viewport--display
+                   viewport-buffer source-buffer))
+                 (viewport-window (plist-get display-state :window)))
+            (should (eq (plist-get display-state :placement) 'side))
+            (should (window-live-p viewport-window))
+            (should-not (eq viewport-window source-window))
+            (should (eq (window-parameter source-window 'window-side) side))
+            (should-not (window-parameter viewport-window 'window-side))
+            (should (>= (window-total-width source-window)
+                        ai-code-editor-viewport-min-width))
+            (should (>= (window-total-width viewport-window)
+                        ai-code-editor-viewport-min-width))
+            (should (>= (nth 0 (window-edges viewport-window))
+                        (nth 2 (window-edges source-window))))
+            (window--check)
+            (ai-code-editor-viewport-test--transpose-parent-if-supported
+             viewport-window)
+            (window--check)
+            (ai-code-editor-viewport--restore-window
+             display-state viewport-buffer)
+            (window--check)
+            (should (window-live-p source-window))
+            (should (eq (window-buffer source-window) source-buffer))
+            (should (eq (window-parameter source-window 'window-side) side))
+            (should (window-live-p main-window))
+            (should (eq (window-buffer main-window) main-buffer))
+            (should-not (get-buffer-window viewport-buffer t))))))))
 
 (ert-deftest test-ai-code-editor-viewport--display-replace-restores-hidden-source-window ()
   "Replacement placement should restore the user's previous window buffer."


### PR DESCRIPTION
## Summary

- Use a deterministic editor viewport fallback order: below, right, left, then replace.
- Keep viewport placement on the frame selected when the request begins and prevent frame-producing display actions.
- Target a 12-line viewport below sources with at least 24 lines, accepting a minimum viewport height of 8 lines.
- Use balanced side placement only when both the source and viewport remain at least 24 columns wide.
- Split side-window sessions into normal windows to remain valid after `window-layout-transpose`.
- Exclude temporary external-editor staging files from `recentf` without changing user configuration.

## Motivation

Editor viewport requests could fail when below placement was unavailable, unexpectedly use another frame, or produce invalid same-side window trees after layout transposition. Temporary external-editor files could also appear in `recentf`.

This change makes placement deterministic, preserves usable source dimensions, rolls back failed layout attempts, and safely restores the original session after the viewport closes.

## Verification

- 54 editor viewport ERT tests pass.
- Full suite: 1204 passed, 13 existing skips, 0 failures.
- Repository byte compilation succeeds with no new warnings in touched files.
- Checkdoc and `git diff --check` pass.
- Tests cover all four side-window positions, layout transposition, restoration, dimension boundaries, selected-frame isolation, no-frame behavior, cancel/save flows, and `recentf` exclusion.