### PR TITLE
Confirm prompt sending after starting a missing session

### DIFF
--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -161,6 +161,35 @@ Argument ARG is passed to the backend's switch function."
         (funcall ai-code--cli-switch-fn arg)
       (funcall ai-code--cli-switch-fn))))
 
+(defun ai-code--missing-session-error-p (error-data)
+  "Return non-nil when ERROR-DATA reports a missing AI session."
+  (string-match-p
+   "\\(?:\\`\\|: \\)No [^\n]+ session\\(?: for this project\\|;\\)"
+   (error-message-string error-data)))
+
+(defun ai-code--send-command-with-session-recovery (command)
+  "Send COMMAND, offering to start a missing session before one retry."
+  (let ((source-buffer (current-buffer)))
+    (condition-case err
+        (progn
+          (funcall ai-code--cli-send-fn command)
+          t)
+      (error
+       (if (not (ai-code--missing-session-error-p err))
+           (signal (car err) (cdr err))
+         (if (not (y-or-n-p
+                   (format "No %s session for this project.  Start one? "
+                           (ai-code-current-backend-label))))
+             nil
+           (ai-code-cli-start)
+           (if (not (y-or-n-p "Ready to send prompt? "))
+               nil
+             (if (buffer-live-p source-buffer)
+                 (with-current-buffer source-buffer
+                   (funcall ai-code--cli-send-fn command))
+               (funcall ai-code--cli-send-fn command))
+             t)))))))
+
 ;;;###autoload
 (defun ai-code-cli-send-command (&optional command)
   "Send COMMAND to the current backend when supported.
@@ -172,7 +201,7 @@ Noninteractive callers must supply COMMAND."
       (call-interactively ai-code--cli-send-fn)
     (if (null command)
         (user-error "COMMAND is required for noninteractive calls")
-      (funcall ai-code--cli-send-fn command))))
+      (ai-code--send-command-with-session-recovery command))))
 
 ;;;###autoload
 (defun ai-code-claude-code-el-send-command (cmd)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -203,8 +203,8 @@ If file doesn't exist, create it with sample prompt."
 (defun ai-code--execute-command (command)
   "Execute COMMAND directly without saving to prompt file."
   (message "Executing command: %s" command)
-  (ignore-errors (ai-code-cli-send-command command))
-  (ai-code-cli-switch-to-buffer))
+  (when (ignore-errors (ai-code-cli-send-command command))
+    (ai-code-cli-switch-to-buffer)))
 
 (defun ai-code--generate-prompt-headline (prompt-text)
   "Generate an Org headline for PROMPT-TEXT."
@@ -377,8 +377,8 @@ send the prompt directly to it instead of going through the default
 backend dispatch."
   (if-let ((target (ai-code--prompt-choose-target-session)))
       (ai-code--send-prompt-to-session-buffer full-prompt target)
-    (ai-code-cli-send-command full-prompt)
-    (ai-code-cli-switch-to-buffer)))
+    (when (ai-code-cli-send-command full-prompt)
+      (ai-code-cli-switch-to-buffer))))
 
 (defun ai-code--write-prompt-to-file-and-send (prompt-text)
   "Write PROMPT-TEXT to the AI prompt file."

--- a/test/test_ai-code-backends.el
+++ b/test/test_ai-code-backends.el
@@ -46,6 +46,53 @@
     (should-error (ai-code-cli-send-command nil)
                   :type 'user-error)))
 
+(ert-deftest ai-code-test-cli-send-command-retries-after-start-confirmation ()
+  "Start a missing session and retry the original command after confirmation."
+  (let* ((backend-key 'test-missing-session)
+         (ai-code-backends
+          `((,backend-key
+             :label "Test Backend"
+             :require nil
+             :start ai-code-test-start-missing-session
+             :switch ai-code-test-switch-missing-session
+             :send ai-code-test-send-missing-session
+             :resume nil
+             :cli "test")))
+         (ai-code-selected-backend backend-key)
+         (ai-code--repo-backend-alist nil)
+         (ai-code--cli-start-fn ai-code--cli-start-fn)
+         (ai-code--cli-switch-fn ai-code--cli-switch-fn)
+         (ai-code--cli-send-fn ai-code--cli-send-fn)
+         (ai-code--cli-resume-fn ai-code--cli-resume-fn)
+         (ai-code-cli nil)
+         (attempt-count 0)
+         (answers '(t t))
+         (events nil))
+    (cl-letf (((symbol-function 'ai-code-test-start-missing-session)
+               (lambda (&optional _arg)
+                 (setq events (append events '((start))))))
+              ((symbol-function 'ai-code-test-switch-missing-session)
+               (lambda (&optional _arg)))
+              ((symbol-function 'ai-code-test-send-missing-session)
+               (lambda (command)
+                 (setq attempt-count (1+ attempt-count)
+                       events (append events (list (list 'send command))))
+                 (when (= attempt-count 1)
+                   (user-error "No Test Backend session for this project"))))
+              ((symbol-function 'y-or-n-p)
+               (lambda (question)
+                 (setq events (append events (list (list 'ask question))))
+                 (pop answers))))
+      (ai-code-set-backend backend-key)
+      (should (ai-code-cli-send-command "original prompt"))
+      (should
+       (equal events
+              '((send "original prompt")
+                (ask "No Test Backend session for this project.  Start one? ")
+                (start)
+                (ask "Ready to send prompt? ")
+                (send "original prompt")))))))
+
 (ert-deftest ai-code-test-cli-resume-preserves-prefix-arg ()
   "Ensure `current-prefix-arg' reaches backend resume when ARG is nil."
   (let* ((backend-key 'test-backend)

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -38,6 +38,16 @@
   "Text without a slash prefix should be a normal prompt."
   (should-not (ai-code--direct-command-p "explain this file")))
 
+(ert-deftest ai-code-test-execute-command-skips-switch-when-send-cancelled ()
+  "Do not switch to a session after direct command sending is cancelled."
+  (let ((switch-called nil))
+    (cl-letf (((symbol-function 'ai-code-cli-send-command)
+               (lambda (_command) nil))
+              ((symbol-function 'ai-code-cli-switch-to-buffer)
+               (lambda () (setq switch-called t))))
+      (ai-code--execute-command "/status")
+      (should-not switch-called))))
+
 (ert-deftest ai-code-test-apply-prompt-suffixes-preserves-provider-order ()
   "Prompt suffix providers should run in hook order."
   (let ((ai-code-prompt-suffix-functions
@@ -1309,6 +1319,18 @@ evaluates BODY, and ensures everything is cleaned up afterward."
       (ai-code--send-prompt "test prompt")
       (should (string= cli-send-called "test prompt"))
       (should switch-called))))
+
+(ert-deftest ai-code-test-send-prompt-skips-switch-when-send-cancelled ()
+  "Do not switch to a session after prompt sending is cancelled."
+  (let ((switch-called nil))
+    (cl-letf (((symbol-function 'ai-code--prompt-choose-target-session)
+               (lambda () nil))
+              ((symbol-function 'ai-code-cli-send-command)
+               (lambda (_command) nil))
+              ((symbol-function 'ai-code-cli-switch-to-buffer)
+               (lambda () (setq switch-called t))))
+      (ai-code--send-prompt "test prompt")
+      (should-not switch-called))))
 
 (provide 'test-ai-code-prompt-mode)
 ;;; test_ai-code-prompt-mode.el ends here


### PR DESCRIPTION
Fixes #461.

When a prompt was prepared without an active AI coding session, the backend error surfaced only after the user had finished entering and confirming the prompt. This change recovers from that missing-session error in the shared send path.

The flow now asks whether to start the selected backend, waits for the user to confirm `Ready to send prompt?`, and then retries the exact original prompt once. It intentionally relies on the user's confirmation instead of adding backend-specific readiness detection, while unrelated backend errors continue to propagate normally.

Verification:
- Added an ERT regression test for the send → start → confirm → retry sequence.
- All 28 backend tests pass; byte compilation and Checkdoc are clean.