### PR TITLE
Add CLI-aware backend install and upgrade flow

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Add CLI-aware backend install and upgrade flow
 - Stop tracking generated autoload file (ai-code-autoloads.el is a generated artifact — tracking it breaks Elpaca updates on Emacs), by nailuoGG
 - Fix editor viewport placement and temporary recentf entries, by cxa
 

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -214,7 +214,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-claude-code-resume
      :config  "~/.claude.json"
      :agent-file "CLAUDE.md"
-     :upgrade "npm install -g @anthropic-ai/claude-code@latest"
+     :install "npm install -g @anthropic-ai/claude-code@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "claude")
     (gemini
@@ -226,7 +227,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-gemini-cli-resume
      :config  "~/.gemini/settings.json"
      :agent-file "GEMINI.md"
-     :upgrade "npm install -g @google/gemini-cli"
+     :install "npm install -g @google/gemini-cli"
+     :upgrade nil
      :install-skills nil
      :cli     "gemini")
     (antigravity
@@ -238,7 +240,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-antigravity-cli-resume
      :config  "~/.gemini/antigravity-cli/settings.json"
      :agent-file "AGENTS.md"
-     :upgrade "curl -fsSL https://antigravity.google/cli/install.sh | bash"
+     :install "curl -fsSL https://antigravity.google/cli/install.sh | bash"
+     :upgrade nil
      :install-skills nil
      :cli     "agy")
     (github-copilot-cli
@@ -250,7 +253,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-github-copilot-cli-resume
      :config  "~/.copilot/mcp-config.json"
      :agent-file nil
-     :upgrade "npm install -g @github/copilot"
+     :install "npm install -g @github/copilot"
+     :upgrade nil
      :install-skills nil
      :cli     "copilot")
     (codex
@@ -262,7 +266,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-codex-cli-resume
      :config  "~/.codex/config.toml"
      :agent-file "AGENTS.md"
-     :upgrade "npm install -g @openai/codex@latest"
+     :install "npm install -g @openai/codex@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "codex")
     (open-interpreter
@@ -274,6 +279,7 @@ so the CLI itself handles the installation details."
      :resume  ai-code-open-interpreter-cli-resume
      :config  "~/.openinterpreter/config.toml"
      :agent-file "AGENTS.md"
+     :install nil
      :upgrade nil
      :install-skills nil
      :cli     "interpreter")
@@ -286,7 +292,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-opencode-resume
      :config  "~/.config/opencode/opencode.jsonc"
      :agent-file nil
-     :upgrade "npm i -g opencode-ai@latest"
+     :install "npm i -g opencode-ai@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "opencode")
     (kilo
@@ -298,7 +305,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-kilo-resume
      :config  "~/.config/kilo/kilo.json"
      :agent-file nil
-     :upgrade "npm install -g kilo@latest"
+     :install "npm install -g kilo@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "kilo")
     (grok
@@ -310,7 +318,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-grok-cli-resume
      :config  "~/.config/grok/config.json"
      :agent-file nil
-     :upgrade "bun add -g @vibe-kit/grok-cli"
+     :install "bun add -g @vibe-kit/grok-cli"
+     :upgrade nil
      :install-skills nil
      :cli     "grok")
     (cursor
@@ -322,7 +331,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-cursor-cli-resume
      :config  "~/.cursor"
      :agent-file nil
-     :upgrade "cursor-agent update"
+     :install "cursor-agent update"
+     :upgrade nil
      :install-skills nil
      :cli     "cursor-agent")
     (kiro
@@ -334,7 +344,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-kiro-cli-resume
      :config  "~/.kiro/settings/cli.json"
      :agent-file nil
-     :upgrade "kiro-cli update"
+     :install "kiro-cli update"
+     :upgrade nil
      :install-skills nil
      :cli     "kiro-cli")
     (codebuddy
@@ -346,7 +357,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-codebuddy-cli-resume
      :config  "~/.codebuddy"
      :agent-file nil
-     :upgrade "codebuddy update"
+     :install "codebuddy update"
+     :upgrade nil
      :install-skills nil
      :cli     "codebuddy")
     (aider
@@ -358,10 +370,11 @@ so the CLI itself handles the installation details."
      :resume  nil
      :config  "~/.aider.conf.yml"
      :agent-file nil
+     :install nil
      :upgrade nil
      :install-skills nil
      :cli     "aider")
-    (eca              ; external backend, requires eca package
+    (eca                      ; external backend, requires eca package
      :label "ECA (Editor Code Assistant)"
      :require ai-code-eca
      :start   ai-code-eca-start
@@ -370,7 +383,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-eca-resume
      :config  "~/.config/eca/config.json"
      :agent-file "AGENTS.md"
-     :upgrade ai-code-eca-upgrade
+     :install ai-code-eca-upgrade
+     :upgrade nil
      :install-skills ai-code-eca-install-skills
      :cli     nil)
     (agent-shell      ; external backend, requires agent-shell package
@@ -382,6 +396,7 @@ so the CLI itself handles the installation details."
      :resume  ai-code-agent-shell-resume
      :config  nil
      :agent-file nil
+     :install nil
      :upgrade nil
      :install-skills nil
      :cli     "agent-shell")
@@ -394,6 +409,7 @@ so the CLI itself handles the installation details."
      :resume  nil
      :config  nil
      :agent-file nil
+     :install nil
      :upgrade nil
      :install-skills nil
      :cli     nil)
@@ -406,7 +422,8 @@ so the CLI itself handles the installation details."
      :resume  claude-code-ide-resume
      :config  "~/.claude.json"
      :agent-file "CLAUDE.md"
-     :upgrade "npm install -g @anthropic-ai/claude-code@latest"
+     :install "npm install -g @anthropic-ai/claude-code@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "claude")
     (claude-code-el ; external backend, requires claude-code.el package
@@ -418,12 +435,13 @@ so the CLI itself handles the installation details."
      :resume  claude-code-resume
      :config  "~/.claude.json"
      :agent-file "CLAUDE.md"
-     :upgrade "npm install -g @anthropic-ai/claude-code@latest"
+     :install "npm install -g @anthropic-ai/claude-code@latest"
+     :upgrade nil
      :install-skills nil
      :cli     "claude"))
   "Available AI backends and their integration metadata.
 Each entry is a plist with backend labels, command functions,
-configuration paths, upgrade commands, and skill-install commands."
+configuration paths, install and upgrade commands, and skill-install commands."
   :type '(repeat (list (symbol :tag "Key")
                        (const :label) (string :tag "Label")
                        (const :require) (symbol :tag "Feature to require")
@@ -432,7 +450,11 @@ configuration paths, upgrade commands, and skill-install commands."
                        (const :send) (symbol :tag "Send function")
                        (const :resume) (choice (symbol :tag "Resume function")
                                                (const :tag "Not supported" nil))
+                       (const :install) (choice (string :tag "Install command")
+                                                (symbol :tag "Install function")
+                                                (const :tag "Not supported" nil))
                        (const :upgrade) (choice (string :tag "Upgrade command")
+                                                (symbol :tag "Upgrade function")
                                                 (const :tag "Not supported" nil))
                        (const :cli) (string :tag "CLI name")
                        (const :agent-file) (choice (string :tag "Agent file name")
@@ -593,32 +615,44 @@ invoke `ai-code-cli-resume'; otherwise call `ai-code-cli-start'."
 
 ;;;###autoload
 (defun ai-code-upgrade-backend (&optional arg)
-  "Run the upgrade command for the currently selected backend.
-If the backend defines an :upgrade property, use it:
-  - string: run as a shell command via `compile'.
-  - symbol: call the function with prefix arg forwarded.
-ARG is the prefix argument to pass to the upgrade function."
+  "Install or upgrade the currently selected backend's CLI.
+When the declared CLI is unavailable, use :install.  Otherwise, use
+:upgrade when defined and fall back to :install.  String commands run
+via `compile'; function symbols receive prefix ARG interactively."
   (interactive "P")
   (let* ((spec (ai-code--backend-spec ai-code-selected-backend)))
     (if (not spec)
         (user-error "No backend is currently selected")
-      (let* ((plist   (cdr spec))
+      (let* ((plist (cdr spec))
+             (install (plist-get plist :install))
              (upgrade (plist-get plist :upgrade))
-             (label   (ai-code-current-backend-label)))
+             (cli (plist-get plist :cli))
+             (label (ai-code-current-backend-label))
+             (cli-available (and (stringp cli) (executable-find cli)))
+             (command (if cli-available (or upgrade install) install))
+             (property (if (and cli-available upgrade) :upgrade :install)))
+        (when (and command (symbolp command))
+          (ai-code--ensure-backend-loaded spec))
         (cond
-         ((stringp upgrade)
-          (compile upgrade)
-          (message "Running upgrade command for %s" label))
-         ((and upgrade (symbolp upgrade) (fboundp upgrade))
+         ((stringp command)
+          (compile command)
+          (message "Running %s command for %s" property label))
+         ((and command (symbolp command) (fboundp command))
           (let ((current-prefix-arg arg))
-            (call-interactively upgrade))
-          (message "Running upgrade for %s" label))
-         ((and upgrade (symbolp upgrade) (not (fboundp upgrade)))
-          (user-error "Backend '%s' declares :upgrade function '%s' but it is not callable"
-                      label upgrade))
+            (call-interactively command))
+          (message "Running %s for %s" property label))
+         ((and command (symbolp command) (not (fboundp command)))
+          (user-error "Backend '%s' declares %s function '%s' but it is not callable"
+                      label property command))
+         ((and (null install) (null upgrade))
+          (user-error "Backend '%s' defines neither :install nor :upgrade command"
+                      label))
+         ((not install)
+          (user-error "Backend '%s' CLI '%s' is unavailable and :install is not defined"
+                      label (or cli "<none>")))
          (t
-          (user-error "Upgrade command for backend '%s' is not defined"
-                      label)))))))
+          (user-error "Backend '%s' declares invalid %s command: %S"
+                      label property command)))))))
 
 (defun ai-code--install-backend-skills-fallback (label)
   "Fallback skills installation for backend LABEL.

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -240,8 +240,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-antigravity-cli-resume
      :config  "~/.gemini/antigravity-cli/settings.json"
      :agent-file "AGENTS.md"
-     :install "curl -fsSL https://antigravity.google/cli/install.sh | bash"
-     :upgrade "agy update"
+     :install "agy update"
+     :upgrade nil
      :install-skills nil
      :cli     "agy")
     (github-copilot-cli

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -240,8 +240,8 @@ so the CLI itself handles the installation details."
      :resume  ai-code-antigravity-cli-resume
      :config  "~/.gemini/antigravity-cli/settings.json"
      :agent-file "AGENTS.md"
-     :install "agy update"
-     :upgrade nil
+     :install "curl -fsSL https://antigravity.google/cli/install.sh | bash"
+     :upgrade "agy update"
      :install-skills nil
      :cli     "agy")
     (github-copilot-cli

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -241,7 +241,7 @@ so the CLI itself handles the installation details."
      :config  "~/.gemini/antigravity-cli/settings.json"
      :agent-file "AGENTS.md"
      :install "curl -fsSL https://antigravity.google/cli/install.sh | bash"
-     :upgrade nil
+     :upgrade "agy update"
      :install-skills nil
      :cli     "agy")
     (github-copilot-cli

--- a/test/test_ai-code-backends.el
+++ b/test/test_ai-code-backends.el
@@ -148,10 +148,7 @@
   (let ((claude-spec (ai-code--backend-spec 'claude-code)))
     (should (equal (plist-get (cdr claude-spec) :install)
                    "npm install -g @anthropic-ai/claude-code@latest"))
-    (should-not
-     (seq-some (lambda (spec)
-                 (plist-get (cdr spec) :upgrade))
-               ai-code-backends))))
+    (should-not (plist-get (cdr claude-spec) :upgrade))))
 
 (ert-deftest ai-code-test-antigravity-backend-spec-contract ()
   "Ensure the Antigravity backend entry exposes required integration keys."
@@ -164,6 +161,9 @@
     (should (eq (plist-get (cdr spec) :resume) 'ai-code-antigravity-cli-resume))
     (should (equal (plist-get (cdr spec) :config) "~/.gemini/antigravity-cli/settings.json"))
     (should (equal (plist-get (cdr spec) :agent-file) "AGENTS.md"))
+    (should (equal (plist-get (cdr spec) :install)
+                   "curl -fsSL https://antigravity.google/cli/install.sh | bash"))
+    (should (equal (plist-get (cdr spec) :upgrade) "agy update"))
     (should (equal (plist-get (cdr spec) :cli) "agy"))))
 
 (ert-deftest ai-code-test-backend-selection-keeps-repo-session-backend ()

--- a/test/test_ai-code-backends.el
+++ b/test/test_ai-code-backends.el
@@ -138,9 +138,20 @@
     (should (eq (plist-get (cdr spec) :switch) 'ai-code-eca-switch))
     (should (eq (plist-get (cdr spec) :send) 'ai-code-eca-send))
     (should (eq (plist-get (cdr spec) :resume) 'ai-code-eca-resume))
-    (should (eq (plist-get (cdr spec) :upgrade) 'ai-code-eca-upgrade))
+    (should (eq (plist-get (cdr spec) :install) 'ai-code-eca-upgrade))
+    (should-not (plist-get (cdr spec) :upgrade))
     (should (eq (plist-get (cdr spec) :install-skills) 'ai-code-eca-install-skills))
     (should (null (plist-get (cdr spec) :cli)))))
+
+(ert-deftest ai-code-test-backend-install-metadata-migrates-upgrade-defaults ()
+  "Ensure default upgrade commands migrate to install metadata."
+  (let ((claude-spec (ai-code--backend-spec 'claude-code)))
+    (should (equal (plist-get (cdr claude-spec) :install)
+                   "npm install -g @anthropic-ai/claude-code@latest"))
+    (should-not
+     (seq-some (lambda (spec)
+                 (plist-get (cdr spec) :upgrade))
+               ai-code-backends))))
 
 (ert-deftest ai-code-test-antigravity-backend-spec-contract ()
   "Ensure the Antigravity backend entry exposes required integration keys."
@@ -220,6 +231,124 @@
       (should (eq (car start-calls) 'backend-a))
       (should (equal (reverse start-calls)
                      '(backend-a backend-b backend-a))))))
+
+(ert-deftest ai-code-test-upgrade-backend-installs-when-cli-missing ()
+  "A missing CLI should run the backend install command."
+  (let* ((compiled-command nil)
+         (ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install "install command"
+                              :upgrade "upgrade command"
+                              :cli "test-cli")))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_cli) nil))
+              ((symbol-function 'compile)
+               (lambda (command)
+                 (setq compiled-command command)))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (ai-code-upgrade-backend)
+      (should (equal compiled-command "install command")))))
+
+(ert-deftest ai-code-test-upgrade-backend-upgrades-when-cli-available ()
+  "An available CLI should run the backend upgrade command."
+  (let* ((checked-cli nil)
+         (compiled-command nil)
+         (ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install "install command"
+                              :upgrade "upgrade command"
+                              :cli "test-cli")))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (cli)
+                 (setq checked-cli cli)
+                 "/usr/bin/test-cli"))
+              ((symbol-function 'compile)
+               (lambda (command)
+                 (setq compiled-command command)))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (ai-code-upgrade-backend)
+      (should (equal checked-cli "test-cli"))
+      (should (equal compiled-command "upgrade command")))))
+
+(ert-deftest ai-code-test-upgrade-backend-falls-back-to-install-function ()
+  "An available CLI without an upgrade should call the install function."
+  (let* ((received-prefix nil)
+         (ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install ai-code-test--install-backend
+                              :upgrade nil
+                              :cli "test-cli")))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_cli) "/usr/bin/test-cli"))
+              ((symbol-function 'ai-code-test--install-backend)
+               (lambda ()
+                 (interactive)
+                 (setq received-prefix current-prefix-arg)))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (ai-code-upgrade-backend '(4))
+      (should (equal received-prefix '(4))))))
+
+(ert-deftest ai-code-test-upgrade-backend-installs-when-cli-is-nil ()
+  "A backend without CLI metadata should run its install command."
+  (let* ((compiled-command nil)
+         (ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install "install command"
+                              :upgrade nil
+                              :cli nil)))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_cli)
+                 (ert-fail "Should not check a nil CLI")))
+              ((symbol-function 'compile)
+               (lambda (command)
+                 (setq compiled-command command)))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (ai-code-upgrade-backend)
+      (should (equal compiled-command "install command")))))
+
+(ert-deftest ai-code-test-upgrade-backend-errors-without-missing-cli-install ()
+  "A missing CLI without an install command should signal an error."
+  (let* ((compiled-command nil)
+         (ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install nil
+                              :upgrade "upgrade command"
+                              :cli "test-cli")))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_cli) nil))
+              ((symbol-function 'compile)
+               (lambda (command)
+                 (setq compiled-command command)))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (should-error (ai-code-upgrade-backend) :type 'user-error)
+      (should-not compiled-command))))
+
+(ert-deftest ai-code-test-upgrade-backend-errors-without-any-command ()
+  "A backend without install or upgrade commands should explain both keys."
+  (let* ((ai-code-backends '((test-backend
+                              :label "Test Backend"
+                              :install nil
+                              :upgrade nil
+                              :cli "test-cli")))
+         (ai-code-selected-backend 'test-backend))
+    (cl-letf (((symbol-function 'executable-find)
+               (lambda (_cli) "/usr/bin/test-cli")))
+      (let ((error-data (should-error (ai-code-upgrade-backend)
+                                      :type 'user-error)))
+        (should (string-match-p ":install"
+                                (error-message-string error-data)))
+        (should (string-match-p ":upgrade"
+                                (error-message-string error-data)))))))
 
 (ert-deftest ai-code-test-install-skills-with-string-command ()
   "Backend with :install-skills string runs it via compile."

--- a/test/test_ai-code-eca.el
+++ b/test/test_ai-code-eca.el
@@ -29,7 +29,8 @@
     (should (plist-get spec :switch))
     (should (plist-get spec :send))
     (should (plist-get spec :resume))
-    (should (plist-get spec :upgrade))
+    (should (plist-get spec :install))
+    (should-not (plist-get spec :upgrade))
     (should (plist-get spec :install-skills))))
 
 (ert-deftest ai-code-test-eca-add-menu-group-when-eca-selected ()


### PR DESCRIPTION
## Summary

Separate backend installation from upgrades so the existing Install / Upgrade action chooses the right command based on whether the configured CLI is available on PATH.

- Add `:install` metadata to each backend and migrate existing setup commands, while retaining `:upgrade` for true update commands such as `agy update`.
- Update `ai-code-upgrade-backend` to install missing CLIs, upgrade available CLIs, fall back to installation when no upgrade is defined, and report actionable configuration errors.
- Add focused ERT coverage for metadata migration, PATH-based dispatch, function commands, fallback behavior, and ECA metadata.

## Verification

- `git diff --check origin/main...HEAD`
- Tests were not run during PR creation, per request.