### PR TITLE
Confirm viewport cancellation and restore source focus

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Confirm before canceling a nonblank editor viewport and refocus its source
 
 ** 1.91
 - Add Grill support to some github related tool and scoped context copying, re-organize menu

--- a/ai-code-editor-viewport.el
+++ b/ai-code-editor-viewport.el
@@ -132,6 +132,12 @@ VIEWPORT defaults to the current buffer."
     (define-key map (kbd "C-c C-c") #'ai-code-editor-viewport-finish)
     (define-key map (kbd "C-c C-k") #'ai-code-editor-viewport-cancel)
     (define-key map (kbd "C-g") #'ai-code-editor-viewport-cancel)
+    (define-key map [remap abort-recursive-edit]
+                #'ai-code-editor-viewport-cancel)
+    (define-key map [remap exit-recursive-edit]
+                #'ai-code-editor-viewport-cancel)
+    (define-key map [remap keyboard-escape-quit]
+                #'ai-code-editor-viewport-cancel)
     (define-key map [remap yank] #'ai-code-editor-viewport-yank)
     (define-key map [remap clipboard-yank] #'ai-code-editor-viewport-yank)
     map)
@@ -146,11 +152,18 @@ VIEWPORT defaults to the current buffer."
 (defun ai-code-editor-viewport--header-command-keys
     (command all-bindings)
   "Return keys for COMMAND in the viewport map.
-Join every binding when ALL-BINDINGS is non-nil; otherwise return the first."
+Join every direct binding when ALL-BINDINGS is non-nil; otherwise return the
+first binding, including bindings supplied through command remapping."
   (if all-bindings
       (when-let* ((bindings
-                   (where-is-internal
-                    command ai-code-editor-viewport-mode-map)))
+                   (seq-remove
+                    (lambda (binding)
+                      (and (vectorp binding)
+                           (> (length binding) 0)
+                           (eq (aref binding 0) 'remap)))
+                    (where-is-internal
+                     command ai-code-editor-viewport-mode-map
+                     nil nil t))))
         (mapconcat #'key-description bindings "/"))
     (when-let* ((binding
                  (where-is-internal
@@ -357,13 +370,25 @@ Return the temporary overlay, or nil when SOURCE-BUFFER is no longer live."
   (setq ai-code-editor-viewport--outcome 'finished)
   (exit-recursive-edit))
 
+(defun ai-code-editor-viewport--discard-confirmed-p ()
+  "Return non-nil when the current viewport may be discarded."
+  (condition-case nil
+      (or (save-restriction
+            (widen)
+            (string-blank-p
+             (buffer-substring-no-properties (point-min) (point-max))))
+          (y-or-n-p "Discard viewport contents and cancel? "))
+    (quit nil)))
+
 (defun ai-code-editor-viewport-cancel ()
-  "Cancel the current AI CLI editor viewport without saving changes."
+  "Cancel the current AI CLI editor viewport without saving changes.
+Prompt before discarding content unless the viewport contains only whitespace."
   (interactive)
   (unless ai-code-editor-viewport-mode
     (user-error "Not in an AI CLI editor viewport"))
-  (setq ai-code-editor-viewport--outcome 'canceled)
-  (exit-recursive-edit))
+  (when (ai-code-editor-viewport--discard-confirmed-p)
+    (setq ai-code-editor-viewport--outcome 'canceled)
+    (exit-recursive-edit)))
 
 (defun ai-code-editor-viewport--replace-window (buffer window)
   "Display BUFFER by replacing WINDOW and return its display state."
@@ -740,7 +765,8 @@ When STAGING-FILE-P is non-nil, keep the saved file out of `recentf'."
   "Edit FILE in a viewport associated with SOURCE-BUFFER.
 LINE is one-based and COLUMN is zero-based, matching editor arguments.
 ORIGIN-FRAME preserves the request's frame across deferred handling.  When
-STAGING-FILE-P is non-nil, keep FILE out of `recentf'."
+STAGING-FILE-P is non-nil, keep FILE out of `recentf'.  After cancellation,
+refocus the original source window when it still displays SOURCE-BUFFER."
   (let* ((state (ai-code-editor-viewport--make-buffer
                  file source-buffer staging-file-p))
          (base-buffer (plist-get state :base-buffer))
@@ -750,6 +776,13 @@ STAGING-FILE-P is non-nil, keep FILE out of `recentf'."
          (source-cursor-offset
           (ai-code-editor-viewport--source-draft-cursor-offset
            source-buffer snapshot))
+         (source-window
+          (and (buffer-live-p source-buffer)
+               (get-buffer-window
+                source-buffer
+                (if (frame-live-p origin-frame)
+                    origin-frame
+                  (selected-frame)))))
          (display-state nil)
          (source-input-overlay nil)
          (finished nil))
@@ -776,16 +809,42 @@ STAGING-FILE-P is non-nil, keep FILE out of `recentf'."
                       (ai-code-editor-viewport--disable-source-input
                        source-buffer snapshot source-cursor-offset
                        (plist-get display-state :placement)))
-                (recursive-edit)
-                (when (eq ai-code-editor-viewport--outcome 'finished)
+                (while (not
+                        (memq
+                         (buffer-local-value
+                          'ai-code-editor-viewport--outcome buffer)
+                         '(finished canceled)))
+                  (condition-case nil
+                      (with-current-buffer buffer
+                        (recursive-edit))
+                    (quit nil))
+                  (unless (memq
+                           (buffer-local-value
+                            'ai-code-editor-viewport--outcome buffer)
+                           '(finished canceled))
+                    (with-current-buffer buffer
+                      (when (ai-code-editor-viewport--discard-confirmed-p)
+                        (setq ai-code-editor-viewport--outcome
+                              'canceled)))))
+                (when (eq (buffer-local-value
+                           'ai-code-editor-viewport--outcome buffer)
+                          'finished)
                   (ai-code-editor-viewport--commit-buffer
                    base-buffer buffer snapshot staging-file-p)
                   (setq finished t)))
             (when (overlayp source-input-overlay)
               (delete-overlay source-input-overlay))
-            (ai-code-editor-viewport-mode -1)
-            (ai-code-editor-viewport--restore-window
-             display-state buffer)))
+            (let ((canceled
+                   (eq (buffer-local-value
+                        'ai-code-editor-viewport--outcome buffer)
+                       'canceled)))
+              (ai-code-editor-viewport-mode -1)
+              (ai-code-editor-viewport--restore-window
+               display-state buffer)
+              (when (and canceled
+                         (window-live-p source-window)
+                         (eq (window-buffer source-window) source-buffer))
+                (select-window source-window)))))
       (when (buffer-live-p buffer)
         (kill-buffer buffer))
       (when (and (buffer-live-p owned-base-buffer)

--- a/test/test_ai-code-editor-viewport.el
+++ b/test/test_ai-code-editor-viewport.el
@@ -25,6 +25,12 @@
      (let ((,buffer (current-buffer)))
        ,@body)))
 
+(defun ai-code-editor-viewport-test--confirm-cancel ()
+  "Cancel the current viewport and confirm discarding nonblank content."
+  (cl-letf (((symbol-function 'y-or-n-p)
+             (lambda (_message) t)))
+    (ai-code-editor-viewport-cancel)))
+
 (defun ai-code-editor-viewport-test--display-from-lateral-side
     (side source-buffer viewport-buffer &optional width)
   "Display VIEWPORT-BUFFER from a SIDE SOURCE-BUFFER fixture.
@@ -75,6 +81,196 @@ Give the source side window WIDTH columns, defaulting to 40."
     (ai-code-editor-viewport-mode 1)
     (should (eq (key-binding (kbd "C-g"))
                 #'ai-code-editor-viewport-cancel))))
+
+(ert-deftest test-ai-code-editor-viewport--mode-remaps-recursive-exits-to-cancel ()
+  "Standard `recursive-edit' exits should use viewport cancellation."
+  (with-temp-buffer
+    (ai-code-editor-viewport-mode 1)
+    (dolist (command '(abort-recursive-edit
+                       exit-recursive-edit
+                       keyboard-escape-quit))
+      (should (eq (command-remapping command)
+                  #'ai-code-editor-viewport-cancel)))))
+
+(ert-deftest test-ai-code-editor-viewport--cancel-keeps-nonblank-content-when-declined ()
+  "Declining discard confirmation should keep editing nonblank content."
+  (with-temp-buffer
+    (insert "draft")
+    (ai-code-editor-viewport-mode 1)
+    (let (prompt exited)
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (message)
+                   (setq prompt message)
+                   nil))
+                ((symbol-function 'exit-recursive-edit)
+                 (lambda ()
+                   (setq exited t))))
+        (ai-code-editor-viewport-cancel))
+      (should (string-match-p "discard" (downcase prompt)))
+      (should-not exited)
+      (should (equal (buffer-string) "draft")))))
+
+(ert-deftest test-ai-code-editor-viewport--cancel-discards-nonblank-content-when-confirmed ()
+  "Confirming discard should cancel editing nonblank content."
+  (with-temp-buffer
+    (insert "draft")
+    (ai-code-editor-viewport-mode 1)
+    (let (prompt exited)
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (message)
+                   (setq prompt message)
+                   t))
+                ((symbol-function 'exit-recursive-edit)
+                 (lambda ()
+                   (setq exited t))))
+        (ai-code-editor-viewport-cancel))
+      (should (string-match-p "discard" (downcase prompt)))
+      (should exited))))
+
+(ert-deftest test-ai-code-editor-viewport--cancel-skips-confirmation-for-blank-content ()
+  "Canceling whitespace-only content should exit without confirmation."
+  (with-temp-buffer
+    (insert " \n\t ")
+    (ai-code-editor-viewport-mode 1)
+    (let (exited)
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (_message)
+                   (ert-fail "Blank viewport content should not prompt")))
+                ((symbol-function 'exit-recursive-edit)
+                 (lambda ()
+                   (setq exited t))))
+        (ai-code-editor-viewport-cancel))
+      (should exited))))
+
+(ert-deftest test-ai-code-editor-viewport--cancel-checks-content-outside-narrowing ()
+  "Canceling should confirm when nonblank content is hidden by narrowing."
+  (with-temp-buffer
+    (insert "hidden draft")
+    (narrow-to-region (point-max) (point-max))
+    (ai-code-editor-viewport-mode 1)
+    (let (prompt exited)
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (message)
+                   (setq prompt message)
+                   nil))
+                ((symbol-function 'exit-recursive-edit)
+                 (lambda ()
+                   (setq exited t))))
+        (ai-code-editor-viewport-cancel))
+      (should prompt)
+      (should-not exited))))
+
+(ert-deftest test-ai-code-editor-viewport--alternate-exit-decline-keeps-editing ()
+  "Declining an alternate recursive exit should resume viewport editing."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-alternate-exit-source*")
+    (let* ((directory (make-temp-file "ai-code-editor-alternate-exit-" t))
+           (file (expand-file-name "prompt.md" directory))
+           (answers '(nil t))
+           (recursive-calls 0))
+      (unwind-protect
+          (progn
+            (with-temp-file file
+              (insert "original"))
+            (cl-letf (((symbol-function 'ai-code-editor-viewport--display)
+                       (lambda (&rest _args) nil))
+                      ((symbol-function 'recursive-edit)
+                       (lambda ()
+                         (setq recursive-calls (1+ recursive-calls))
+                         (erase-buffer)
+                         (insert "discard me")))
+                      ((symbol-function 'y-or-n-p)
+                       (lambda (_message)
+                         (prog1 (car answers)
+                           (setq answers (cdr answers))))))
+              (should-not
+               (ai-code-editor-viewport--edit-file
+                file source-buffer)))
+            (should (= recursive-calls 2))
+            (should-not answers)
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "original"))))
+        (when-let* ((buffer (get-file-buffer file)))
+          (kill-buffer buffer))
+        (delete-directory directory t)))))
+
+(ert-deftest test-ai-code-editor-viewport--alternate-abort-decline-keeps-editing ()
+  "Declining an alternate recursive abort should resume viewport editing."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-alternate-abort-source*")
+    (let* ((directory (make-temp-file "ai-code-editor-alternate-abort-" t))
+           (file (expand-file-name "prompt.md" directory))
+           (answers '(nil t))
+           (recursive-calls 0))
+      (unwind-protect
+          (progn
+            (with-temp-file file
+              (insert "original"))
+            (cl-letf (((symbol-function 'ai-code-editor-viewport--display)
+                       (lambda (&rest _args) nil))
+                      ((symbol-function 'recursive-edit)
+                       (lambda ()
+                         (setq recursive-calls (1+ recursive-calls))
+                         (erase-buffer)
+                         (insert "discard me")
+                         (signal 'quit nil)))
+                      ((symbol-function 'y-or-n-p)
+                       (lambda (_message)
+                         (prog1 (car answers)
+                           (setq answers (cdr answers))))))
+              (should-not
+               (ai-code-editor-viewport--edit-file
+                file source-buffer)))
+            (should (= recursive-calls 2))
+            (should-not answers)
+            (with-temp-buffer
+              (insert-file-contents file)
+              (should (equal (buffer-string) "original"))))
+        (when-let* ((buffer (get-file-buffer file)))
+          (kill-buffer buffer))
+        (delete-directory directory t)))))
+
+(ert-deftest test-ai-code-editor-viewport--cancel-refocuses-source-input ()
+  "Canceling should focus the visible source session after closing the viewport."
+  (ai-code-editor-viewport-test--with-buffer
+      (source-buffer "*ai-code-editor-focus-source*")
+    (ai-code-editor-viewport-test--with-buffer
+        (main-buffer "*ai-code-editor-focus-main*")
+      (let* ((directory (make-temp-file "ai-code-editor-focus-" t))
+             (file (expand-file-name "prompt.md" directory)))
+        (unwind-protect
+            (progn
+              (with-temp-file file
+                (insert "draft"))
+              (save-window-excursion
+                (delete-other-windows)
+                (switch-to-buffer main-buffer)
+                (let* ((ai-code-editor-viewport-window-height 11)
+                       (source-window
+                        (display-buffer-in-side-window
+                         source-buffer
+                         '((side . right)
+                           (slot . 0)
+                           (window-width . 40))))
+                       viewport-window)
+                  (select-window source-window)
+                  (cl-letf (((symbol-function 'recursive-edit)
+                             (lambda ()
+                               (setq viewport-window (selected-window))
+                               (ai-code-editor-viewport-test--confirm-cancel)))
+                            ((symbol-function 'exit-recursive-edit)
+                             (lambda () nil)))
+                    (should-not
+                     (ai-code-editor-viewport--edit-file
+                      file source-buffer)))
+                  (should-not (window-live-p viewport-window))
+                  (should (eq (selected-window) source-window))
+                  (should (eq (window-buffer source-window)
+                              source-buffer)))))
+          (when-let* ((buffer (get-file-buffer file)))
+            (kill-buffer buffer))
+          (delete-directory directory t))))))
 
 (ert-deftest test-ai-code-editor-viewport--mode-advertises-smart-yank ()
   "The viewport header should describe the single smart paste command."
@@ -252,7 +448,7 @@ Give the source side window WIDTH columns, defaulting to 40."
                       ((symbol-function 'recursive-edit)
                        (lambda ()
                          (setq viewport-name (buffer-name))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -300,7 +496,7 @@ directory."
                        (lambda ()
                          (if finish-p
                              (ai-code-editor-viewport-finish)
-                           (ai-code-editor-viewport-cancel))))
+                           (ai-code-editor-viewport-test--confirm-cancel))))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should
@@ -391,7 +587,7 @@ directory."
                                (substring-no-properties display)))
                              (should (= (string-width display) 105)))
                            (should (equal (buffer-string) source-text)))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -529,7 +725,7 @@ directory."
                        (lambda ()
                          (erase-buffer)
                          (insert "discard me")
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -809,7 +1005,7 @@ directory."
                        (lambda ()
                          (setq seen-position
                                (list (line-number-at-pos) (current-column)))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1628,7 +1824,7 @@ directory."
                                (should ai-code-editor-viewport-mode)
                                (ai-code-editor-viewport-finish))
                            (setq second-viewport (current-buffer))
-                           (ai-code-editor-viewport-cancel)))))
+                           (ai-code-editor-viewport-test--confirm-cancel)))))
               (should (ai-code-editor-viewport--edit-file file source-buffer)))
             (should-not inner-result)
             (should-not (eq first-viewport second-viewport)))
@@ -1657,7 +1853,7 @@ directory."
                        (lambda ()
                          (setq viewport-point (point))
                          (should (looking-at-p "beta"))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1688,7 +1884,7 @@ directory."
                        (lambda ()
                          (should (= (point) 19))
                          (should (looking-at-p "line"))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1719,7 +1915,7 @@ directory."
                        (lambda ()
                          (should (= (point) 8))
                          (should (looking-at-p "me"))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1750,7 +1946,7 @@ directory."
                        (lambda ()
                          (should (= (point) 7))
                          (should (looking-at-p "\nthird"))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1786,7 +1982,7 @@ directory."
                        (lambda ()
                          (should (= (point) 7))
                          (should (looking-at-p "beta"))
-                         (ai-code-editor-viewport-cancel)))
+                         (ai-code-editor-viewport-test--confirm-cancel)))
                       ((symbol-function 'exit-recursive-edit)
                        (lambda () nil)))
               (should-not
@@ -1822,7 +2018,7 @@ directory."
                                (setq inner-result
                                      (ai-code-editor-viewport--edit-file
                                       file source-buffer))
-                               (ai-code-editor-viewport-cancel))
+                               (ai-code-editor-viewport-test--confirm-cancel))
                            (insert " INNER")
                            (ai-code-editor-viewport-finish)))))
               (should-not


### PR DESCRIPTION
## Summary

- prompt for confirmation before canceling a viewport containing nonblank content
- treat whitespace-only viewport content as empty
- keep the viewport open when discard confirmation is declined
- guard alternate recursive-edit exit and abort paths before viewport cleanup
- restore focus to the original source input window after cancellation when it is still available
- avoid forcing window-layout changes when the source window is no longer available

## Testing

- added regression coverage for confirmed and declined cancellation
- added coverage for whitespace-only and narrowed viewport content
- added full-lifecycle coverage for alternate exit, abort, and source-focus restoration
- passed all 1,271 tests with 0 unexpected failures and 13 existing skips
- passed byte compilation, checkdoc, and `git diff --check`