### PR TITLE
Fix: remove dedicated Pi launcher

### DIFF
--- a/README.org
+++ b/README.org
@@ -61,7 +61,6 @@ Minimal setup:
 
 First 60 seconds:
 - `C-c a a`: Start the currently selected AI CLI session
-- `C-c a p`: Select Pi and start it directly (`C-u`: resume)
 - `C-c a c`: Ask AI to change current function/region
 - `C-c a q`: Ask question only (no code change)
 - `C-c a z`: Jump back to AI session buffer
@@ -189,8 +188,8 @@ appends the destination PNG path when invoking it:
   - When a visible AI session buffer already exists, prompts can be routed to that session directly instead of opening a new one.
 - *Insert into AI Sessions*: Open the configurable `ai-code-menu` prefix (`C-c a` in the configuration examples), then press `I` to open the Insert submenu for files, Dired selections, regions, diagnostics-aware DWIM, screenshots, and clipboard images. The `I` entry always remains available. If no session is running, pressing it reports that state; if only sessions for other projects are running, it opens the submenu with just the `to...` entries for choosing one explicitly. An editor viewport associated with the destination session receives the insertion when present; otherwise AI Code inserts into that session's TUI input without submitting it. Screenshot capture may require the [[*Optional Screenshot Capture][platform-specific utility described above]].
   - Inserted TUI content is always preceded and followed by two newline characters.[fn:insert-tui-spacing] In a viewport, AI Code omits the leading two newlines when the viewport is empty, keeps them when it already contains content, and always appends two newlines. Viewport attachments follow the same spacing rule.
-- *Agile Development Workflows*: Use the refactoring navigator (`r`), the guided TDD cycle (`t`), and the pull/review diff helper (`v`) to keep AI-assisted work aligned with agile best practices. Prompt authoring is first-class through quick access to the prompt file (`o`), build/test helper (`b`), and AI-assisted shell/file execution (`!`). In prompt files, send the current block with `C-c C-c`.
-- *Productivity & Debugging Utilities*: Initialize project navigation assets (`.`), investigate exceptions (`e`), debug Emacs runtime issues (`d`), auto-fix Flycheck issues in scope (`f`), copy file paths formatted for prompts (`k`), open prompt history (`o`), capture session notes straight into Org (`n`), search notes with AI (`/`), and dictate prompts with speech-to-text (`:`).
+- *Agile Development Workflows*: Use the refactoring navigator (`r`), the guided TDD cycle (`t`), and the pull/review diff helper (`v`) to keep AI-assisted work aligned with agile best practices. Prompt authoring is first-class through quick access to the prompt file (`p`), build/test helper (`b`), and AI-assisted shell/file execution (`!`). In prompt files, send the current block with `C-c C-c`.
+- *Productivity & Debugging Utilities*: Initialize project navigation assets (`.`), investigate exceptions (`e`), debug Emacs runtime issues (`d`), auto-fix Flycheck issues in scope (`f`), copy file paths formatted for prompts (`k`), open prompt history (`p`), capture session notes straight into Org (`n`), search notes with AI (`/`), and dictate prompts with speech-to-text (`:`).
 - *Architecture Document Generation*: Derive practical architecture documents for the current repository with `C-c a A` (`ai-code-derive-architecture-document`). The command can generate architecture guardrails, a C4 PlantUML overview, a lightweight DDD context, or a test context document under `.ai.code.files/architecture/` so future AI coding sessions can reuse module boundaries, dependency rules, runtime flows, and validation expectations. See [[./docs/architecture/c4-overview.org][the C4 architecture overview for this repository]] for an example C4 diagram guide.
 - *Seamless Prompt Management*: Open the prompt file via `ai-code-open-prompt-file` (stored under `.ai.code.files/.ai.code.prompt.org` by default), send regions with `ai-code-prompt-send-block`, and reuse prompt snippets via `yasnippet` to keep conversations organized.
 - *Interactive Chat & Context Tools*: Dedicated buffers hold long-running chats, automatically enriched with file paths, diffs, and history from Magit or Git commands for richer AI responses.
@@ -508,11 +507,10 @@ To transfer development work between different AI coding backends (e.g., from Co
      Install Pi with =npm install -g --ignore-scripts @earendil-works/pi-coding-agent=,
      or use the installer documented at [[https://pi.dev/][pi.dev]].  Ensure the =pi=
      executable is on your PATH, authenticate with an API key or =/login=, and
-     select the backend with =(ai-code-set-backend 'pi)=.  Customize
+     select the backend with =C-c a s= or =(ai-code-set-backend 'pi)=.  Customize
      =ai-code-pi-program= or =ai-code-pi-program-switches= to change the
-     executable or startup flags.  =C-c a p= is a first-level shortcut that
-     selects Pi and starts it directly; use =C-u C-c a p= to open Pi's resume
-     picker.  =C-c a R= also resumes when Pi is already selected.  In Pi session buffers, Shift+Enter and
+     executable or startup flags.  Once selected, =C-c a a= starts Pi and
+     =C-c a R= resumes a session.  In Pi session buffers, Shift+Enter and
      Ctrl+Enter insert a newline, and Ctrl+Escape sends Escape to cancel the
      current operation.
 

--- a/ai-code.el
+++ b/ai-code.el
@@ -52,7 +52,6 @@
 ;;
 ;;   2) First 60 seconds:
 ;;      - C-c a a : Start the selected AI CLI session
-;;      - C-c a p : Select Pi and start it directly (C-u: resume)
 ;;      - C-c a c : Ask AI to change current function/region
 ;;      - C-c a q : Ask question only (no code change)
 ;;      - C-c a z : Jump back to active AI session buffer
@@ -402,17 +401,6 @@ Otherwise switch to AI CLI buffer."
       (wrong-number-of-arguments ;; will be triggered during calling corresponding function in external backends such as claude-code-ide.el, claude-code.el, since the corresponding function doesn't have parameter
        (ai-code-cli-switch-to-buffer)))))
 
-;;;###autoload
-(defun ai-code-start-pi (&optional arg)
-  "Select the Pi backend and start a Pi session.
-With prefix ARG, open Pi's session picker instead of starting a new session."
-  (interactive "P")
-  (ai-code-set-backend 'pi)
-  (if arg
-      (let ((current-prefix-arg nil))
-        (ai-code-cli-resume))
-    (ai-code-cli-start)))
-
 (defclass ai-code--use-prompt-suffix-type (transient-lisp-variable)
   ((variable :initform 'ai-code-use-prompt-suffix)
    (format :initform "%k %d %v")
@@ -513,7 +501,6 @@ Shows the current backend label to the right."
 ;; Mirror aider.el's reusable-section approach using `transient-define-group`.
 (transient-define-group ai-code--menu-ai-cli-session
   ("a" "Start AI CLI (C-u: args)" ai-code-cli-start)
-  ("p" "Start Pi (C-u: resume)" ai-code-start-pi)
   ("R" "Resume AI CLI (C-u: args)" ai-code-cli-resume)
   ("z" "Switch to AI CLI (C-u: hide)" ai-code-cli-switch-to-buffer-or-hide)
   ("s" ai-code-select-backend :description ai-code--select-backend-description)
@@ -585,7 +572,8 @@ Shows the current backend label to the right."
   ("e" "Investigate exception (C-u: clipboard)" ai-code-investigate-exception)
   ("f" "Fix Flycheck errors in scope" ai-code-flycheck-fix-errors-in-scope)
   ("k" "Copy Cur File Name (C-u: full)" ai-code-copy-buffer-file-name-to-clipboard)
-  ("o" "Open prompt history file" ai-code-open-prompt-file)
+  ;; ("o" "Open recent file (C-u: insert)" ai-code-git-repo-recent-modified-files)
+  ("p" "Open prompt history file" ai-code-open-prompt-file)
   ;; ("m" "Debug python MCP server" ai-code-debug-mcp)
   ;; ("N" "Toggle notifications" ai-code-notifications-toggle)
   ("d" "Debug Emacs runtime" ai-code-debug-emacs-runtime)

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -276,72 +276,12 @@
     (should-not
      (search-forward ";; DONE: add a menu item: Debug your emacs runtime." nil t))))
 
-(ert-deftest ai-code-test-start-pi-activates-backend-and-starts-session ()
-  "The direct Pi launcher should activate Pi and start a new session."
-  (let ((ai-code-selected-backend 'codex)
-        (ai-code--cli-start-fn #'ignore)
-        (ai-code--cli-switch-fn #'ignore)
-        (ai-code--cli-send-fn #'ignore)
-        (ai-code--cli-resume-fn #'ignore)
-        (ai-code-cli "codex")
-        captured-options
-        captured-arg)
-    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
-               (lambda (options arg)
-                 (setq captured-options options
-                       captured-arg arg)))
-              ((symbol-function 'ai-code--git-root)
-               (lambda (&optional _dir) nil))
-              ((symbol-function 'message)
-               (lambda (&rest _args) nil)))
-      (ai-code-start-pi))
-    (should (eq ai-code-selected-backend 'pi))
-    (should (equal ai-code-cli "pi"))
-    (should (equal (plist-get captured-options :program) "pi"))
-    (should-not (plist-get captured-options :switches))
-    (should-not captured-arg)))
-
-(ert-deftest ai-code-test-start-pi-prefix-resumes-without-args-prompt ()
-  "A prefix should open Pi's resume picker without forwarding the prefix."
-  (let ((ai-code-selected-backend 'codex)
-        (ai-code--cli-start-fn #'ignore)
-        (ai-code--cli-switch-fn #'ignore)
-        (ai-code--cli-send-fn #'ignore)
-        (ai-code--cli-resume-fn #'ignore)
-        (ai-code-cli "codex")
-        captured-options
-        captured-arg
-        picker-prefix)
-    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
-               (lambda (options arg)
-                 (setq captured-options options
-                       captured-arg arg)))
-              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
-               (lambda (prefix)
-                 (setq picker-prefix prefix)))
-              ((symbol-function 'ai-code--git-root)
-               (lambda (&optional _dir) nil))
-              ((symbol-function 'message)
-               (lambda (&rest _args) nil)))
-      (let ((current-prefix-arg '(4)))
-        (ai-code-start-pi '(4))))
-    (should (eq ai-code-selected-backend 'pi))
-    (should (equal (plist-get captured-options :switches) '("--resume")))
-    (should-not captured-arg)
-    (should (equal picker-prefix "pi"))))
-
-(ert-deftest ai-code-test-menu-p-starts-pi-at-top-level ()
-  "Test that p is the top-level direct launcher for Pi."
-  (let ((suffix (transient-get-suffix 'ai-code--menu-ai-cli-session "p")))
-    (should suffix)
-    (should (equal (plist-get (cdr suffix) :description)
-                   "Start Pi (C-u: resume)"))
-    (should (eq (plist-get (cdr suffix) :command)
-                'ai-code-start-pi))))
-
-(ert-deftest ai-code-test-menu-o-opens-prompt-history ()
-  "Test that prompt history moves to the available o binding."
-  (let ((suffix (transient-get-suffix 'ai-code--menu-other-tools "o")))
+(ert-deftest ai-code-test-menu-p-opens-prompt-history ()
+  "Test that p remains the top-level prompt history binding."
+  (should-error
+   (transient-get-suffix 'ai-code--menu-ai-cli-session "p")
+   :type 'error)
+  (let ((suffix (transient-get-suffix 'ai-code--menu-other-tools "p")))
     (should suffix)
     (should (eq (plist-get (cdr suffix) :command)
                 'ai-code-open-prompt-file))))


### PR DESCRIPTION
## Summary

Follow up on #450 by removing the backend-specific Pi launcher from the top-level menu.

- Remove `ai-code-start-pi` and the dedicated `p` entry from the AI CLI session menu.
- Use the existing backend-agnostic workflow for Pi: select it with `s`, start it with `a`, and resume it with `R`.
- Restore `p` as the prompt history binding.
- Update the Pi setup documentation and menu tests accordingly.

## Context

The dedicated Pi shortcut was a personal keybinding customization that was accidentally included in #450. Keeping startup behind the generic backend commands preserves a consistent interface across all backends.

## Test plan

- [x] Run the full ERT suite: 1241 tests, 0 unexpected failures, 13 skipped.
- [x] Run Checkdoc on `ai-code.el`.
- [x] Byte-compile `ai-code.el`.
- [x] Run `git diff --check`.
