### PR TITLE
Feat: add Pi coding agent backend support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is **ai-code-interface.el**, an Emacs package that provides a uniform interface for AI-assisted software development across different AI backends (Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot CLI).
+This is **ai-code-interface.el**, an Emacs package that provides a uniform interface for AI-assisted software development across pluggable AI coding backends.
 
 ## Language and Technology
 
@@ -80,7 +80,7 @@ The package uses a pluggable backend system:
 - Backends are registered in `ai-code-backends.el`
 - Each backend provides functions for: start, resume, switch-to-buffer, send-command
 - Backend selection is dynamic via `ai-code-set-backend`
-- Supported backends: Claude Code, Claude Code IDE, Gemini CLI, Codex CLI, GitHub Copilot CLI
+- Supported backends are registered in `ai-code-backends.el`, which is the source of truth for the current backend list.
 
 ## Key Features to Preserve
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The project uses melpazoid for CI checks. The workflow is defined in `.github/wo
 ## High-Level Architecture
 
 ### Core Design Philosophy
-This is a unified interface package for AI-assisted software development that abstracts over multiple AI coding CLI backends (Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot CLI, Opencode, Kilo, Grok CLI, Cursor CLI, CodeBuddy Code CLI, Kiro CLI). The package provides a consistent user experience across different AI tools while maintaining context-aware code actions and agile development workflows.
+This is a unified interface package for AI-assisted software development that abstracts over multiple AI coding CLI backends (Claude Code, Gemini CLI, OpenAI Codex, Pi, GitHub Copilot CLI, Opencode, Kilo, Grok CLI, Cursor CLI, CodeBuddy Code CLI, Kiro CLI). The package provides a consistent user experience across different AI tools while maintaining context-aware code actions and agile development workflows.
 
 ### Backend System Architecture
 
@@ -62,7 +62,7 @@ Backend switching is handled via `ai-code-set-backend`, which:
 3. Updates the UI to reflect the current backend
 
 Backend implementations fall into two categories:
-1. **Native backends** (in this repo): Implemented in files like `ai-code-codex-cli.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, etc.
+1. **Native backends** (in this repo): Implemented in files like `ai-code-codex-cli.el`, `ai-code-pi.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, etc.
 2. **External backends**: Packages like `claude-code-ide.el` and `claude-code.el` that provide backend functions
 
 ### Terminal Infrastructure
@@ -93,7 +93,7 @@ The codebase is organized into focused modules:
 - **`ai-code-prompt-mode.el`**: Prompt file management (`.ai.code.prompt.org`), @-completion, yasnippet integration
 - **`ai-code-input.el`**: User input handling, context gathering, completion utilities
 - **`ai-code-notifications.el`**: Desktop notifications for AI session completion
-- **Backend implementations**: `ai-code-codex-cli.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, `ai-code-opencode.el`, `ai-code-kilo.el`, `ai-code-grok-cli.el`, `ai-code-cursor-cli.el`, `ai-code-kiro-cli.el`, `ai-code-claude-code.el`
+- **Backend implementations**: `ai-code-codex-cli.el`, `ai-code-pi.el`, `ai-code-github-copilot-cli.el`, `ai-code-gemini-cli.el`, `ai-code-codebuddy-cli.el`, `ai-code-opencode.el`, `ai-code-kilo.el`, `ai-code-grok-cli.el`, `ai-code-cursor-cli.el`, `ai-code-kiro-cli.el`, `ai-code-claude-code.el`
 
 ### Transient Menu System
 
@@ -203,6 +203,7 @@ Each backend requires the corresponding CLI to be installed and available on PAT
 - Claude Code: `claude`
 - Gemini CLI: `gemini`
 - OpenAI Codex: `codex`
+- Pi: `pi`
 - GitHub Copilot CLI: `copilot`
 - Opencode: `opencode`
 - Kilo: `kilo`

--- a/README.org
+++ b/README.org
@@ -11,6 +11,7 @@ An Emacs interface for AI-assisted software development. *The purpose is to prov
 
 - Currently it supports these AI coding CLIs:
   - [[https://github.com/openai/codex][OpenAI Codex]]
+  - [[https://pi.dev/][Pi]]
   - [[https://antigravity.google/product/antigravity-cli][Antigravity CLI]]
   - [[https://opencode.ai/][Opencode]]
   - [[https://github.com/anthropics/claude-code][Claude Code]]
@@ -59,7 +60,8 @@ Minimal setup:
 #+end_src
 
 First 60 seconds:
-- `C-c a a`: Start AI CLI session
+- `C-c a a`: Start the currently selected AI CLI session
+- `C-c a p`: Select Pi and start it directly (`C-u`: resume)
 - `C-c a c`: Ask AI to change current function/region
 - `C-c a q`: Ask question only (no code change)
 - `C-c a z`: Jump back to AI session buffer
@@ -86,7 +88,7 @@ Enable installation of packages from MELPA by adding an entry to package-archive
   (use-package ai-code
     ;; :straight (:host github :repo "tninja/ai-code-interface.el") ;; if you want to use straight to install, no need to have MELPA setting above
     :config
-    ;; use codex as backend, other options are 'claude-code, 'gemini, 'github-copilot-cli, 'open-interpreter, 'opencode, 'kilo, 'grok, 'cursor, 'kiro, 'codebuddy, 'aider, 'eca, 'agent-shell, 'claude-code-ide, 'claude-code-el
+    ;; use codex as backend, other options are 'pi, 'claude-code, 'gemini, 'github-copilot-cli, 'open-interpreter, 'opencode, 'kilo, 'grok, 'cursor, 'kiro, 'codebuddy, 'aider, 'eca, 'agent-shell, 'claude-code-ide, 'claude-code-el
     (ai-code-set-backend 'codex)
     ;; Optional: default menu stays unchanged; use a narrower 2-column layout on smaller frames
     ;; (setq ai-code-menu-layout 'two-columns)
@@ -187,8 +189,8 @@ appends the destination PNG path when invoking it:
   - When a visible AI session buffer already exists, prompts can be routed to that session directly instead of opening a new one.
 - *Insert into AI Sessions*: Open the configurable `ai-code-menu` prefix (`C-c a` in the configuration examples), then press `I` to open the Insert submenu for files, Dired selections, regions, diagnostics-aware DWIM, screenshots, and clipboard images. The `I` entry always remains available. If no session is running, pressing it reports that state; if only sessions for other projects are running, it opens the submenu with just the `to...` entries for choosing one explicitly. An editor viewport associated with the destination session receives the insertion when present; otherwise AI Code inserts into that session's TUI input without submitting it. Screenshot capture may require the [[*Optional Screenshot Capture][platform-specific utility described above]].
   - Inserted TUI content is always preceded and followed by two newline characters.[fn:insert-tui-spacing] In a viewport, AI Code omits the leading two newlines when the viewport is empty, keeps them when it already contains content, and always appends two newlines. Viewport attachments follow the same spacing rule.
-- *Agile Development Workflows*: Use the refactoring navigator (`r`), the guided TDD cycle (`t`), and the pull/review diff helper (`v`) to keep AI-assisted work aligned with agile best practices. Prompt authoring is first-class through quick access to the prompt file (`p`), build/test helper (`b`), and AI-assisted shell/file execution (`!`). In prompt files, send the current block with `C-c C-c`.
-- *Productivity & Debugging Utilities*: Initialize project navigation assets (`.`), investigate exceptions (`e`), debug Emacs runtime issues (`d`), auto-fix Flycheck issues in scope (`f`), copy or open file paths formatted for prompts (`k`, `o`), generate MCP inspector commands (`m`), capture session notes straight into Org (`n`), search notes with AI (`/`), dictate prompts with speech-to-text (`:`), and toggle desktop notifications (`N`) to get alerted when AI responses are ready in background sessions.
+- *Agile Development Workflows*: Use the refactoring navigator (`r`), the guided TDD cycle (`t`), and the pull/review diff helper (`v`) to keep AI-assisted work aligned with agile best practices. Prompt authoring is first-class through quick access to the prompt file (`o`), build/test helper (`b`), and AI-assisted shell/file execution (`!`). In prompt files, send the current block with `C-c C-c`.
+- *Productivity & Debugging Utilities*: Initialize project navigation assets (`.`), investigate exceptions (`e`), debug Emacs runtime issues (`d`), auto-fix Flycheck issues in scope (`f`), copy file paths formatted for prompts (`k`), open prompt history (`o`), capture session notes straight into Org (`n`), search notes with AI (`/`), and dictate prompts with speech-to-text (`:`).
 - *Architecture Document Generation*: Derive practical architecture documents for the current repository with `C-c a A` (`ai-code-derive-architecture-document`). The command can generate architecture guardrails, a C4 PlantUML overview, a lightweight DDD context, or a test context document under `.ai.code.files/architecture/` so future AI coding sessions can reuse module boundaries, dependency rules, runtime flows, and validation expectations. See [[./docs/architecture/c4-overview.org][the C4 architecture overview for this repository]] for an example C4 diagram guide.
 - *Seamless Prompt Management*: Open the prompt file via `ai-code-open-prompt-file` (stored under `.ai.code.files/.ai.code.prompt.org` by default), send regions with `ai-code-prompt-send-block`, and reuse prompt snippets via `yasnippet` to keep conversations organized.
 - *Interactive Chat & Context Tools*: Dedicated buffers hold long-running chats, automatically enriched with file paths, diffs, and history from Magit or Git commands for richer AI responses.
@@ -463,6 +465,7 @@ To transfer development work between different AI coding backends (e.g., from Co
 
    Natively supported options:
    - [[https://github.com/openai/codex][OpenAI codex CLI]] (`[[./ai-code-codex-cli.el][ai-code-codex-cli.el]]`)
+   - [[https://pi.dev/][Pi]] (`[[./ai-code-pi.el][ai-code-pi.el]]`)
    - [[https://antigravity.google/product/antigravity-cli][Antigravity CLI]] (`[[./ai-code-antigravity-cli.el][ai-code-antigravity-cli.el]]`)
    - [[https://opencode.ai/][Opencode]] (`[[./ai-code-opencode.el][ai-code-opencode.el]]`)
    - [[https://github.com/anthropics/claude-code][Claude Code]] (`[[./ai-code-claude-code.el][ai-code-claude-code.el]]`)
@@ -500,6 +503,18 @@ To transfer development work between different AI coding backends (e.g., from Co
      Install [[https://github.com/xenodium/agent-shell][agent-shell]] and its dependency [[https://github.com/xenodium/acp.el][acp.el]], then configure one of the ACP agent providers in agent-shell (for example Codex, Gemini, Opencode, etc.).
      Select `agent-shell` via `ai-code-select-backend` (or `(ai-code-set-backend 'agent-shell)` in your config).
      Note: `ai-code-apply-prompt-on-current-file` is CLI-pipe based and is not supported when `agent-shell` is the active backend.
+
+**** Pi setup
+     Install Pi with =npm install -g --ignore-scripts @earendil-works/pi-coding-agent=,
+     or use the installer documented at [[https://pi.dev/][pi.dev]].  Ensure the =pi=
+     executable is on your PATH, authenticate with an API key or =/login=, and
+     select the backend with =(ai-code-set-backend 'pi)=.  Customize
+     =ai-code-pi-program= or =ai-code-pi-program-switches= to change the
+     executable or startup flags.  =C-c a p= is a first-level shortcut that
+     selects Pi and starts it directly; use =C-u C-c a p= to open Pi's resume
+     picker.  =C-c a R= also resumes when Pi is already selected.  In Pi session buffers, Shift+Enter and
+     Ctrl+Enter insert a newline, and Ctrl+Escape sends Escape to cancel the
+     current operation.
 
 **** Grok CLI setup
      Install [[https://grokcli.io/][grok-cli]] and ensure the `grok` executable is on your PATH.

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -270,6 +270,19 @@ so the CLI itself handles the installation details."
      :upgrade nil
      :install-skills nil
      :cli     "codex")
+    (pi
+     :label "Pi"
+     :require ai-code-pi
+     :start   ai-code-pi-start
+     :switch  ai-code-pi-switch-to-buffer
+     :send    ai-code-pi-send-command
+     :resume  ai-code-pi-resume
+     :config  "~/.pi/agent/settings.json"
+     :agent-file "AGENTS.md"
+     :install "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"
+     :upgrade "pi update --self"
+     :install-skills nil
+     :cli     "pi")
     (open-interpreter
      :label "Open Interpreter CLI"
      :require ai-code-open-interpreter-cli

--- a/ai-code-behaviors.el
+++ b/ai-code-behaviors.el
@@ -2245,6 +2245,7 @@ Call this when completely disabling ai-code-behaviors."
     (gemini . "gemini")
     (github-copilot-cli . "copilot")
     (codex . "codex")
+    (pi . "pi")
     (cursor . "cursor")
     (aider . "aider")
     (grok . "grok")

--- a/ai-code-pi.el
+++ b/ai-code-pi.el
@@ -1,0 +1,101 @@
+;;; ai-code-pi.el --- Thin wrapper for Pi coding agent -*- lexical-binding: t; -*-
+
+;; Author: realazy
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;;
+;; Provide Pi coding agent integration by reusing
+;; `ai-code-backends-infra'.  See https://pi.dev/.
+
+;;; Code:
+
+(require 'ai-code-backends)
+(require 'ai-code-backends-infra)
+
+(defgroup ai-code-pi nil
+  "Pi coding agent integration via `ai-code-backends-infra'."
+  :group 'tools
+  :prefix "ai-code-pi-")
+
+(defcustom ai-code-pi-program "pi"
+  "Path to the Pi coding agent executable."
+  :type 'string
+  :group 'ai-code-pi)
+
+(defcustom ai-code-pi-program-switches nil
+  "Command-line switches to pass to Pi on startup."
+  :type '(repeat string)
+  :group 'ai-code-pi)
+
+(defcustom ai-code-pi-multiline-input-sequence "\e[13;2u"
+  "Terminal sequence Pi recognizes as Shift+Enter for multiline input.
+The default uses the Kitty keyboard protocol sequence documented by Pi."
+  :type 'string
+  :group 'ai-code-pi)
+
+(defconst ai-code-pi--session-prefix "pi"
+  "Session prefix used in Pi buffer names.")
+
+(defvar ai-code-pi--processes (make-hash-table :test 'equal)
+  "Hash table mapping Pi session keys to processes.")
+
+;;;###autoload
+(defun ai-code-pi-start (&optional arg)
+  "Start Pi using `ai-code-backends-infra' logic.
+With prefix ARG, prompt for CLI args using
+`ai-code-pi-program-switches' as the default input."
+  (interactive "P")
+  (ai-code-backends-infra--start-cli-session
+   (list :program ai-code-pi-program
+         :switches ai-code-pi-program-switches
+         :label "Pi"
+         :process-table ai-code-pi--processes
+         :session-prefix ai-code-pi--session-prefix
+         :escape-function #'ai-code-pi-send-escape
+         :multiline-input-sequence ai-code-pi-multiline-input-sequence)
+   arg))
+
+;;;###autoload
+(defun ai-code-pi-switch-to-buffer (&optional force-prompt)
+  "Switch to a Pi session buffer.
+When FORCE-PROMPT is non-nil, prompt to select a session."
+  (interactive "P")
+  (ai-code-backends-infra--cli-switch-to-buffer
+   "Pi" ai-code-pi--session-prefix force-prompt))
+
+;;;###autoload
+(defun ai-code-pi-send-command (line)
+  "Send LINE to Pi.
+When called interactively, prompt for the command."
+  (interactive "sPi> ")
+  (ai-code-backends-infra--cli-send-command
+   "Pi" ai-code-pi--session-prefix line))
+
+;;;###autoload
+(defun ai-code-pi-send-escape ()
+  "Send Escape to Pi to cancel its current operation."
+  (interactive)
+  (ai-code-backends-infra--terminal-send-escape))
+
+;;;###autoload
+(defun ai-code-pi-resume (&optional arg)
+  "Open Pi's session picker and resume a previous session.
+When the active region is a session UUID and ARG is nil, resume that
+session directly.  Otherwise ARG is passed to the underlying start function."
+  (interactive "P")
+  (let* ((session-id (and (null arg)
+                          (ai-code-backends-infra--selected-session-id)))
+         (ai-code-pi-program-switches
+          (append ai-code-pi-program-switches
+                  (if session-id
+                      (list "--session" session-id)
+                    '("--resume")))))
+    (ai-code-pi-start arg)
+    (unless session-id
+      (ai-code-backends-infra--cli-show-resume-picker
+       ai-code-pi--session-prefix))))
+
+(provide 'ai-code-pi)
+
+;;; ai-code-pi.el ends here

--- a/ai-code.el
+++ b/ai-code.el
@@ -24,6 +24,7 @@
 ;;
 ;; Supported AI coding CLIs include:
 ;;   - OpenAI Codex
+;;   - Pi
 ;;   - Antigravity CLI
 ;;   - Opencode
 ;;   - Claude Code
@@ -50,7 +51,8 @@
 ;;        (global-set-key (kbd "C-c a") #'ai-code-menu))
 ;;
 ;;   2) First 60 seconds:
-;;      - C-c a a : Start AI CLI session
+;;      - C-c a a : Start the selected AI CLI session
+;;      - C-c a p : Select Pi and start it directly (C-u: resume)
 ;;      - C-c a c : Ask AI to change current function/region
 ;;      - C-c a q : Ask question only (no code change)
 ;;      - C-c a z : Jump back to active AI session buffer
@@ -59,7 +61,7 @@
 ;;
 ;; (use-package ai-code
 ;;   :config
-;;   ;; use codex as backend, other options are 'gemini, 'github-copilot-cli, 'open-interpreter, 'opencode, 'kilo, 'grok, 'claude-code-ide, 'claude-code-el, 'claude-code, 'cursor, 'kiro, 'codebuddy, 'aider, 'agent-shell, 'eca
+;;   ;; use codex as backend, other options are 'pi, 'gemini, 'github-copilot-cli, 'open-interpreter, 'opencode, 'kilo, 'grok, 'claude-code-ide, 'claude-code-el, 'claude-code, 'cursor, 'kiro, 'codebuddy, 'aider, 'agent-shell, 'eca
 ;;   (ai-code-set-backend 'codex) ;; set your preferred backend
 ;;   ;; Optional: use a narrower transient menu on smaller frames
 ;;   ;; (setq ai-code-menu-layout 'two-columns)
@@ -400,6 +402,17 @@ Otherwise switch to AI CLI buffer."
       (wrong-number-of-arguments ;; will be triggered during calling corresponding function in external backends such as claude-code-ide.el, claude-code.el, since the corresponding function doesn't have parameter
        (ai-code-cli-switch-to-buffer)))))
 
+;;;###autoload
+(defun ai-code-start-pi (&optional arg)
+  "Select the Pi backend and start a Pi session.
+With prefix ARG, open Pi's session picker instead of starting a new session."
+  (interactive "P")
+  (ai-code-set-backend 'pi)
+  (if arg
+      (let ((current-prefix-arg nil))
+        (ai-code-cli-resume))
+    (ai-code-cli-start)))
+
 (defclass ai-code--use-prompt-suffix-type (transient-lisp-variable)
   ((variable :initform 'ai-code-use-prompt-suffix)
    (format :initform "%k %d %v")
@@ -500,6 +513,7 @@ Shows the current backend label to the right."
 ;; Mirror aider.el's reusable-section approach using `transient-define-group`.
 (transient-define-group ai-code--menu-ai-cli-session
   ("a" "Start AI CLI (C-u: args)" ai-code-cli-start)
+  ("p" "Start Pi (C-u: resume)" ai-code-start-pi)
   ("R" "Resume AI CLI (C-u: args)" ai-code-cli-resume)
   ("z" "Switch to AI CLI (C-u: hide)" ai-code-cli-switch-to-buffer-or-hide)
   ("s" ai-code-select-backend :description ai-code--select-backend-description)
@@ -571,8 +585,7 @@ Shows the current backend label to the right."
   ("e" "Investigate exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)
   ("k" "Copy Cur File Name (C-u: full)" ai-code-copy-buffer-file-name-to-clipboard)
-  ;; ("o" "Open recent file (C-u: insert)" ai-code-git-repo-recent-modified-files)
-  ("p" "Open prompt history file" ai-code-open-prompt-file)
+  ("o" "Open prompt history file" ai-code-open-prompt-file)
   ;; ("m" "Debug python MCP server" ai-code-debug-mcp)
   ;; ("N" "Toggle notifications" ai-code-notifications-toggle)
   ("d" "Debug Emacs runtime" ai-code-debug-emacs-runtime)

--- a/test/test_ai-code-backends.el
+++ b/test/test_ai-code-backends.el
@@ -166,6 +166,23 @@
     (should (equal (plist-get (cdr spec) :upgrade) "agy update"))
     (should (equal (plist-get (cdr spec) :cli) "agy"))))
 
+(ert-deftest ai-code-test-pi-backend-spec-contract ()
+  "Ensure the Pi backend entry exposes required integration keys."
+  (let ((spec (ai-code--backend-spec 'pi)))
+    (should spec)
+    (should (eq (plist-get (cdr spec) :require) 'ai-code-pi))
+    (should (eq (plist-get (cdr spec) :start) 'ai-code-pi-start))
+    (should (eq (plist-get (cdr spec) :switch) 'ai-code-pi-switch-to-buffer))
+    (should (eq (plist-get (cdr spec) :send) 'ai-code-pi-send-command))
+    (should (eq (plist-get (cdr spec) :resume) 'ai-code-pi-resume))
+    (should (equal (plist-get (cdr spec) :config)
+                   "~/.pi/agent/settings.json"))
+    (should (equal (plist-get (cdr spec) :agent-file) "AGENTS.md"))
+    (should (equal (plist-get (cdr spec) :install)
+                   "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"))
+    (should (equal (plist-get (cdr spec) :upgrade) "pi update --self"))
+    (should (equal (plist-get (cdr spec) :cli) "pi"))))
+
 (ert-deftest ai-code-test-backend-selection-keeps-repo-session-backend ()
   "Switching backend in one repo should not overwrite started backend in another repo."
   (let* ((ai-code-backends

--- a/test/test_ai-code-behaviors.el
+++ b/test/test_ai-code-behaviors.el
@@ -556,6 +556,7 @@
   (should (assoc 'opencode ai-code--backend-session-prefixes))
   (should (assoc 'kilo ai-code--backend-session-prefixes))
   (should (assoc 'claude-code ai-code--backend-session-prefixes))
+  (should (assoc 'pi ai-code--backend-session-prefixes))
   (should-not (assoc 'eca ai-code--backend-session-prefixes)))
 
 (ert-deftest ai-code-test-get-session-prefix ()
@@ -563,6 +564,7 @@
   (should (equal "opencode" (alist-get 'opencode ai-code--backend-session-prefixes)))
   (should (equal "kilo" (alist-get 'kilo ai-code--backend-session-prefixes)))
   (should (equal "claude" (alist-get 'claude-code ai-code--backend-session-prefixes)))
+  (should (equal "pi" (alist-get 'pi ai-code--backend-session-prefixes)))
   (should-not (alist-get 'eca ai-code--backend-session-prefixes)))
 
 (ert-deftest ai-code-test-command-preset-map ()

--- a/test/test_ai-code-pi.el
+++ b/test/test_ai-code-pi.el
@@ -1,0 +1,83 @@
+;;; test_ai-code-pi.el --- Tests for ai-code-pi.el -*- lexical-binding: t; -*-
+
+;; Author: realazy
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for the Pi coding agent backend.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'ai-code-pi)
+
+(ert-deftest ai-code-test-pi-start-uses-generic-helper ()
+  "Pi startup should delegate session setup to the shared helper."
+  (let (captured-options
+        captured-arg)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
+               (lambda (options arg)
+                 (setq captured-options options
+                       captured-arg arg))))
+      (let ((ai-code-pi-program "pi-test")
+            (ai-code-pi-program-switches '("--offline"))
+            (ai-code-pi-multiline-input-sequence "\e[13;2u"))
+        (ai-code-pi-start 'prefix-arg)))
+    (should (eq captured-arg 'prefix-arg))
+    (should (equal (plist-get captured-options :program) "pi-test"))
+    (should (equal (plist-get captured-options :switches) '("--offline")))
+    (should (equal (plist-get captured-options :label) "Pi"))
+    (should (eq (plist-get captured-options :process-table)
+                ai-code-pi--processes))
+    (should (equal (plist-get captured-options :session-prefix) "pi"))
+    (should (eq (plist-get captured-options :escape-function)
+                #'ai-code-pi-send-escape))
+    (should (equal (plist-get captured-options :multiline-input-sequence)
+                   "\e[13;2u"))))
+
+(ert-deftest ai-code-test-pi-resume-opens-session-picker ()
+  "Pi resume should launch with --resume and display its picker."
+  (let (captured-switches
+        captured-arg
+        captured-prefix)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--selected-session-id)
+               (lambda () nil))
+              ((symbol-function 'ai-code-pi-start)
+               (lambda (&optional arg)
+                 (setq captured-switches ai-code-pi-program-switches
+                       captured-arg arg)))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (prefix)
+                 (setq captured-prefix prefix))))
+      (let ((ai-code-pi-program-switches '("--offline")))
+        (ai-code-pi-resume)))
+    (should (equal captured-switches '("--offline" "--resume")))
+    (should-not captured-arg)
+    (should (equal captured-prefix "pi"))))
+
+(ert-deftest ai-code-test-pi-resume-selected-session-uses-session-flag ()
+  "Pi resume should pass a selected UUID through --session."
+  (let ((session-id "12345678-1234-1234-1234-123456789abc")
+        captured-switches
+        captured-arg
+        picker-shown)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--selected-session-id)
+               (lambda () session-id))
+              ((symbol-function 'ai-code-pi-start)
+               (lambda (&optional arg)
+                 (setq captured-switches ai-code-pi-program-switches
+                       captured-arg arg)))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (_prefix)
+                 (setq picker-shown t))))
+      (let ((ai-code-pi-program-switches '("--offline")))
+        (ai-code-pi-resume)))
+    (should (equal captured-switches
+                   (list "--offline" "--session" session-id)))
+    (should-not captured-arg)
+    (should-not picker-shown)))
+
+(provide 'test_ai-code-pi)
+
+;;; test_ai-code-pi.el ends here

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -276,6 +276,76 @@
     (should-not
      (search-forward ";; DONE: add a menu item: Debug your emacs runtime." nil t))))
 
+(ert-deftest ai-code-test-start-pi-activates-backend-and-starts-session ()
+  "The direct Pi launcher should activate Pi and start a new session."
+  (let ((ai-code-selected-backend 'codex)
+        (ai-code--cli-start-fn #'ignore)
+        (ai-code--cli-switch-fn #'ignore)
+        (ai-code--cli-send-fn #'ignore)
+        (ai-code--cli-resume-fn #'ignore)
+        (ai-code-cli "codex")
+        captured-options
+        captured-arg)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
+               (lambda (options arg)
+                 (setq captured-options options
+                       captured-arg arg)))
+              ((symbol-function 'ai-code--git-root)
+               (lambda (&optional _dir) nil))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (ai-code-start-pi))
+    (should (eq ai-code-selected-backend 'pi))
+    (should (equal ai-code-cli "pi"))
+    (should (equal (plist-get captured-options :program) "pi"))
+    (should-not (plist-get captured-options :switches))
+    (should-not captured-arg)))
+
+(ert-deftest ai-code-test-start-pi-prefix-resumes-without-args-prompt ()
+  "A prefix should open Pi's resume picker without forwarding the prefix."
+  (let ((ai-code-selected-backend 'codex)
+        (ai-code--cli-start-fn #'ignore)
+        (ai-code--cli-switch-fn #'ignore)
+        (ai-code--cli-send-fn #'ignore)
+        (ai-code--cli-resume-fn #'ignore)
+        (ai-code-cli "codex")
+        captured-options
+        captured-arg
+        picker-prefix)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
+               (lambda (options arg)
+                 (setq captured-options options
+                       captured-arg arg)))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (prefix)
+                 (setq picker-prefix prefix)))
+              ((symbol-function 'ai-code--git-root)
+               (lambda (&optional _dir) nil))
+              ((symbol-function 'message)
+               (lambda (&rest _args) nil)))
+      (let ((current-prefix-arg '(4)))
+        (ai-code-start-pi '(4))))
+    (should (eq ai-code-selected-backend 'pi))
+    (should (equal (plist-get captured-options :switches) '("--resume")))
+    (should-not captured-arg)
+    (should (equal picker-prefix "pi"))))
+
+(ert-deftest ai-code-test-menu-p-starts-pi-at-top-level ()
+  "Test that p is the top-level direct launcher for Pi."
+  (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "p")))
+    (should suffix)
+    (should (equal (plist-get (cdr suffix) :description)
+                   "Start Pi (C-u: resume)"))
+    (should (eq (plist-get (cdr suffix) :command)
+                'ai-code-start-pi))))
+
+(ert-deftest ai-code-test-menu-o-opens-prompt-history ()
+  "Test that prompt history moves to the available o binding."
+  (let ((suffix (transient-get-suffix 'ai-code--menu-other-tools "o")))
+    (should suffix)
+    (should (eq (plist-get (cdr suffix) :command)
+                'ai-code-open-prompt-file))))
+
 (ert-deftest ai-code-test-menu-ai-cli-session-includes-select-terminal-entry ()
   "Test that the AI CLI session menu exposes terminal backend selection."
   (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "l")))


### PR DESCRIPTION
## Summary

Add native [Pi](https://pi.dev/) coding agent support using the shared AI Code terminal infrastructure.

## Changes

- Add the `ai-code-pi.el` backend with support for:
  - starting sessions;
  - switching between project sessions;
  - sending commands;
  - resuming saved sessions;
  - multiline input via the Kitty keyboard protocol;
  - cancelling operations with `C-<escape>`.
- Register Pi in `ai-code-backends` with:
  - config path: `~/.pi/agent/settings.json`;
  - agent file: `AGENTS.md`;
  - install command: `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`;
  - upgrade command: `pi update --self`.
- Add Pi session detection for behavior presets.
- Add a first-level Pi launcher:
  - `p`: start a new Pi session;
  - `C-u p`: open Pi's resume picker.
- Move “Open prompt history file” from `p` to `o`.
- Update README documentation and contributor guidance.
- Add backend, menu, session, and prefix-argument tests.

## User-facing keybinding change

The top-level `p` binding is now reserved for starting Pi. The prompt history command has moved to `o`.

## Test plan

- [x] Run the full ERT suite: 1244 tests, 0 unexpected failures, 13 skipped.
- [x] Run Checkdoc on touched Emacs Lisp files.
- [x] Run byte compilation.
- [x] Run `git diff --check`.
