### PR TITLE
Harden and modernize Emacs MCP integration

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -29,6 +29,8 @@
 
 (declare-function ai-code--session-handle-at-input "ai-code-input" ())
 (declare-function ai-code--session-project-root "ai-code-utils" ())
+(declare-function ai-code-mcp-agent-refresh-source-context
+                  "ai-code-mcp-agent" (agent-buffer source-buffer))
 
 ;;; Customization
 
@@ -1333,8 +1335,8 @@ OPTIONS is a plist with these keys:
 :env-vars is an optional list of environment variable strings.
 :multiline-input-sequence is an optional terminal sequence for multiline input.
 :prepare-launch is an optional function called with (WORKING-DIR COMMAND).
-When :prepare-launch is present, it may return :command, :cleanup-fn, and
-:post-start-fn entries to customize session creation."
+When :prepare-launch is present, it may return :command, :env-vars,
+:cleanup-fn, and :post-start-fn entries to customize session creation."
   (let* ((resolved (ai-code-backends-infra--resolve-start-command
                     (plist-get options :program)
                     (plist-get options :switches)
@@ -1347,6 +1349,7 @@ When :prepare-launch is present, it may return :command, :cleanup-fn, and
          (launch (when-let* ((prepare-launch (plist-get options :prepare-launch)))
                    (funcall prepare-launch working-dir command)))
          (launch-command (or (plist-get launch :command) command))
+         (launch-env-vars (plist-get launch :env-vars))
          (cleanup-fn (plist-get launch :cleanup-fn))
          (post-start-fn (plist-get launch :post-start-fn)))
     (let ((ai-code-backends-infra--launch-program
@@ -1361,7 +1364,7 @@ When :prepare-launch is present, it may return :command, :cleanup-fn, and
        nil
        (plist-get options :session-prefix)
        arg
-       (plist-get options :env-vars)
+       (append launch-env-vars (plist-get options :env-vars))
        (plist-get options :multiline-input-sequence)
        post-start-fn))))
 
@@ -1599,6 +1602,8 @@ When PREFIX and WORKING-DIR are provided, select from multiple sessions."
                   working-dir
                   force-prompt
                   source-buffer)))
+    (when (fboundp 'ai-code-mcp-agent-refresh-source-context)
+      (ai-code-mcp-agent-refresh-source-context buffer source-buffer))
     (with-current-buffer buffer
       (ai-code-backends-infra--remember-session-buffer prefix working-dir buffer)
       (if (and (string-match-p "\n" line)

--- a/ai-code-claude-code.el
+++ b/ai-code-claude-code.el
@@ -82,6 +82,7 @@ With prefix ARG, prompt for CLI args using
                   (mcp-post-start-fn (plist-get mcp-launch :post-start-fn)))
              (list
               :command (plist-get mcp-launch :command)
+              :env-vars (plist-get mcp-launch :env-vars)
               :cleanup-fn (plist-get mcp-launch :cleanup-fn)
               :post-start-fn
               ;; Preserve backend-specific rendering behavior while letting MCP

--- a/ai-code-github-copilot-cli.el
+++ b/ai-code-github-copilot-cli.el
@@ -77,6 +77,7 @@ With prefix ARG, prompt for CLI args using
                   (mcp-post-start-fn (plist-get mcp-launch :post-start-fn)))
              (list
               :command (plist-get mcp-launch :command)
+              :env-vars (plist-get mcp-launch :env-vars)
               :cleanup-fn (plist-get mcp-launch :cleanup-fn)
               :post-start-fn
               ;; Copilot redraws via alternate-screen sequences, so keep the

--- a/ai-code-mcp-agent.el
+++ b/ai-code-mcp-agent.el
@@ -23,8 +23,17 @@
   :type '(repeat symbol)
   :group 'ai-code-mcp-agent)
 
+(defcustom ai-code-mcp-agent-token-lifetime-seconds (* 24 60 60)
+  "Lifetime of a per-launch MCP bearer token in seconds."
+  :type 'positive-integer
+  :group 'ai-code-mcp-agent)
+
 (defconst ai-code-mcp-agent--server-name "emacs_tools"
   "Server name used in backend MCP config overrides.")
+
+(defconst ai-code-mcp-agent--token-environment-variable
+  "AI_CODE_MCP_BEARER_TOKEN"
+  "Child-process environment variable that carries the MCP bearer token.")
 
 (defconst ai-code-mcp-agent--status-buffer-name "*AI Code MCP Status*"
   "Buffer name used to display MCP status to users.")
@@ -71,17 +80,36 @@
     (ai-code-mcp-builtins-setup)
     (let* ((port (ai-code-mcp-http-server-ensure))
            (session-id (ai-code-mcp-agent--make-session-id backend))
-           (url (ai-code-mcp-agent--make-server-url port session-id))
+           (token (ai-code-mcp--random-secret))
+           (url (ai-code-mcp-agent--make-server-url port))
            (command-metadata
-            (ai-code-mcp-agent--inject-command backend command url))
+            (ai-code-mcp-agent--inject-command
+             backend command url
+             ai-code-mcp-agent--token-environment-variable))
            (runtime-files (plist-get command-metadata :runtime-files)))
+      (ai-code-mcp-register-session
+       session-id working-dir (current-buffer)
+       (list :backend backend
+             :state 'pending
+             :tool-profile ai-code-mcp-default-tool-profile
+             :token token
+             :expires-at
+             (time-add (current-time)
+                       (seconds-to-time
+                        ai-code-mcp-agent-token-lifetime-seconds))))
       (list :command (plist-get command-metadata :command)
+            :env-vars
+            (list (format "%s=%s"
+                          ai-code-mcp-agent--token-environment-variable
+                          token))
+            :mcp-session-id session-id
+            :mcp-server-url url
             :cleanup-fn
             (ai-code-mcp-agent--make-cleanup-function
              session-id runtime-files)
             :post-start-fn (lambda (buffer _process _instance-name)
                              (ai-code-mcp-agent--record-buffer-session
-                              buffer backend session-id working-dir url))))))
+                              buffer backend session-id url))))))
 
 (defun ai-code-mcp-agent--make-cleanup-function (session-id runtime-files)
   "Return a repeat-safe cleanup function for SESSION-ID and RUNTIME-FILES.
@@ -104,7 +132,9 @@ Failed file removals are retried; session unregistration occurs at most once."
         (setq remaining-files (nreverse failed-files)))
       (unless unregistered
         (ai-code-mcp-unregister-session session-id)
-        (setq unregistered t)))))
+        (setq unregistered t)
+        (when (zerop (ai-code-mcp-session-count))
+          (ai-code-mcp-http-server-stop))))))
 
 (defun ai-code-mcp-agent--make-session-id (backend)
   "Create a fresh session id for BACKEND."
@@ -113,45 +143,45 @@ Failed file removals are retried; session unregistration occurs at most once."
           (format-time-string "%Y%m%d%H%M%S")
           (random 1000000)))
 
-(defun ai-code-mcp-agent--make-server-url (port session-id)
-  "Build an MCP server URL from PORT and SESSION-ID."
-  (format "http://127.0.0.1:%d/mcp/%s" port session-id))
+(defun ai-code-mcp-agent--make-server-url (port)
+  "Build the MCP server URL for PORT."
+  (format "http://127.0.0.1:%d/mcp" port))
 
-(defun ai-code-mcp-agent--record-buffer-session (buffer backend session-id working-dir url)
-  "Record BUFFER session for BACKEND, SESSION-ID, WORKING-DIR, and URL."
-  (ai-code-mcp-register-session session-id working-dir buffer)
+(defun ai-code-mcp-agent--record-buffer-session (buffer backend session-id url)
+  "Record BUFFER session for BACKEND, SESSION-ID, and URL."
+  (ai-code-mcp-attach-agent-buffer session-id buffer)
   (with-current-buffer buffer
     (setq-local ai-code-mcp-agent--backend backend
                 ai-code-mcp-agent--session-id session-id
                 ai-code-mcp-agent--server-url url)))
 
-(defun ai-code-mcp-agent--inject-command (backend command url)
-  "Return launch metadata after injecting URL into COMMAND for BACKEND."
+(defun ai-code-mcp-agent-refresh-source-context (agent-buffer source-buffer)
+  "Refresh AGENT-BUFFER's MCP prompt origin from SOURCE-BUFFER."
+  (when (and (buffer-live-p agent-buffer)
+             (buffer-live-p source-buffer))
+    (let ((session-id
+           (buffer-local-value 'ai-code-mcp-agent--session-id agent-buffer)))
+      (when session-id
+        (ai-code-mcp-update-source-context session-id source-buffer)))))
+
+(defun ai-code-mcp-agent--inject-command (backend command url token-env-var)
+  "Inject URL and TOKEN-ENV-VAR into COMMAND for BACKEND launch metadata."
   (pcase backend
-    ('codex
+    ((or 'codex 'open-interpreter)
      (list :command
-           (concat command
-                   " -c "
-                   (shell-quote-argument
-                    (format "mcp_servers.%s={ url = %s }"
-                            ai-code-mcp-agent--server-name
-                            (json-encode url))))))
-    ('open-interpreter
-     (list :command
-           (concat command
-                   " -c "
-                   (shell-quote-argument
-                    (format "mcp_servers.%s={ url = %s }"
-                            ai-code-mcp-agent--server-name
-                            (json-encode url))))))
+           (ai-code-mcp-agent--toml-config-command
+            command url token-env-var)))
     ('github-copilot-cli
      (list :command
            (concat command
                    " --additional-mcp-config "
                    (shell-quote-argument
-                    (ai-code-mcp-agent--copilot-config-json url)))))
+                    (ai-code-mcp-agent--copilot-config-json
+                     url token-env-var)))))
     ('claude-code
-     (let ((config-file (ai-code-mcp-agent--claude-code-config-file url)))
+     (let ((config-file
+            (ai-code-mcp-agent--claude-code-config-file
+             url token-env-var)))
        (list :command
              (concat command
                      " --mcp-config "
@@ -159,23 +189,46 @@ Failed file removals are retried; session unregistration occurs at most once."
              :runtime-files (list config-file))))
     (_ (list :command command))))
 
-(defun ai-code-mcp-agent--copilot-config-json (url)
-  "Return a Copilot CLI MCP config JSON string for URL."
+(defun ai-code-mcp-agent--toml-config-command (command url token-env-var)
+  "Add a TOML MCP override for URL and TOKEN-ENV-VAR to COMMAND."
+  (concat command
+          " -c "
+          (shell-quote-argument
+           (format "mcp_servers.%s={ url = %s, bearer_token_env_var = %s }"
+                   ai-code-mcp-agent--server-name
+                   (json-encode url)
+                   (json-encode token-env-var)))))
+
+(defun ai-code-mcp-agent--authorization-template (token-env-var)
+  "Return an Authorization header template for TOKEN-ENV-VAR."
+  (format "Bearer ${%s}" token-env-var))
+
+(defun ai-code-mcp-agent--copilot-config-json (url token-env-var)
+  "Return a Copilot MCP config for URL using TOKEN-ENV-VAR."
   (json-encode
    `((mcpServers
       . ((,ai-code-mcp-agent--server-name
           . ((type . "http")
-             (url . ,url))))))))
+             (url . ,url)
+             (headers
+              . ((Authorization
+                  . ,(ai-code-mcp-agent--authorization-template
+                      token-env-var))))
+             (tools . ["*"]))))))))
 
-(defun ai-code-mcp-agent--claude-code-config-file (url)
-  "Write a Claude Code MCP config file for URL and return its path."
+(defun ai-code-mcp-agent--claude-code-config-file (url token-env-var)
+  "Write a Claude MCP config for URL using TOKEN-ENV-VAR and return its path."
   (let ((config-file (make-temp-file "ai-code-mcp-claude-code-" nil ".json")))
     (with-temp-file config-file
       (insert (json-encode
                `((mcpServers
                   . ((,ai-code-mcp-agent--server-name
                       . ((type . "http")
-                         (url . ,url)))))))))
+                         (url . ,url)
+                         (headers
+                          . ((Authorization
+                              . ,(ai-code-mcp-agent--authorization-template
+                                  token-env-var))))))))))))
     config-file))
 
 (provide 'ai-code-mcp-agent)

--- a/ai-code-mcp-common.el
+++ b/ai-code-mcp-common.el
@@ -25,6 +25,30 @@
                       t))
     '()))
 
+(defun ai-code-mcp--random-secret ()
+  "Return a 256-bit secret encoded as lowercase hexadecimal."
+  (cond
+   ((executable-find "openssl")
+    (with-temp-buffer
+      (unless (zerop (call-process "openssl" nil t nil
+                                   "rand" "-hex" "32"))
+        (error "OpenSSL could not generate an MCP secret"))
+      (let ((secret (string-trim (buffer-string))))
+        (unless (string-match-p "\\`[[:xdigit:]]\\{64\\}\\'" secret)
+          (error "OpenSSL returned an invalid MCP secret"))
+        (downcase secret))))
+   ((and (file-readable-p "/dev/urandom") (executable-find "head"))
+    (with-temp-buffer
+      (set-buffer-multibyte nil)
+      (unless (zerop (call-process "head" nil t nil
+                                   "-c" "32" "/dev/urandom"))
+        (error "Could not read operating-system entropy"))
+      (unless (= (buffer-size) 32)
+        (error "Could not read enough operating-system entropy"))
+      (secure-hash 'sha256 (current-buffer))))
+   (t
+    (error "No secure random source is available for MCP authentication"))))
+
 (provide 'ai-code-mcp-common)
 
 ;;; ai-code-mcp-common.el ends here

--- a/ai-code-mcp-debug-tools.el
+++ b/ai-code-mcp-debug-tools.el
@@ -110,11 +110,27 @@
 (defun ai-code-mcp-debug-tools--register-base-tools ()
   "Register the standard MCP debugging tools."
   (dolist (tool ai-code-mcp-debug-tools--specs)
-    (apply #'ai-code-mcp-make-tool tool)))
+    (apply #'ai-code-mcp-make-tool
+           (append
+            tool
+            '(:category debug
+              :annotations
+              ((readOnlyHint . t)
+               (destructiveHint . :json-false)
+               (idempotentHint . t)
+               (openWorldHint . :json-false)))))))
 
 (defun ai-code-mcp-debug-tools--register-eval-tool ()
   "Register the optional `eval_elisp' MCP tool."
-  (apply #'ai-code-mcp-make-tool ai-code-mcp-debug-tools--eval-spec))
+  (apply #'ai-code-mcp-make-tool
+         (append
+          ai-code-mcp-debug-tools--eval-spec
+          '(:category eval
+            :annotations
+            ((readOnlyHint . :json-false)
+             (destructiveHint . t)
+             (idempotentHint . :json-false)
+             (openWorldHint . t))))))
 
 (defun ai-code-mcp-debug-tools--enabled-p ()
   "Return non-nil when debug tools are enabled globally."

--- a/ai-code-mcp-http-server.el
+++ b/ai-code-mcp-http-server.el
@@ -10,6 +10,8 @@
 
 (require 'cl-lib)
 (require 'json)
+(require 'seq)
+(require 'subr-x)
 
 (require 'ai-code-mcp-server)
 
@@ -23,6 +25,26 @@
 When nil, an available port is selected automatically."
   :type '(choice (const :tag "Auto-select" nil)
                  integer)
+  :group 'ai-code-mcp-http-server)
+
+(defcustom ai-code-mcp-http-server-max-request-bytes (* 1024 1024)
+  "Maximum accepted MCP HTTP request body size in bytes."
+  :type 'natnum
+  :group 'ai-code-mcp-http-server)
+
+(defcustom ai-code-mcp-http-server-max-header-bytes (* 64 1024)
+  "Maximum accepted MCP HTTP request header size in bytes."
+  :type 'natnum
+  :group 'ai-code-mcp-http-server)
+
+(defcustom ai-code-mcp-http-server-rate-limit 120
+  "Maximum authenticated requests allowed per session rate window."
+  :type 'natnum
+  :group 'ai-code-mcp-http-server)
+
+(defcustom ai-code-mcp-http-server-rate-window-seconds 60
+  "Length of the authenticated request rate window in seconds."
+  :type 'positive-integer
   :group 'ai-code-mcp-http-server)
 
 (defvar ai-code-mcp-http-server--server nil
@@ -80,12 +102,48 @@ When nil, an available port is selected automatically."
 
 (defun ai-code-mcp-http-server--filter (process chunk)
   "Accumulate CHUNK for PROCESS and handle a full request."
-  (let* ((data (concat (or (process-get process :data) "") chunk))
-         (request (ai-code-mcp-http-server--parse-request data)))
-    (process-put process :data data)
-    (when request
-      (process-put process :data nil)
-      (ai-code-mcp-http-server--handle-request process request))))
+  (condition-case nil
+      (let* ((data (concat (or (process-get process :data) "") chunk))
+             (header-end (string-match "\r\n\r\n" data)))
+        (cond
+         ((and (null header-end)
+               (> (string-bytes data)
+                  ai-code-mcp-http-server-max-header-bytes))
+          (ai-code-mcp-http-server--send-response
+           process 431 "text/plain" "Request Header Fields Too Large"))
+         ((and header-end
+               (> header-end ai-code-mcp-http-server-max-header-bytes))
+          (ai-code-mcp-http-server--send-response
+           process 431 "text/plain" "Request Header Fields Too Large"))
+         ((and header-end
+               (> (string-bytes data)
+                  (+ header-end 4
+                     ai-code-mcp-http-server-max-request-bytes)))
+          (ai-code-mcp-http-server--send-response
+           process 413 "text/plain" "Payload Too Large"))
+         (t
+          (process-put process :data data)
+          (when-let ((request
+                      (ai-code-mcp-http-server--parse-request data)))
+            (process-put process :data nil)
+            (ai-code-mcp-http-server--handle-request process request)))))
+    (error
+     (ai-code-mcp-http-server--send-response
+      process 400 "text/plain" "Bad Request"))))
+
+(defun ai-code-mcp-http-server--content-length (headers)
+  "Return the validated Content-Length from HEADERS, or `invalid'."
+  (let ((values
+         (mapcar #'cdr
+                 (seq-filter
+                  (lambda (header)
+                    (equal (car header) "content-length"))
+                  headers))))
+    (cond
+     ((null values) 0)
+     ((not (= (length values) 1)) 'invalid)
+     ((not (string-match-p "\\`[0-9]+\\'" (car values))) 'invalid)
+     (t (string-to-number (car values))))))
 
 (defun ai-code-mcp-http-server--parse-request (data)
   "Parse DATA when it includes a full HTTP request."
@@ -97,16 +155,21 @@ When nil, an available port is selected automatically."
            (request-line (car lines))
            (headers (delq nil (mapcar #'ai-code-mcp-http-server--parse-header
                                       (cdr lines))))
-           (content-length (string-to-number
-                            (or (cdr (assoc "content-length" headers))
-                                "0"))))
-      (when (<= (+ body-start content-length) (string-bytes data))
-        (pcase-let ((`(,method ,path)
-                     (ai-code-mcp-http-server--parse-request-line request-line)))
+           (content-length
+            (ai-code-mcp-http-server--content-length headers)))
+      (pcase-let ((`(,method ,path)
+                   (ai-code-mcp-http-server--parse-request-line request-line)))
+        (cond
+         ((eq content-length 'invalid)
+          (list :method method :path path :headers headers :bad-request t))
+         ((> content-length ai-code-mcp-http-server-max-request-bytes)
+          (list :method method :path path :headers headers :too-large t))
+         ((<= (+ body-start content-length) (string-bytes data))
           (list :method method
                 :path path
                 :headers headers
-                :body (substring data body-start (+ body-start content-length))))))))
+                :body (substring data body-start
+                                 (+ body-start content-length)))))))))
 
 (defun ai-code-mcp-http-server--parse-request-line (line)
   "Parse HTTP request LINE."
@@ -124,70 +187,373 @@ When nil, an available port is selected automatically."
 (defun ai-code-mcp-http-server--handle-request (process request)
   "Handle REQUEST received on PROCESS."
   (condition-case err
-      (pcase (plist-get request :method)
-        ("POST"
-         (ai-code-mcp-http-server--handle-post process request))
-        (_
-         (ai-code-mcp-http-server--send-response process 404 "text/plain" "Not Found")))
+      (let ((session (ai-code-mcp-http-server--authenticate request)))
+        (cond
+         ((plist-get request :bad-request)
+          (ai-code-mcp-http-server--send-response
+           process 400 "text/plain" "Bad Request"))
+         ((plist-get request :too-large)
+          (ai-code-mcp-http-server--send-response
+           process 413 "text/plain" "Payload Too Large"))
+         ((not (equal (plist-get request :path) "/mcp"))
+          (ai-code-mcp-http-server--send-response
+           process 404 "text/plain" "Not Found"))
+         ((not (ai-code-mcp-http-server--origin-allowed-p request))
+          (ai-code-mcp-http-server--send-response
+           process 403 "text/plain" "Forbidden"))
+         ((not session)
+          (ai-code-mcp-http-server--send-response
+           process 401 "text/plain" ""))
+         ((ai-code-mcp-http-server--rate-limited-p (car session))
+          (ai-code-mcp-http-server--send-response
+           process 429 "text/plain" "Too Many Requests"
+           `(("Retry-After" . ,(number-to-string
+                                ai-code-mcp-http-server-rate-window-seconds)))))
+         ((and (equal (plist-get request :method) "POST")
+               (not (ai-code-mcp-http-server--json-content-type-p request)))
+          (ai-code-mcp-http-server--send-response
+           process 415 "text/plain" "Unsupported Media Type"))
+         ((and (equal (plist-get request :method) "POST")
+               (not (ai-code-mcp-http-server--accepts-mcp-responses-p request)))
+          (ai-code-mcp-http-server--send-response
+           process 406 "text/plain" "Not Acceptable"))
+         ((equal (plist-get request :method) "POST")
+          (let ((ai-code-mcp--current-session-id (car session)))
+            (ai-code-mcp-http-server--handle-post process request)))
+         (t
+          (ai-code-mcp-http-server--send-response
+           process 405 "text/plain" "Method Not Allowed"))))
+    (json-parse-error
+     (ai-code-mcp-http-server--send-json-error
+      process nil -32700 "Parse error"
+      (if (ai-code-mcp-http-server--modern-request-headers-p request)
+          400
+        200)))
+    (ai-code-mcp-protocol-error
+     (ai-code-mcp-http-server--send-json-error
+      process
+      (ai-code-mcp-http-server--request-id request)
+      (nth 1 err)
+      (nth 2 err)
+      200
+      (nth 3 err)))
     (error
+     (display-warning
+      'ai-code-mcp-http-server
+      (format "MCP HTTP request failed: %s" (error-message-string err)))
      (ai-code-mcp-http-server--send-json-error
       process
       (ai-code-mcp-http-server--request-id request)
       -32603
-      (format "Internal error: %s" (error-message-string err))))))
+      "Internal error"))))
+
+(defun ai-code-mcp-http-server--origin-allowed-p (request)
+  "Return non-nil when REQUEST has no Origin or a loopback Origin."
+  (let ((origin (cdr (assoc "origin" (plist-get request :headers))))
+        (case-fold-search t))
+    (or (null origin)
+        (string-match-p
+         "\\`https?://\\(?:localhost\\|127\\.0\\.0\\.1\\|\\[::1\\]\\)\\(?::[0-9]+\\)?\\'"
+         origin))))
+
+(defun ai-code-mcp-http-server--json-content-type-p (request)
+  "Return non-nil when REQUEST declares an application/json body."
+  (let ((content-type
+         (cdr (assoc "content-type" (plist-get request :headers))))
+        (case-fold-search t))
+    (and content-type
+         (string-match-p
+          "\\`application/json\\(?:[ 	]*;.*\\)?\\'"
+          content-type))))
+
+(defun ai-code-mcp-http-server--rate-limited-p (session-id)
+  "Record a request for SESSION-ID and return non-nil when over limit."
+  (let* ((context (ai-code-mcp-get-session-context session-id))
+         (now (float-time))
+         (window-start (plist-get context :rate-window-start))
+         (count (or (plist-get context :rate-count) 0)))
+    (when (or (null window-start)
+              (>= (- now window-start)
+                  ai-code-mcp-http-server-rate-window-seconds))
+      (setq window-start now
+            count 0))
+    (if (>= count ai-code-mcp-http-server-rate-limit)
+        t
+      (setq context (plist-put context :rate-window-start window-start))
+      (setq context (plist-put context :rate-count (1+ count)))
+      (puthash session-id context ai-code-mcp--sessions)
+      nil)))
+
+(defun ai-code-mcp-http-server--accepts-mcp-responses-p (request)
+  "Return non-nil when REQUEST accepts JSON and event-stream responses."
+  (let* ((accept (cdr (assoc "accept" (plist-get request :headers))))
+         (types
+          (mapcar (lambda (value)
+                    (downcase
+                     (string-trim (car (split-string value ";" t)))))
+                  (split-string (or accept "") "," t))))
+    (and (member "application/json" types)
+         (member "text/event-stream" types))))
+
+(defun ai-code-mcp-http-server--authenticate (request)
+  "Return the MCP session authenticated by REQUEST, or nil."
+  (let* ((authorization
+          (cdr (assoc "authorization" (plist-get request :headers))))
+         (case-fold-search t)
+         (token (and authorization
+                     (string-match "\\`Bearer[ 	]+\\(.+\\)\\'" authorization)
+                     (match-string 1 authorization))))
+    (ai-code-mcp-find-session-by-token token)))
 
 (defun ai-code-mcp-http-server--handle-post (process request)
   "Handle POST REQUEST on PROCESS."
-  (let ((response
-         (ai-code-mcp-http-server--json-rpc-response
-          (plist-get request :path)
-          (plist-get request :body))))
-    (if (null response)
-        (ai-code-mcp-http-server--send-accepted process)
-      (ai-code-mcp-http-server--send-json
-       process
-       200
-       response))))
-
-(defun ai-code-mcp-http-server--json-rpc-response (path body)
-  "Return a JSON-RPC response alist for PATH and BODY.
-Returns nil for notifications."
-  (let* ((json-object (json-parse-string body :object-type 'alist))
+  (let* ((json-object
+          (ai-code-mcp-http-server--parse-json
+           (plist-get request :body)))
          (id (alist-get 'id json-object))
          (method (alist-get 'method json-object))
          (params (alist-get 'params json-object))
-         (ai-code-mcp--current-session-id
-          (ai-code-mcp-http-server--session-id-from-path path)))
-    (when id
-      `((jsonrpc . "2.0")
-        (id . ,id)
-        (result . ,(ai-code-mcp-dispatch method params))))))
+         (context (ai-code-mcp-get-session-context))
+         (modern (ai-code-mcp-http-server--modern-request-p
+                  request method params))
+         (envelope-error
+          (ai-code-mcp-http-server--json-rpc-envelope-error json-object))
+         (transport-error
+          (unless envelope-error
+            (if modern
+                (ai-code-mcp-http-server--modern-transport-error
+                 method params request)
+              (ai-code-mcp-http-server--legacy-transport-error
+               method request context)))))
+    (cond
+     (envelope-error
+      (ai-code-mcp-http-server--send-json-error
+       process id -32600 envelope-error (if modern 400 200)))
+     (transport-error
+      (ai-code-mcp-http-server--send-json-error
+       process id
+       (or (plist-get transport-error :code) -32600)
+       (or (plist-get transport-error :message) transport-error)
+       400
+       (plist-get transport-error :data)))
+     ((not (ai-code-mcp-http-server--method-allowed-p
+            method context modern))
+      (ai-code-mcp-http-server--send-json-error
+       process id -32600 "MCP session is not ready" 400))
+     (t
+      (let* ((transport-session-id
+              (when (equal method "initialize")
+                (ai-code-mcp-http-server--begin-legacy-session params)))
+             (_completed
+              (when (equal method "notifications/initialized")
+                (ai-code-mcp-http-server--complete-legacy-session request)))
+             (response-headers
+              (when transport-session-id
+                `(("MCP-Session-Id" . ,transport-session-id)))))
+        (ai-code-mcp-http-server--dispatch-request
+         process json-object modern response-headers))))))
+
+(defun ai-code-mcp-http-server--parse-json (body)
+  "Parse JSON request BODY into the server's canonical representation."
+  (json-parse-string body
+                     :object-type 'alist
+                     :array-type 'array
+                     :null-object :null
+                     :false-object :json-false))
+
+(defun ai-code-mcp-http-server--modern-request-headers-p (request)
+  "Return non-nil when REQUEST headers select the modern protocol."
+  (let ((version (cdr (assoc "mcp-protocol-version"
+                             (plist-get request :headers)))))
+    (and version
+         (not (member version ai-code-mcp--legacy-protocol-versions)))))
+
+(defun ai-code-mcp-http-server--modern-request-p (request method params)
+  "Return non-nil when REQUEST, METHOD, and PARAMS use modern MCP."
+  (let* ((meta (and (listp params) (alist-get '_meta params)))
+         (body-version
+          (and (listp meta)
+               (alist-get 'io.modelcontextprotocol/protocolVersion meta))))
+    (or (equal method "server/discover")
+        (ai-code-mcp-http-server--modern-request-headers-p request)
+        (equal body-version ai-code-mcp--modern-protocol-version))))
+
+(defun ai-code-mcp-http-server--modern-transport-error
+    (method params request)
+  "Return a modern transport error for METHOD, PARAMS, and REQUEST."
+  (let* ((headers (plist-get request :headers))
+         (header-version (cdr (assoc "mcp-protocol-version" headers)))
+         (header-method (cdr (assoc "mcp-method" headers)))
+         (header-name (cdr (assoc "mcp-name" headers)))
+         (meta (and (listp params) (alist-get '_meta params)))
+         (version-entry
+          (and (listp meta)
+               (assq 'io.modelcontextprotocol/protocolVersion meta)))
+         (capabilities-entry
+          (and (listp meta)
+               (assq 'io.modelcontextprotocol/clientCapabilities meta)))
+         (body-version (cdr version-entry))
+         (body-name (and (listp params)
+                         (or (alist-get 'name params)
+                             (alist-get 'uri params))))
+         (requires-name
+          (member method '("tools/call" "resources/read" "prompts/get"))))
+    (cond
+     ((or (null version-entry) (not (stringp body-version))
+          (null capabilities-entry))
+      (list :code -32602
+            :message "Missing required per-request MCP metadata"))
+     ((not (equal header-version body-version))
+      (list :code -32020
+            :message "Header mismatch: MCP-Protocol-Version"))
+     ((not (equal body-version ai-code-mcp--modern-protocol-version))
+      (list :code -32022
+            :message "Unsupported protocol version"
+            :data `((supported . [,ai-code-mcp--modern-protocol-version])
+                    (requested . ,body-version))))
+     ((not (equal header-method method))
+      (list :code -32020
+            :message "Header mismatch: Mcp-Method"))
+     ((and requires-name
+           (not (equal (ai-code-mcp-http-server--decode-header-value
+                        header-name)
+                       body-name)))
+      (list :code -32020
+            :message "Header mismatch: Mcp-Name")))))
+
+(defun ai-code-mcp-http-server--decode-header-value (value)
+  "Decode modern MCP header VALUE, including its Base64 sentinel form."
+  (when value
+    (if (string-match "\\`=\\?base64\\?\\(.+\\)\\?=\\'" value)
+        (condition-case nil
+            (decode-coding-string
+             (base64-decode-string (match-string 1 value))
+             'utf-8)
+          (error nil))
+      value)))
+
+(defun ai-code-mcp-http-server--dispatch-request
+    (process json-object modern response-headers)
+  "Dispatch JSON-OBJECT and reply on PROCESS.
+MODERN selects stateless protocol semantics and RESPONSE-HEADERS are appended
+to a successful response."
+  (let* ((id-entry (assq 'id json-object))
+         (id (cdr id-entry))
+         (method (alist-get 'method json-object))
+         (params (alist-get 'params json-object))
+         (ai-code-mcp--current-protocol-version
+          (and modern ai-code-mcp--modern-protocol-version)))
+    (if (null id-entry)
+        (ai-code-mcp-http-server--send-accepted process)
+      (condition-case err
+          (ai-code-mcp-http-server--send-json
+           process 200
+           `((jsonrpc . "2.0")
+             (id . ,id)
+             (result . ,(ai-code-mcp-dispatch method params)))
+           response-headers)
+        (ai-code-mcp-protocol-error
+         (let ((code (nth 1 err)))
+           (ai-code-mcp-http-server--send-json-error
+            process id code (nth 2 err)
+            (cond
+             ((not modern) 200)
+             ((= code -32601) 404)
+             (t 400))
+            (nth 3 err))))
+        (error
+         (display-warning
+          'ai-code-mcp-http-server
+          (format "MCP dispatch failed: %s" (error-message-string err)))
+         (ai-code-mcp-http-server--send-json-error
+          process id -32603 "Internal error" 500))))))
+
+(defun ai-code-mcp-http-server--json-rpc-envelope-error (json-object)
+  "Return an error string when JSON-OBJECT is not a JSON-RPC request."
+  (cond
+   ((not (listp json-object)) "Invalid JSON-RPC request object")
+   ((not (equal "2.0" (alist-get 'jsonrpc json-object)))
+    "Invalid or missing jsonrpc version")
+   ((not (stringp (alist-get 'method json-object)))
+    "Invalid or missing JSON-RPC method")
+   ((and (assq 'id json-object)
+         (not (or (stringp (alist-get 'id json-object))
+                  (integerp (alist-get 'id json-object)))))
+    "JSON-RPC id must be a string or integer")
+   ((and (assq 'params json-object)
+         (not (listp (alist-get 'params json-object))))
+    "JSON-RPC params must be an object")))
+
+(defun ai-code-mcp-http-server--legacy-transport-error (method request context)
+  "Return a legacy transport error for METHOD, REQUEST, and CONTEXT."
+  (unless (equal method "initialize")
+    (let* ((headers (plist-get request :headers))
+           (expected-session-id (plist-get context :transport-session-id))
+           (actual-session-id (cdr (assoc "mcp-session-id" headers)))
+           (expected-version (plist-get context :protocol-version))
+           (actual-version (cdr (assoc "mcp-protocol-version" headers))))
+      (cond
+       ((and expected-session-id
+             (not (equal expected-session-id actual-session-id)))
+        (list :code -32600
+              :message "Missing or invalid MCP-Session-Id header"))
+       ((and expected-version
+             (not (equal expected-version actual-version)))
+        (list :code -32600
+              :message "Missing or invalid MCP-Protocol-Version header"))))))
+
+(defun ai-code-mcp-http-server--method-allowed-p (method context modern)
+  "Return non-nil when METHOD is valid for CONTEXT and protocol era MODERN."
+  (if modern
+      (or (member method '("server/discover" "tools/list" "ping"))
+          (not (equal method "tools/call"))
+          (eq (plist-get context :state) 'ready))
+    (or (member method '("initialize" "notifications/initialized" "ping"))
+        (eq (plist-get context :state) 'ready))))
+
+(defun ai-code-mcp-http-server--begin-legacy-session (params)
+  "Record a legacy MCP session initialized with PARAMS."
+  (let* ((session-id ai-code-mcp--current-session-id)
+         (protocol-version
+          (ai-code-mcp-negotiate-legacy-version
+           (alist-get 'protocolVersion params)))
+         (client-info (alist-get 'clientInfo params))
+         (transport-session-id (ai-code-mcp--random-secret)))
+    (ai-code-mcp-begin-legacy-session
+     session-id transport-session-id protocol-version client-info)
+    transport-session-id))
+
+(defun ai-code-mcp-http-server--complete-legacy-session (request)
+  "Complete legacy MCP initialization described by REQUEST headers."
+  (let ((headers (plist-get request :headers)))
+    (ai-code-mcp-complete-legacy-session
+     ai-code-mcp--current-session-id
+     (cdr (assoc "mcp-session-id" headers))
+     (cdr (assoc "mcp-protocol-version" headers)))))
 
 (defun ai-code-mcp-http-server--request-id (request)
   "Extract the JSON-RPC request ID from REQUEST."
   (when-let ((body (plist-get request :body)))
     (condition-case nil
         (alist-get 'id
-                   (json-parse-string body :object-type 'alist))
+                   (ai-code-mcp-http-server--parse-json body))
       (error nil))))
 
-(defun ai-code-mcp-http-server--session-id-from-path (path)
-  "Extract session ID from PATH."
-  (when (string-match "\\`/mcp/\\([^/?]+\\)" path)
-    (match-string 1 path)))
-
-(defun ai-code-mcp-http-server--send-json-error (process id code message)
-  "Send a JSON-RPC error response with ID, CODE, and MESSAGE on PROCESS."
+(defun ai-code-mcp-http-server--send-json-error
+    (process id code message &optional http-code data)
+  "Send a JSON-RPC error on PROCESS.
+ID, CODE, MESSAGE, HTTP-CODE, and DATA describe the error response."
   (ai-code-mcp-http-server--send-json
    process
-   500
+   (or http-code 500)
    `((jsonrpc . "2.0")
      (id . ,id)
      (error . ((code . ,code)
-               (message . ,message))))))
+               (message . ,message)
+               ,@(when data `((data . ,data))))))))
 
-(defun ai-code-mcp-http-server--send-json (process code payload)
-  "Send JSON PAYLOAD with HTTP CODE on PROCESS."
+(defun ai-code-mcp-http-server--send-json (process code payload &optional headers)
+  "Send JSON PAYLOAD with HTTP CODE and optional HEADERS on PROCESS."
   (let ((json-object-type 'alist)
         (json-array-type 'list)
         (json-key-type 'symbol))
@@ -195,14 +561,17 @@ Returns nil for notifications."
      process
      code
      "application/json"
-     (json-encode payload))))
+     (json-encode payload)
+     headers)))
 
 (defun ai-code-mcp-http-server--send-accepted (process)
   "Send an empty HTTP 202 Accepted response on PROCESS."
   (ai-code-mcp-http-server--send-response process 202 "text/plain" ""))
 
-(defun ai-code-mcp-http-server--send-response (process code content-type body)
-  "Send an HTTP response with CODE, CONTENT-TYPE, and BODY on PROCESS."
+(defun ai-code-mcp-http-server--send-response
+    (process code content-type body &optional headers)
+  "Send an HTTP response on PROCESS.
+CODE, CONTENT-TYPE, BODY, and HEADERS describe the response."
   (let* ((payload (or body ""))
          (response (concat
                     (format "HTTP/1.1 %d %s\r\n"
@@ -210,6 +579,11 @@ Returns nil for notifications."
                             (ai-code-mcp-http-server--reason code))
                     (format "Content-Type: %s\r\n" content-type)
                     (format "Content-Length: %d\r\n" (string-bytes payload))
+                    (mapconcat (lambda (header)
+                                 (format "%s: %s\r\n"
+                                         (car header) (cdr header)))
+                               headers
+                               "")
                     "Connection: close\r\n\r\n"
                     payload)))
     (process-send-string process response)
@@ -219,7 +593,16 @@ Returns nil for notifications."
   "Return the HTTP reason phrase for CODE."
   (alist-get code '((200 . "OK")
                     (202 . "Accepted")
+                    (400 . "Bad Request")
+                    (401 . "Unauthorized")
+                    (403 . "Forbidden")
                     (404 . "Not Found")
+                    (405 . "Method Not Allowed")
+                    (406 . "Not Acceptable")
+                    (413 . "Payload Too Large")
+                    (415 . "Unsupported Media Type")
+                    (429 . "Too Many Requests")
+                    (431 . "Request Header Fields Too Large")
                     (500 . "Internal Server Error"))
              "OK"))
 

--- a/ai-code-mcp-server.el
+++ b/ai-code-mcp-server.el
@@ -42,18 +42,21 @@
 (declare-function flycheck-error-level "flycheck" (err))
 (declare-function flycheck-error-checker "flycheck" (err))
 (declare-function flycheck-error-message "flycheck" (err))
+(declare-function flycheck-running-p "flycheck")
 (declare-function flymake-diagnostics "flymake" (&optional beg end))
 (declare-function flymake-diagnostic-beg "flymake" (diag))
 (declare-function flymake-diagnostic-end "flymake" (diag))
 (declare-function flymake-diagnostic-type "flymake" (diag))
 (declare-function flymake-diagnostic-backend "flymake" (diag))
 (declare-function flymake-diagnostic-text "flymake" (diag))
+(declare-function flymake-running-backends "flymake")
 (declare-function url-filename "url-parse" (urlobj))
 (declare-function url-generic-parse-url "url-parse" (url))
 (declare-function url-host "url-parse" (urlobj))
 (declare-function url-type "url-parse" (urlobj))
 
 (defvar flycheck-current-errors)
+(defvar flycheck-last-status-change)
 
 (defgroup ai-code-mcp-server nil
   "MCP tools core settings for AI Code Interface."
@@ -64,6 +67,14 @@
   "List of MCP tool specifications.
 Each item is a plist with at least `:function', `:name', and `:description'."
   :type '(repeat sexp)
+  :group 'ai-code-mcp-server)
+
+(defcustom ai-code-mcp-default-tool-profile 'debug
+  "Default MCP tool exposure profile.
+The `core' profile exposes editor and project tools, `debug' additionally
+exposes read-only Emacs inspection tools, and `full' also permits tools in the
+`eval' category when their own explicit feature gate is enabled."
+  :type '(choice (const core) (const debug) (const full))
   :group 'ai-code-mcp-server)
 
 (defcustom ai-code-mcp-diagnostics-backend 'auto
@@ -90,6 +101,9 @@ be a non-negative integer."
 (defvar ai-code-mcp--current-session-id nil
   "Dynamically bound MCP session id for the current tool invocation.")
 
+(defvar ai-code-mcp--current-protocol-version nil
+  "Dynamically bound MCP version for the current request.")
+
 (defvar ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal)
   "Hash table mapping MCP session ids to recorded diagnostics baselines.
 Each value is a hash table mapping diagnostic identity strings to counts.
@@ -97,8 +111,21 @@ The baseline lets `get_diagnostics' report only NEW diagnostics so the
 agent can verify it introduced no regressions, without tracking the
 baseline in the model context itself.")
 
-(defconst ai-code-mcp--protocol-version "2024-11-05"
-  "Protocol version reported by the MCP core.")
+(define-error 'ai-code-mcp-protocol-error "MCP protocol error")
+
+(defun ai-code-mcp-signal-protocol-error (code message &optional data)
+  "Signal an MCP protocol error with CODE, MESSAGE, and optional DATA."
+  (signal 'ai-code-mcp-protocol-error (list code message data)))
+
+(defconst ai-code-mcp--protocol-version "2025-11-25"
+  "Preferred initialization-based MCP protocol version.")
+
+(defconst ai-code-mcp--modern-protocol-version "2026-07-28"
+  "Stateless MCP protocol version supported by the server.")
+
+(defconst ai-code-mcp--legacy-protocol-versions
+  '("2025-11-25" "2025-06-18" "2025-03-26")
+  "Initialization-based MCP protocol versions supported by the server.")
 
 (defconst ai-code-mcp--builtin-tool-specs
   '((:function ai-code-mcp-project-info
@@ -226,6 +253,8 @@ Required keys are `:function', `:name', and `:description'."
         (description (plist-get slots :description))
         (args (plist-get slots :args))
         (category (plist-get slots :category))
+        (annotations (plist-get slots :annotations))
+        (output-schema (plist-get slots :output-schema))
         spec)
     (unless function
       (error "Tool :function is required"))
@@ -240,6 +269,10 @@ Required keys are `:function', `:name', and `:description'."
       (setq spec (plist-put spec :args args)))
     (when category
       (setq spec (plist-put spec :category category)))
+    (when annotations
+      (setq spec (plist-put spec :annotations annotations)))
+    (when output-schema
+      (setq spec (plist-put spec :output-schema output-schema)))
     (setq ai-code-mcp-server-tools
           (append
            (seq-remove
@@ -249,13 +282,17 @@ Required keys are `:function', `:name', and `:description'."
            (list spec)))
     spec))
 
-(defun ai-code-mcp-register-session (session-id project-dir buffer)
-  "Register MCP SESSION-ID with PROJECT-DIR and BUFFER."
-  (puthash session-id
-           (list :project-dir project-dir
-                 :buffer buffer
-                 :start-time (current-time))
-           ai-code-mcp--sessions))
+(defun ai-code-mcp-register-session (session-id project-dir buffer &optional metadata)
+  "Register MCP SESSION-ID with PROJECT-DIR, source BUFFER, and METADATA."
+  (let ((context (list :project-dir project-dir
+                       :buffer buffer
+                       :source-buffer buffer
+                       :state 'ready
+                       :start-time (current-time))))
+    (while metadata
+      (setq context (plist-put context (pop metadata) (pop metadata))))
+    (puthash session-id context ai-code-mcp--sessions)
+    (ai-code-mcp-update-source-context session-id buffer)))
 
 (defun ai-code-mcp-unregister-session (session-id)
   "Unregister MCP SESSION-ID and free its recorded diagnostics baseline."
@@ -266,6 +303,95 @@ Required keys are `:function', `:name', and `:description'."
   "Return session context for SESSION-ID or the current session."
   (gethash (or session-id ai-code-mcp--current-session-id)
            ai-code-mcp--sessions))
+
+(defun ai-code-mcp-session-count ()
+  "Return the number of registered MCP application sessions."
+  (hash-table-count ai-code-mcp--sessions))
+
+(defun ai-code-mcp-find-session-by-token (token)
+  "Return the session id and context authenticated by TOKEN."
+  (when (stringp token)
+    (catch 'found
+      (maphash
+       (lambda (session-id context)
+         (when (and (stringp (plist-get context :token))
+                    (string= token (plist-get context :token))
+                    (not (ai-code-mcp--session-expired-p context)))
+           (throw 'found (cons session-id context))))
+       ai-code-mcp--sessions)
+      nil)))
+
+(defun ai-code-mcp--session-expired-p (context)
+  "Return non-nil when CONTEXT has passed its authentication expiry."
+  (when-let ((expires-at (plist-get context :expires-at)))
+    (time-less-p expires-at (current-time))))
+
+(defun ai-code-mcp-update-source-context (session-id source-buffer)
+  "Snapshot SOURCE-BUFFER as the prompt origin for SESSION-ID."
+  (let ((context (ai-code-mcp-get-session-context session-id)))
+    (unless context
+      (error "Unknown MCP session: %s" session-id))
+    (unless (buffer-live-p source-buffer)
+      (error "MCP source buffer is not live"))
+    (let ((snapshot
+           (with-current-buffer source-buffer
+             (let ((position (ai-code-mcp--point-line-column
+                              source-buffer (point))))
+               (list :buffer source-buffer
+                     :point (point)
+                     :line (alist-get 'line position)
+                     :column (alist-get 'column position)
+                     :modification-tick (buffer-chars-modified-tick)
+                     :captured-at (current-time))))))
+      (setq context (plist-put context :buffer source-buffer))
+      (setq context (plist-put context :source-buffer source-buffer))
+      (setq context (plist-put context :source-snapshot snapshot))
+      (setq context (plist-put context :updated-at (current-time)))
+      (puthash session-id context ai-code-mcp--sessions)
+      context)))
+
+(defun ai-code-mcp-attach-agent-buffer (session-id agent-buffer)
+  "Attach AGENT-BUFFER to SESSION-ID without replacing its source."
+  (let ((context (ai-code-mcp-get-session-context session-id)))
+    (unless context
+      (error "Unknown MCP session: %s" session-id))
+    (setq context (plist-put context :agent-buffer agent-buffer))
+    (setq context (plist-put context :state 'ready))
+    (setq context (plist-put context :updated-at (current-time)))
+    (puthash session-id context ai-code-mcp--sessions)
+    context))
+
+(defun ai-code-mcp-begin-legacy-session
+    (session-id transport-session-id protocol-version client-info)
+  "Begin legacy MCP initialization for SESSION-ID.
+TRANSPORT-SESSION-ID identifies subsequent HTTP requests, while
+PROTOCOL-VERSION and CLIENT-INFO record the negotiated client metadata."
+  (let ((context (ai-code-mcp-get-session-context session-id)))
+    (unless context
+      (error "Unknown MCP session: %s" session-id))
+    (setq context (plist-put context :transport-session-id transport-session-id))
+    (setq context (plist-put context :protocol-version protocol-version))
+    (setq context (plist-put context :client-info client-info))
+    (setq context (plist-put context :state 'initializing))
+    (setq context (plist-put context :updated-at (current-time)))
+    (puthash session-id context ai-code-mcp--sessions)
+    context))
+
+(defun ai-code-mcp-complete-legacy-session
+    (session-id transport-session-id protocol-version)
+  "Complete legacy initialization for SESSION-ID.
+TRANSPORT-SESSION-ID and PROTOCOL-VERSION must match the initialized session."
+  (let ((context (ai-code-mcp-get-session-context session-id)))
+    (unless (and context
+                 (eq (plist-get context :state) 'initializing)
+                 (equal transport-session-id
+                        (plist-get context :transport-session-id))
+                 (equal protocol-version (plist-get context :protocol-version)))
+      (error "Invalid MCP initialized notification"))
+    (setq context (plist-put context :state 'ready))
+    (setq context (plist-put context :updated-at (current-time)))
+    (puthash session-id context ai-code-mcp--sessions)
+    context))
 
 (defmacro ai-code-mcp-with-session-context (session-id &rest body)
   "Run BODY with SESSION-ID project context."
@@ -287,18 +413,36 @@ Required keys are `:function', `:name', and `:description'."
 (defun ai-code-mcp-dispatch (method &optional params)
   "Dispatch MCP METHOD using PARAMS."
   (pcase method
-    ("initialize" (ai-code-mcp--initialize))
+    ("initialize" (ai-code-mcp--initialize params))
+    ("server/discover" (ai-code-mcp--discover))
+    ("ping" '())
     ("tools/list" (ai-code-mcp--tools-list))
     ("tools/call" (ai-code-mcp--tools-call params))
-    (_ (error "Unknown MCP method: %s" method))))
+    (_ (ai-code-mcp-signal-protocol-error
+        -32601 (format "Method not found: %s" method)))))
 
 (defun ai-code-mcp-builtins-setup ()
   "Register the built-in common Emacs MCP tools."
   (interactive)
   (dolist (tool ai-code-mcp--builtin-tool-specs)
-    (apply #'ai-code-mcp-make-tool tool))
+    (apply #'ai-code-mcp-make-tool
+           (append tool
+                   (list :category 'core
+                         :annotations
+                         (ai-code-mcp--builtin-tool-annotations
+                          (plist-get tool :name))))))
   (dolist (setup-fn ai-code-mcp-server-tool-setup-functions)
     (funcall setup-fn)))
+
+(defun ai-code-mcp--builtin-tool-annotations (name)
+  "Return effect annotations for built-in tool NAME."
+  (let ((read-only (not (member name '("diagnostics_baseline"
+                                       "notify_user")))))
+    `((title . ,(capitalize (string-replace "_" " " name)))
+      (readOnlyHint . ,(ai-code-mcp--json-bool read-only))
+      (destructiveHint . :json-false)
+      (idempotentHint . ,(ai-code-mcp--json-bool read-only))
+      (openWorldHint . :json-false))))
 
 (defun ai-code-mcp--ensure-builtins ()
   "Ensure built-in MCP tools are registered."
@@ -347,28 +491,44 @@ Required keys are `:function', `:name', and `:description'."
           (region . nil))))))
 
 (defun ai-code-mcp--editor-state-data ()
-  "Return an alist describing the selected window buffer."
-  (let* ((window (ai-code-mcp--selected-window))
-         (buffer (window-buffer window))
-         (point (window-point window))
-         (position (ai-code-mcp--point-line-column buffer point))
-         (region-state (ai-code-mcp--region-state buffer point)))
-    (with-current-buffer buffer
-      `((ok . t)
-        (buffer_name . ,(buffer-name buffer))
-        (file_path . ,(buffer-file-name buffer))
-        (major_mode . ,(symbol-name major-mode))
-        (modified . ,(ai-code-mcp--json-bool
-                      (buffer-modified-p)))
-        (read_only . ,(ai-code-mcp--json-bool buffer-read-only))
-        (narrowed . ,(ai-code-mcp--json-bool
-                      (buffer-narrowed-p)))
-        (point . ,point)
-        (line . ,(alist-get 'line position))
-        (column . ,(alist-get 'column position))
-        (region_active . ,(alist-get 'region_active region-state))
-        (region . ,(alist-get 'region region-state))
-        (default_directory . ,default-directory)))))
+  "Return an alist describing the active session source buffer."
+  (let* ((context (ai-code-mcp-get-session-context))
+         (source-buffer (plist-get context :buffer))
+         (source-snapshot (plist-get context :source-snapshot))
+         (window (ai-code-mcp--selected-window)))
+    (if (and context (not (buffer-live-p source-buffer)))
+        '((ok . :json-false)
+          (status . "unavailable")
+          (reason . "Prompt source buffer is no longer live"))
+      (let* ((buffer (if (buffer-live-p source-buffer)
+                         source-buffer
+                       (window-buffer window)))
+             (point (if (and (eq buffer source-buffer) source-snapshot)
+                        (plist-get source-snapshot :point)
+                      (window-point window)))
+             (position (if (and (eq buffer source-buffer) source-snapshot)
+                           `((line . ,(plist-get source-snapshot :line))
+                             (column . ,(plist-get source-snapshot :column)))
+                         (ai-code-mcp--point-line-column buffer point)))
+             (region-point (with-current-buffer buffer
+                             (min point (point-max))))
+             (region-state (ai-code-mcp--region-state buffer region-point)))
+        (with-current-buffer buffer
+          `((ok . t)
+            (buffer_name . ,(buffer-name buffer))
+            (file_path . ,(buffer-file-name buffer))
+            (major_mode . ,(symbol-name major-mode))
+            (modified . ,(ai-code-mcp--json-bool
+                          (buffer-modified-p)))
+            (read_only . ,(ai-code-mcp--json-bool buffer-read-only))
+            (narrowed . ,(ai-code-mcp--json-bool
+                          (buffer-narrowed-p)))
+            (point . ,point)
+            (line . ,(alist-get 'line position))
+            (column . ,(alist-get 'column position))
+            (region_active . ,(alist-get 'region_active region-state))
+            (region . ,(alist-get 'region region-state))
+            (default_directory . ,default-directory)))))))
 
 (defun ai-code-mcp-editor-state ()
   "Return a JSON payload for the current editor state."
@@ -438,25 +598,26 @@ When START-LINE and NUM-LINES are non-nil, return only that line range."
 
 (defun ai-code-mcp-get-diagnostics (&optional uri since)
   "Return a JSON diagnostics observation envelope for URI or the project.
-The envelope has `status', `summary', `files', `next_actions', and
-`artifacts' keys so the agent's verification loop reads an actionable
-signal instead of a raw list.  When SINCE is the string \"baseline\",
-report only diagnostics that are new relative to the baseline recorded by
-`ai-code-mcp-diagnostics-baseline', so the agent can confirm it introduced
-no new problems before finishing."
-  (let* ((entries (if uri
-                      (ai-code-mcp--diagnostics-for-uri uri)
-                    (ai-code-mcp--diagnostics-for-project)))
+The envelope includes coverage and freshness metadata so an unavailable or
+still-running diagnostics backend cannot be mistaken for a clean result.
+When SINCE is the string \"baseline\", report only diagnostics that are new
+relative to the baseline recorded by `ai-code-mcp-diagnostics-baseline'."
+  (let* ((observation (if uri
+                          (ai-code-mcp--diagnostics-for-uri uri)
+                        (ai-code-mcp--diagnostics-for-project)))
+         (entries (plist-get observation :entries))
          (delta (and (stringp since) (string-equal since "baseline"))))
     (json-encode
      (cond
       ((and delta (not (ai-code-mcp--diagnostics-baseline-recorded-p)))
-       (ai-code-mcp--diagnostics-no-baseline-envelope))
+       (ai-code-mcp--diagnostics-no-baseline-envelope observation))
       (delta
        (ai-code-mcp--diagnostics-envelope
-        (ai-code-mcp--diagnostics-new-since-baseline entries) 'delta))
+        (ai-code-mcp--diagnostics-new-since-baseline entries)
+        'delta
+        observation))
       (t
-       (ai-code-mcp--diagnostics-envelope entries 'current))))))
+       (ai-code-mcp--diagnostics-envelope entries 'current observation))))))
 
 (defun ai-code-mcp--diagnostics-summary (entries)
   "Return a one-line human summary string for diagnostics ENTRIES."
@@ -538,44 +699,208 @@ diagnostics -- not as a way to page through the omitted ones."
  to focus on diagnostics you introduced."
               shown total plural))))
 
-(defun ai-code-mcp--diagnostics-envelope (entries &optional context)
+(defun ai-code-mcp--diagnostics-observation-count (observation predicate)
+  "Count targets in OBSERVATION that satisfy PREDICATE."
+  (cl-count-if predicate (plist-get observation :targets)))
+
+(defun ai-code-mcp--diagnostics-observation-complete-p (observation)
+  "Return non-nil when OBSERVATION covers every requested target.
+A nil observation represents a compatibility caller that supplied diagnostic
+entries directly and is therefore treated as complete."
+  (or (null observation)
+      (let ((targets (plist-get observation :targets)))
+        (and targets
+             (cl-every (lambda (target)
+                         (eq (plist-get target :state) 'ready))
+                       targets)))))
+
+(defun ai-code-mcp--diagnostics-backend-counts (observation)
+  "Return sorted backend coverage entries for OBSERVATION."
+  (let ((counts (make-hash-table :test 'eq))
+        pairs)
+    (dolist (target (plist-get observation :targets))
+      (when-let ((backend (plist-get target :backend)))
+        (puthash backend (1+ (gethash backend counts 0)) counts)))
+    (maphash (lambda (backend count)
+               (push (cons backend count) pairs))
+             counts)
+    (vconcat
+     (mapcar (lambda (pair)
+               `((name . ,(symbol-name (car pair)))
+                 (files . ,(cdr pair))))
+             (sort pairs
+                   (lambda (left right)
+                     (string< (symbol-name (car left))
+                              (symbol-name (car right)))))))))
+
+(defun ai-code-mcp--diagnostics-coverage-data (observation)
+  "Return JSON-ready diagnostics coverage metadata for OBSERVATION."
+  (let* ((targets (plist-get observation :targets))
+         (requested (length targets))
+         (checked (ai-code-mcp--diagnostics-observation-count
+                   observation
+                   (lambda (target) (plist-get target :backend))))
+         (unavailable (ai-code-mcp--diagnostics-observation-count
+                       observation
+                       (lambda (target)
+                         (eq (plist-get target :state) 'unavailable))))
+         (running (ai-code-mcp--diagnostics-observation-count
+                   observation
+                   (lambda (target)
+                     (eq (plist-get target :state) 'running))))
+         (complete (ai-code-mcp--diagnostics-observation-complete-p
+                    observation))
+         (unavailable-targets
+          (delq nil
+                (mapcar
+                 (lambda (target)
+                   (when (eq (plist-get target :state) 'unavailable)
+                     `((uri . ,(plist-get target :uri))
+                       (reason . ,(plist-get target :reason)))))
+                 targets))))
+    (append
+     `((scope . ,(or (plist-get observation :scope) "supplied_entries"))
+       (requested_files . ,requested)
+       (checked_files . ,checked)
+       (unavailable_files . ,unavailable)
+       (running_files . ,running)
+       (complete . ,(ai-code-mcp--json-bool complete))
+       (backends . ,(ai-code-mcp--diagnostics-backend-counts observation))
+       (unavailable . ,(vconcat unavailable-targets)))
+     (when-let ((reason (plist-get observation :reason)))
+       `((reason . ,reason))))))
+
+(defun ai-code-mcp--diagnostics-freshness-data (observation)
+  "Return JSON-ready snapshot metadata for diagnostics OBSERVATION."
+  (let* ((targets (plist-get observation :targets))
+         (modified (ai-code-mcp--diagnostics-observation-count
+                    observation
+                    (lambda (target) (plist-get target :modified))))
+         (buffers
+          (mapcar
+           (lambda (target)
+             `((uri . ,(plist-get target :uri))
+               (backend . ,(if-let ((backend (plist-get target :backend)))
+                               (symbol-name backend)
+                             :null))
+               (state . ,(symbol-name (plist-get target :state)))
+               (modified . ,(ai-code-mcp--json-bool
+                              (plist-get target :modified)))
+               (modification_tick
+                . ,(or (plist-get target :modification-tick) :null))))
+           targets)))
+    `((observed_at . ,(or (plist-get observation :observed-at)
+                          (format-time-string "%Y-%m-%dT%H:%M:%SZ" nil t)))
+      (modified_files . ,modified)
+      (buffers . ,(vconcat buffers)))))
+
+(defun ai-code-mcp--diagnostics-coverage-summary (observation)
+  "Return a concise coverage warning for OBSERVATION, or nil."
+  (unless (ai-code-mcp--diagnostics-observation-complete-p observation)
+    (let* ((targets (plist-get observation :targets))
+           (requested (length targets))
+           (checked (ai-code-mcp--diagnostics-observation-count
+                     observation
+                     (lambda (target) (plist-get target :backend))))
+           (running (ai-code-mcp--diagnostics-observation-count
+                     observation
+                     (lambda (target)
+                       (eq (plist-get target :state) 'running)))))
+      (cond
+       ((zerop requested)
+        " Diagnostics unavailable: no open project buffers were in scope.")
+       ((zerop checked)
+        (format " Diagnostics unavailable: no active checker covered the %d requested file%s."
+                requested (if (= requested 1) "" "s")))
+       (t
+        (format " Diagnostics coverage incomplete: checked %d of %d requested file%s%s."
+                checked requested (if (= requested 1) "" "s")
+                (if (> running 0)
+                    (format "; %d checker%s still running"
+                            running (if (= running 1) " is" "s are"))
+                  "")))))))
+
+(defun ai-code-mcp--diagnostics-coverage-actions (observation)
+  "Return actions needed to complete diagnostics OBSERVATION coverage."
+  (unless (ai-code-mcp--diagnostics-observation-complete-p observation)
+    (let ((running (ai-code-mcp--diagnostics-observation-count
+                    observation
+                    (lambda (target)
+                      (eq (plist-get target :state) 'running))))
+          (unavailable (ai-code-mcp--diagnostics-observation-count
+                        observation
+                        (lambda (target)
+                          (eq (plist-get target :state) 'unavailable)))))
+      (delq nil
+            (list
+             (when (> unavailable 0)
+               "Enable Flymake or Flycheck for each unavailable buffer, then run get_diagnostics again.")
+             (when (> running 0)
+               "Wait for running diagnostics backends to finish, then run get_diagnostics again.")
+             (when (zerop (length (plist-get observation :targets)))
+               "Open the project files to inspect and enable Flymake or Flycheck before retrying."))))))
+
+(defun ai-code-mcp--diagnostics-envelope (entries &optional context observation)
   "Return a diagnostics observation envelope alist for ENTRIES.
 CONTEXT is `current' (default) or `delta'.  In the `delta' context the
 status and summary describe diagnostics that are new since the baseline
 and express the done-condition the agent must reach (new == 0).
+OBSERVATION supplies coverage and freshness metadata for the scan.
 
 The listed `files' and `next_actions' are capped at
 `ai-code-mcp-diagnostics-max-report-diagnostics' so a large project cannot
 overflow the model context; the summary always reports the true totals and
 notes any truncation."
-  (let* ((has-issues (and entries t))
-         (total (ai-code-mcp--diagnostics-total-count entries))
+  (let* ((total (ai-code-mcp--diagnostics-total-count entries))
+         (has-issues (> total 0))
+         (complete (ai-code-mcp--diagnostics-observation-complete-p
+                    observation))
+         (checked (ai-code-mcp--diagnostics-observation-count
+                   observation
+                   (lambda (target) (plist-get target :backend))))
          (capped-cell (ai-code-mcp--cap-diagnostics-entries
                        entries ai-code-mcp-diagnostics-max-report-diagnostics))
          (capped (car capped-cell))
          (shown (cdr capped-cell))
          (truncated (> total shown))
-         (status (cond ((not has-issues) "clean")
-                       ((eq context 'delta) "regression")
-                       (t "issues")))
+         (status (cond
+                  (has-issues (if (eq context 'delta) "regression" "issues"))
+                  (complete "clean")
+                  ((zerop checked) "unavailable")
+                  (t "incomplete")))
          (base-summary (cond
                         ((eq context 'delta)
-                         (if has-issues
-                             (concat (ai-code-mcp--diagnostics-summary entries)
-                                     " These are NEW versus the baseline;"
-                                     " not done until new == 0.")
+                         (cond
+                          (has-issues
+                           (concat (ai-code-mcp--diagnostics-summary entries)
+                                   " These are NEW versus the baseline;"
+                                   " not done until new == 0."))
+                          (complete
                            (concat "No new diagnostics versus the baseline;"
-                                   " done-condition met (new == 0).")))
+                                   " done-condition met (new == 0)."))
+                          (t
+                           (concat "No new diagnostics were observed versus"
+                                   " the baseline, but coverage is incomplete;"
+                                   " the done-condition is not established."))))
                         (t (ai-code-mcp--diagnostics-summary entries))))
-         (summary (if truncated
-                      (concat base-summary
-                              (ai-code-mcp--diagnostics-truncation-note
-                               shown total context))
-                    base-summary)))
+         (coverage-summary
+          (ai-code-mcp--diagnostics-coverage-summary observation))
+         (summary (concat
+                   base-summary
+                   (or coverage-summary "")
+                   (if truncated
+                       (ai-code-mcp--diagnostics-truncation-note
+                        shown total context)
+                     "")))
+         (actions (append
+                   (append (ai-code-mcp--diagnostics-next-actions capped) nil)
+                   (ai-code-mcp--diagnostics-coverage-actions observation))))
     `((status . ,status)
       (summary . ,summary)
       (files . ,(vconcat capped))
-      (next_actions . ,(ai-code-mcp--diagnostics-next-actions capped))
+      (next_actions . ,(vconcat actions))
+      (coverage . ,(ai-code-mcp--diagnostics-coverage-data observation))
+      (freshness . ,(ai-code-mcp--diagnostics-freshness-data observation))
       (artifacts . ,(vconcat nil)))))
 
 (defun ai-code-mcp--diagnostics-baseline-key ()
@@ -594,10 +919,11 @@ notes any truncation."
     (dolist (entry entries total)
       (setq total (+ total (length (alist-get 'diagnostics entry)))))))
 
-(defun ai-code-mcp--diagnostics-no-baseline-envelope ()
+(defun ai-code-mcp--diagnostics-no-baseline-envelope (&optional observation)
   "Return an envelope explaining that no diagnostics baseline was recorded.
 This avoids reporting pre-existing diagnostics as regressions when the agent
-requests `since=\"baseline\"' without first calling `diagnostics_baseline'."
+requests `since=\"baseline\"' without first calling `diagnostics_baseline'.
+OBSERVATION supplies metadata about the attempted diagnostics scan."
   `((status . "no_baseline")
     (summary . ,(concat "No diagnostics baseline recorded for this session;"
                         " current diagnostics are not reported as regressions."))
@@ -605,6 +931,8 @@ requests `since=\"baseline\"' without first calling `diagnostics_baseline'."
     (next_actions . ,(vector
                       (concat "Call the diagnostics_baseline MCP tool, then"
                               " re-run get_diagnostics with since=\"baseline\".")))
+    (coverage . ,(ai-code-mcp--diagnostics-coverage-data observation))
+    (freshness . ,(ai-code-mcp--diagnostics-freshness-data observation))
     (artifacts . ,(vconcat nil))))
 
 (defun ai-code-mcp--diagnostic-identity (uri diagnostic)
@@ -687,8 +1015,10 @@ diagnostics without listing every diagnostic."
 Return a JSON observation envelope describing what was recorded.  Later
 `get_diagnostics' calls with `since' set to \"baseline\" report only NEW
 diagnostics relative to this snapshot, which lets the agent verify it did
-not introduce new problems."
-  (let* ((entries (ai-code-mcp--diagnostics-for-project))
+not introduce new problems.  Refuse to record a baseline unless every open
+project buffer in scope has an active, idle diagnostics backend."
+  (let* ((observation (ai-code-mcp--diagnostics-for-project))
+         (entries (plist-get observation :entries))
          (counts (ai-code-mcp--diagnostics-identity-counts entries))
          (count (ai-code-mcp--diagnostics-total-count entries))
          (sources (ai-code-mcp--diagnostics-top-sources-string entries))
@@ -698,75 +1028,155 @@ not introduce new problems."
  status is \"clean\"."
                            count (if (= count 1) "" "s"))
                    (when sources (format " Top sources: %s." sources)))))
-    (puthash (ai-code-mcp--diagnostics-baseline-key) counts
-             ai-code-mcp--diagnostics-baselines)
-    (json-encode
-     `((status . "baseline_recorded")
-       (summary . ,summary)
-       ;; The baseline is recorded server-side in `counts' (via `puthash'
-       ;; above); do not echo the full diagnostics list back into the model
-       ;; context.  Returning every project diagnostic here can produce a
-       ;; payload far too large to fit in the model context, which defeats the
-       ;; purpose of keeping the baseline out of context in the first place.
-       (files . ,(vconcat nil))
-       (next_actions . ,(vector
-                         (concat "Edit, then call get_diagnostics with"
-                                 " since=\"baseline\" on the touched files and"
-                                 " finish only when status is \"clean\".")))
-       (artifacts . ,(vconcat nil))))))
+    (if (not (ai-code-mcp--diagnostics-observation-complete-p observation))
+        (json-encode
+         `((status . "baseline_unavailable")
+           (summary . ,(concat
+                        "Diagnostics baseline was not recorded because"
+                        " coverage is incomplete."
+                        (or (ai-code-mcp--diagnostics-coverage-summary
+                             observation)
+                            "")))
+           (files . ,(vconcat nil))
+           (next_actions
+            . ,(vconcat
+                (ai-code-mcp--diagnostics-coverage-actions observation)))
+           (coverage . ,(ai-code-mcp--diagnostics-coverage-data observation))
+           (freshness . ,(ai-code-mcp--diagnostics-freshness-data observation))
+           (artifacts . ,(vconcat nil))))
+      (puthash (ai-code-mcp--diagnostics-baseline-key) counts
+               ai-code-mcp--diagnostics-baselines)
+      (json-encode
+       `((status . "baseline_recorded")
+         (summary . ,summary)
+         ;; The baseline is recorded server-side in `counts' (via `puthash'
+         ;; above); do not echo the full diagnostics list back into the model
+         ;; context.  Returning every project diagnostic here can produce a
+         ;; payload far too large to fit in the model context, which defeats
+         ;; keeping the baseline out of context in the first place.
+         (files . ,(vconcat nil))
+         (next_actions . ,(vector
+                           (concat "Edit, then call get_diagnostics with"
+                                   " since=\"baseline\" on the touched files and"
+                                   " finish only when status is \"clean\".")))
+         (coverage . ,(ai-code-mcp--diagnostics-coverage-data observation))
+         (freshness . ,(ai-code-mcp--diagnostics-freshness-data observation))
+         (artifacts . ,(vconcat nil)))))))
 
 (defun ai-code-mcp--diagnostics-for-uri (uri)
-  "Return a list with diagnostics for URI, or nil when none exist.
-The entry uses the canonical file URI of the resolved buffer (via
-`ai-code-mcp--file-path-to-uri') so its identity matches the baseline that
-`ai-code-mcp-diagnostics-baseline' records from the project scan, even when
-URI is given in a non-canonical form such as a localhost or bare-path URI."
-  (when-let* ((file-path (ai-code-mcp--uri-to-file-path uri))
-              (buffer (get-file-buffer file-path))
-              (diagnostics (ai-code-mcp--buffer-diagnostics buffer)))
-    (when-let ((entry (ai-code-mcp--diagnostics-file-entry
-                       (ai-code-mcp--file-path-to-uri
-                        (or (buffer-file-name buffer) file-path))
-                       diagnostics)))
-      (list entry))))
+  "Return a diagnostics observation for URI.
+The observation records an unavailable target when the file has no open
+buffer instead of incorrectly treating the missing diagnostics as clean."
+  (let* ((file-path (ai-code-mcp--uri-to-file-path uri))
+         (buffer (and file-path (get-file-buffer file-path)))
+         (target
+          (if buffer
+              (ai-code-mcp--diagnostics-observe-buffer buffer)
+            (list :uri uri
+                  :backend nil
+                  :state 'unavailable
+                  :reason "buffer_not_open"
+                  :modified nil
+                  :modification-tick nil
+                  :diagnostics (vconcat nil)))))
+    (ai-code-mcp--make-diagnostics-observation
+     "requested_uri" (list target))))
 
 (defun ai-code-mcp--diagnostics-for-project ()
-  "Return project diagnostics for open file-visiting buffers."
+  "Return a diagnostics observation for open project file buffers."
   (let ((project-dir (ai-code-mcp--project-directory))
-        diagnostics-by-file)
-    (dolist (buffer (buffer-list) (nreverse diagnostics-by-file))
+        targets)
+    (dolist (buffer (buffer-list))
       (when-let ((file-path (buffer-file-name buffer)))
         (when (or (not project-dir)
                   (file-in-directory-p file-path project-dir))
-          (when-let ((diagnostics (ai-code-mcp--buffer-diagnostics buffer)))
-            (when-let ((entry (ai-code-mcp--diagnostics-file-entry
-                               (ai-code-mcp--file-path-to-uri file-path)
-                               diagnostics)))
-              (push entry diagnostics-by-file))))))))
+          (push (ai-code-mcp--diagnostics-observe-buffer buffer) targets))))
+    (ai-code-mcp--make-diagnostics-observation
+     "open_project_buffers"
+     (nreverse targets)
+     (when (null targets) "no_open_project_buffers"))))
 
-(defun ai-code-mcp--buffer-diagnostics (buffer)
-  "Return a vector of diagnostics for BUFFER."
+(defun ai-code-mcp--make-diagnostics-observation (scope targets
+                                                        &optional reason)
+  "Return a diagnostics observation for SCOPE and TARGETS.
+REASON explains why a scope has no targets."
+  (let (entries)
+    (dolist (target targets)
+      (when-let ((entry (ai-code-mcp--diagnostics-file-entry
+                         (plist-get target :uri)
+                         (plist-get target :diagnostics))))
+        (push entry entries)))
+    (list :scope scope
+          :targets targets
+          :entries (nreverse entries)
+          :reason reason
+          :observed-at (format-time-string "%Y-%m-%dT%H:%M:%SZ" nil t))))
+
+(defun ai-code-mcp--diagnostics-observe-buffer (buffer)
+  "Return diagnostics and coverage metadata observed from BUFFER."
+  (let* ((backend (ai-code-mcp--diagnostics-backend-for-buffer buffer))
+         (running (and backend
+                       (ai-code-mcp--diagnostics-backend-running-p
+                        buffer backend)))
+         (state (cond ((null backend) 'unavailable)
+                      (running 'running)
+                      (t 'ready))))
+    (with-current-buffer buffer
+      (list :uri (ai-code-mcp--file-path-to-uri (buffer-file-name buffer))
+            :backend backend
+            :state state
+            :reason (cond ((null backend) "no_active_backend")
+                          (running "diagnostics_running"))
+            :modified (buffer-modified-p)
+            :modification-tick (buffer-chars-modified-tick)
+            :diagnostics (if backend
+                             (ai-code-mcp--buffer-diagnostics buffer backend)
+                           (vconcat nil))))))
+
+(defun ai-code-mcp--buffer-diagnostics (buffer &optional backend)
+  "Return a vector of diagnostics for BUFFER using optional BACKEND."
   (vconcat
-   (pcase (ai-code-mcp--diagnostics-backend-for-buffer buffer)
+   (pcase (or backend (ai-code-mcp--diagnostics-backend-for-buffer buffer))
      ('flycheck (or (ai-code-mcp--flycheck-diagnostics buffer) '()))
      ('flymake (or (ai-code-mcp--flymake-diagnostics buffer) '()))
      (_ '()))))
 
+(defun ai-code-mcp--diagnostics-backend-active-p (buffer backend)
+  "Return non-nil when diagnostics BACKEND is active in BUFFER."
+  (with-current-buffer buffer
+    (pcase backend
+      ('flycheck (and (featurep 'flycheck)
+                      (bound-and-true-p flycheck-mode)))
+      ('flymake (and (featurep 'flymake)
+                     (bound-and-true-p flymake-mode)))
+      (_ nil))))
+
 (defun ai-code-mcp--diagnostics-backend-for-buffer (buffer)
-  "Return the diagnostics backend symbol to use for BUFFER."
+  "Return the active diagnostics backend symbol to use for BUFFER."
   (let ((backend ai-code-mcp-diagnostics-backend))
     (if (eq backend 'auto)
         (cond
-         ((with-current-buffer buffer
-            (and (featurep 'flycheck)
-                 (bound-and-true-p flycheck-mode)))
+         ((ai-code-mcp--diagnostics-backend-active-p buffer 'flycheck)
           'flycheck)
-         ((with-current-buffer buffer
-            (and (featurep 'flymake)
-                 (bound-and-true-p flymake-mode)))
+         ((ai-code-mcp--diagnostics-backend-active-p buffer 'flymake)
           'flymake)
          (t nil))
-      backend)))
+      (and (ai-code-mcp--diagnostics-backend-active-p buffer backend)
+           backend))))
+
+(defun ai-code-mcp--diagnostics-backend-running-p (buffer backend)
+  "Return non-nil when diagnostics BACKEND is still running in BUFFER."
+  (with-current-buffer buffer
+    (pcase backend
+      ('flycheck
+       (or (and (fboundp 'flycheck-running-p)
+                (ignore-errors (flycheck-running-p)))
+           (and (boundp 'flycheck-last-status-change)
+                (eq flycheck-last-status-change 'running))))
+      ('flymake
+       (and (fboundp 'flymake-running-backends)
+            (ignore-errors (flymake-running-backends))))
+      (_ nil))))
 
 (defun ai-code-mcp--flycheck-diagnostics (buffer)
   "Return Flycheck diagnostics for BUFFER."
@@ -996,33 +1406,104 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
                             (substring text 0 (min 80 (length text)))
                           "")))))))))))
 
-(defun ai-code-mcp--initialize ()
-  "Return the MCP initialize payload."
-  `((protocolVersion . ,ai-code-mcp--protocol-version)
+(defun ai-code-mcp--initialize (&optional params)
+  "Return the MCP initialize payload negotiated from PARAMS."
+  (let ((protocol-version
+         (ai-code-mcp-negotiate-legacy-version
+          (alist-get 'protocolVersion params))))
+    `((protocolVersion . ,protocol-version)
     (capabilities . ((tools . ((listChanged . :json-false)))))
     (serverInfo . ((name . "ai-code-mcp-tools")
-                   (version . "0.1.0")))))
+                   (version . "0.1.0"))))))
+
+(defun ai-code-mcp-negotiate-legacy-version (requested)
+  "Return the supported legacy version negotiated for REQUESTED."
+  (if (member requested ai-code-mcp--legacy-protocol-versions)
+      requested
+    ai-code-mcp--protocol-version))
+
+(defun ai-code-mcp--discover ()
+  "Return stateless MCP server discovery metadata."
+  `((resultType . "complete")
+    (supportedVersions . [,ai-code-mcp--modern-protocol-version])
+    (capabilities . ((tools . ((listChanged . :json-false)))))
+    (_meta . ,(ai-code-mcp--server-meta))
+    (instructions
+     . "Use these tools for live Emacs context and Emacs-side validation.")
+    (ttlMs . 5000)
+    (cacheScope . "private")))
+
+(defun ai-code-mcp--modern-request-p ()
+  "Return non-nil while dispatching the stateless MCP version."
+  (equal ai-code-mcp--current-protocol-version
+         ai-code-mcp--modern-protocol-version))
+
+(defun ai-code-mcp--server-meta ()
+  "Return per-response server identity metadata."
+  '((io.modelcontextprotocol/serverInfo
+     . ((name . "ai-code-mcp-tools") (version . "0.1.0")))))
+
+(defun ai-code-mcp--complete-result (fields)
+  "Add modern completion metadata to result FIELDS when required."
+  (if (ai-code-mcp--modern-request-p)
+      (append `((resultType . "complete"))
+              fields
+              `((_meta . ,(ai-code-mcp--server-meta))))
+    fields))
 
 (defun ai-code-mcp--tools-list ()
   "Return MCP tools/list response."
   (ai-code-mcp--ensure-builtins)
-  `((tools . ,(mapcar #'ai-code-mcp--tool-to-mcp
-                      ai-code-mcp-server-tools))))
+  (ai-code-mcp--complete-result
+   `((tools . ,(mapcar
+                #'ai-code-mcp--tool-to-mcp
+                (sort (seq-filter #'ai-code-mcp--tool-available-p
+                                  (copy-sequence ai-code-mcp-server-tools))
+                      (lambda (left right)
+                        (string< (plist-get left :name)
+                                 (plist-get right :name))))))
+     ,@(when (ai-code-mcp--modern-request-p)
+         '((ttlMs . 5000) (cacheScope . "private"))))))
 
 (defun ai-code-mcp--tools-call (params)
   "Return MCP tools/call response for PARAMS."
   (ai-code-mcp--ensure-builtins)
   (let* ((tool-name (alist-get 'name params))
-         (arguments (or (alist-get 'arguments params) '()))
-         (tool (ai-code-mcp--find-tool tool-name))
-         (result (ai-code-mcp--call-tool tool arguments)))
-    `((content . (((type . "text")
-                   (text . ,(ai-code-mcp--format-result result))))))))
+         (arguments-entry (assq 'arguments params))
+         (arguments (if arguments-entry (cdr arguments-entry) '()))
+         (tool (progn
+                 (unless (stringp tool-name)
+                   (ai-code-mcp-signal-protocol-error
+                    -32602 "Tool name must be a string"))
+                 (ai-code-mcp--find-tool tool-name))))
+    (condition-case err
+        (ai-code-mcp--tool-success-result
+         (ai-code-mcp--call-tool tool arguments))
+      (ai-code-mcp-protocol-error
+       (signal (car err) (cdr err)))
+      (error
+       (ai-code-mcp--tool-error-result err)))))
 
 (defun ai-code-mcp--find-tool (tool-name)
   "Return the tool spec matching TOOL-NAME."
-  (or (ai-code-mcp--find-tool-spec tool-name)
-      (error "Unknown tool: %s" tool-name)))
+  (or (let ((tool (ai-code-mcp--find-tool-spec tool-name)))
+        (and tool (ai-code-mcp--tool-available-p tool) tool))
+      (ai-code-mcp-signal-protocol-error
+       -32602 (format "Unknown tool: %s" tool-name))))
+
+(defun ai-code-mcp--active-tool-profile ()
+  "Return the tool profile for the active application session."
+  (or (plist-get (ai-code-mcp-get-session-context) :tool-profile)
+      ai-code-mcp-default-tool-profile))
+
+(defun ai-code-mcp--tool-available-p (tool)
+  "Return non-nil when TOOL belongs to the active exposure profile."
+  (let ((category (or (plist-get tool :category) 'core)))
+    (pcase (ai-code-mcp--active-tool-profile)
+      ('core (eq category 'core))
+      ('debug (memq category '(core debug)))
+      ('full (memq category '(core debug eval)))
+      (_ nil))))
 
 (defun ai-code-mcp--find-tool-spec (tool-name)
   "Return the tool spec matching TOOL-NAME, or nil."
@@ -1039,26 +1520,114 @@ When WHOLE-FILE is non-nil, inspect the root node instead."
 
 (defun ai-code-mcp--validate-args (arguments arg-specs)
   "Return ordered ARGUMENTS validated against ARG-SPECS."
+  (unless (and (listp arguments)
+               (seq-every-p #'consp arguments))
+    (ai-code-mcp-signal-protocol-error
+     -32602 "Tool arguments must be a JSON object"))
+  (let ((allowed-names (mapcar (lambda (spec)
+                                 (plist-get spec :name))
+                               arg-specs)))
+    (dolist (entry arguments)
+      (unless (member (if (symbolp (car entry))
+                          (symbol-name (car entry))
+                        (car entry))
+                      allowed-names)
+        (ai-code-mcp-signal-protocol-error
+         -32602 (format "Unknown tool argument: %s" (car entry))))))
   (let (values)
     (dolist (spec arg-specs (nreverse values))
       (let* ((name (plist-get spec :name))
-             (entry (assq (intern name) arguments)))
+             (entry (or (assq (intern name) arguments)
+                        (assoc name arguments))))
         (when (and (not (plist-get spec :optional))
                    (null entry))
-          (error "Missing required argument: %s" name))
-        (push (cdr entry) values)))))
+          (ai-code-mcp-signal-protocol-error
+           -32602 (format "Missing required argument: %s" name)))
+        (when (and entry
+                   (not (ai-code-mcp--argument-type-p
+                         (cdr entry) (plist-get spec :type))))
+          (ai-code-mcp-signal-protocol-error
+           -32602
+           (format "Argument %s must be %s"
+                   name (plist-get spec :type))))
+        (push (if (and entry (eq (cdr entry) :null))
+                  nil
+                (cdr entry))
+              values)))))
+
+(defun ai-code-mcp--argument-type-p (value type)
+  "Return non-nil when VALUE satisfies JSON schema TYPE."
+  (pcase type
+    ('string (stringp value))
+    ('integer (integerp value))
+    ('number (numberp value))
+    ('boolean (memq value '(t :json-false :false)))
+    ('array (or (vectorp value) (listp value)))
+    ('object (or (hash-table-p value) (listp value)))
+    (_ nil)))
+
+(defun ai-code-mcp--tool-success-result (value)
+  "Return an MCP success result for tool VALUE."
+  (let* ((structured (ai-code-mcp--structured-content value))
+         (is-error (if (eq (alist-get 'ok structured) :json-false)
+                       t
+                     :json-false)))
+    (ai-code-mcp--complete-result
+     `((content . (((type . "text")
+                    (text . ,(ai-code-mcp--format-result value)))))
+       (structuredContent . ,structured)
+       (isError . ,is-error)))))
+
+(defun ai-code-mcp--tool-error-result (err)
+  "Return an MCP semantic error result for ERR."
+  (let* ((message (error-message-string err))
+         (structured
+          `((error . ((type . "tool_execution_error")
+                      (message . ,message))))))
+    (ai-code-mcp--complete-result
+     `((content . (((type . "text") (text . ,message))))
+       (structuredContent . ,structured)
+       (isError . t)))))
+
+(defun ai-code-mcp--structured-content (value)
+  "Return object-shaped structured content for tool VALUE."
+  (cond
+   ((stringp value)
+    (condition-case nil
+        (let ((parsed (json-parse-string
+                       value
+                       :object-type 'alist
+                       :array-type 'array
+                       :null-object :null
+                       :false-object :json-false)))
+          (cond
+           ((and (listp parsed) (seq-every-p #'consp parsed)) parsed)
+           ((and (null parsed)
+                 (string-match-p "\\`[[:space:]]*{" value))
+            (ai-code-mcp--empty-object))
+           (t `((value . ,parsed)))))
+      (json-parse-error `((text . ,value)))))
+   ((hash-table-p value) value)
+   ((and (listp value) (seq-every-p #'consp value)) value)
+   ((listp value) `((items . ,(vconcat value))))
+   (t `((value . ,value)))))
 
 (defun ai-code-mcp--tool-to-mcp (tool)
   "Convert TOOL spec into MCP tool metadata."
   `((name . ,(plist-get tool :name))
     (description . ,(plist-get tool :description))
+    ,@(when-let ((annotations (plist-get tool :annotations)))
+        `((annotations . ,annotations)))
     (inputSchema . ((type . "object")
+                    (additionalProperties . :json-false)
                     (properties . ,(or (ai-code-mcp--args-to-schema
                                         (plist-get tool :args))
                                        (ai-code-mcp--empty-object)))
                     (required . ,(vconcat
                                   (ai-code-mcp--required-args
-                                   (plist-get tool :args))))))))
+                                   (plist-get tool :args))))))
+    ,@(when-let ((output-schema (plist-get tool :output-schema)))
+        `((outputSchema . ,output-schema)))))
 
 (defun ai-code-mcp--empty-object ()
   "Return an empty JSON object placeholder."

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -48,7 +48,9 @@ the terminal backend infrastructure.")
 (declare-function ai-code-backends-infra--session-buffer-p "ai-code-backends-infra" (buffer))
 (declare-function ai-code-backends-infra--session-buffer-matches-directory-p "ai-code-backends-infra" (buffer directory))
 (declare-function ai-code-backends-infra--terminal-send-string
-  "ai-code-backends-infra" (string &optional paste))
+                  "ai-code-backends-infra" (string &optional paste))
+(declare-function ai-code-mcp-agent-refresh-source-context
+                  "ai-code-mcp-agent" (agent-buffer source-buffer))
 (declare-function ai-code-backends-infra--terminal-send-return "ai-code-backends-infra" ())
 (declare-function ai-code-backends-infra--display-buffer-in-side-window "ai-code-backends-infra" (buffer))
 
@@ -357,6 +359,8 @@ Return a session buffer, or nil for default backend dispatch."
 
 (defun ai-code--send-prompt-to-session-buffer (prompt buffer)
   "Send PROMPT directly to session BUFFER and display it."
+  (when (fboundp 'ai-code-mcp-agent-refresh-source-context)
+    (ai-code-mcp-agent-refresh-source-context buffer (current-buffer)))
   (with-current-buffer buffer
     (if (and (string-match-p "\n" prompt)
              (bound-and-true-p ai-code-backends-infra-use-paste-backends)
@@ -658,7 +662,7 @@ Special commands:
 Following issue #404 behavior:
 1. If cursor is on an Org section headline, call `ai-code-implement-todo`.
 2. If there is a selected region, send the selected region to the AI session.
-3. Otherwise, fallback to the existing `org-mode` `C-c C-c` action (`org-ctrl-c-ctrl-c`)."
+3. Otherwise, fall back to the existing `org-ctrl-c-ctrl-c' action."
   (interactive)
   (cond
    ((and (derived-mode-p 'org-mode)
@@ -681,7 +685,7 @@ Following issue #404 behavior:
    (t
     (if (fboundp 'org-ctrl-c-ctrl-c)
         (call-interactively #'org-ctrl-c-ctrl-c)
-      (user-error "org-ctrl-c-ctrl-c is not defined")))))
+      (user-error "Org command org-ctrl-c-ctrl-c is not defined")))))
 
 (defun ai-code--mark-prompt-block ()
   "Mark the current prompt block.

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -232,6 +232,7 @@ The result is a cons of whether SYMBOL is bound and its default value."
                (should (equal working-dir "/project/"))
                (should (equal command "codex --quiet"))
                (list :command "env MCP=1 codex --quiet"
+                     :env-vars '("AI_CODE_MCP_BEARER_TOKEN=secret")
                      :cleanup-fn cleanup-fn
                      :post-start-fn post-start-fn)))
        'prefix-arg))
@@ -245,7 +246,8 @@ The result is a cons of whether SYMBOL is bound and its default value."
                          nil
                          "codex"
                          'prefix-arg
-                         '("TERM_PROGRAM=vscode")
+                         '("AI_CODE_MCP_BEARER_TOKEN=secret"
+                           "TERM_PROGRAM=vscode")
                          "\r\n"
                          post-start-fn)))))
 
@@ -1292,6 +1294,41 @@ The prefix argument should also force instance-name prompting."
           (should (equal (car calls) '("line1\nline2" nil))))
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-send-line-refreshes-mcp-source-context ()
+  "Every resolved CLI send should snapshot its source before terminal I/O."
+  (let ((source-buffer (generate-new-buffer " *ai-code-mcp-source*"))
+        (agent-buffer (generate-new-buffer " *ai-code-mcp-agent*"))
+        refreshed
+        sent)
+    (unwind-protect
+        (cl-letf (((symbol-function
+                    'ai-code-backends-infra--resolve-session-buffer)
+                   (lambda (&rest _args) agent-buffer))
+                  ((symbol-function
+                    'ai-code-backends-infra--remember-session-buffer)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ai-code-mcp-agent-refresh-source-context)
+                   (lambda (agent source)
+                     (setq refreshed (list agent source))))
+                  ((symbol-function
+                    'ai-code-backends-infra--terminal-send-string)
+                   (lambda (line &optional _paste)
+                     (setq sent line)))
+                  ((symbol-function
+                    'ai-code-backends-infra--terminal-send-return)
+                   (lambda () nil))
+                  ((symbol-function 'sit-for)
+                   (lambda (&rest _args) nil)))
+          (with-current-buffer source-buffer
+            (ai-code-backends-infra--send-line-to-session
+             nil "missing" "inspect" "codex" "/tmp/"))
+          (should (equal (list agent-buffer source-buffer) refreshed))
+          (should (equal "inspect" sent)))
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer))
+      (when (buffer-live-p agent-buffer)
+        (kill-buffer agent-buffer)))))
 
 (ert-deftest test-ai-code-backends-infra-terminal-send-string-ghostel-uses-public-api ()
   "Ghostel sessions should send input through `ghostel-send-string'."

--- a/test/test_ai-code-codex-cli.el
+++ b/test/test_ai-code-codex-cli.el
@@ -25,7 +25,9 @@
   (let ((captured-command nil)
         (captured-cleanup-fn nil)
         (captured-post-start-fn nil)
+        (captured-env-vars nil)
         (registered nil)
+        (attached nil)
         (unregistered nil)
         (builtins-called nil)
         (ensure-called nil)
@@ -42,9 +44,15 @@
                    (lambda ()
                      (setq ensure-called t)
                      8765))
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () "test-codex-token"))
                   ((symbol-function 'ai-code-mcp-register-session)
-                   (lambda (session-id project-dir buffer)
-                     (setq registered (list session-id project-dir buffer))))
+                   (lambda (session-id project-dir buffer metadata)
+                     (setq registered
+                           (list session-id project-dir buffer metadata))))
+                  ((symbol-function 'ai-code-mcp-attach-agent-buffer)
+                   (lambda (session-id buffer)
+                     (setq attached (list session-id buffer))))
                   ((symbol-function 'ai-code-mcp-unregister-session)
                    (lambda (session-id)
                      (setq unregistered session-id)))
@@ -54,29 +62,36 @@
                          (_working-dir _buffer-name _process-table command
                                        &optional _escape-fn cleanup-fn
                                        _instance-name _prefix _force-prompt
-                                       _env-vars _multiline-input-sequence
+                                       env-vars _multiline-input-sequence
                                        post-start-fn)
                          args
                        (setq captured-command command)
                        (setq captured-cleanup-fn cleanup-fn)
-                       (setq captured-post-start-fn post-start-fn))
+                       (setq captured-post-start-fn post-start-fn)
+                       (setq captured-env-vars env-vars))
                      nil)))
           (ai-code-codex-cli)
           (should builtins-called)
           (should ensure-called)
           (should (string-match-p "mcp_servers\\.emacs_tools" captured-command))
+          (should (string-match-p "bearer_token_env_var" captured-command))
+          (should-not (string-match-p "test-codex-token" captured-command))
+          (should (equal captured-env-vars
+                         '("AI_CODE_MCP_BEARER_TOKEN=test-codex-token")))
           (should (functionp captured-cleanup-fn))
           (should (functionp captured-post-start-fn))
           (funcall captured-post-start-fn session-buffer nil "default")
           (should (equal "/tmp/test-codex" (nth 1 registered)))
-          (should (eq session-buffer (nth 2 registered)))
+          (should-not (eq session-buffer (nth 2 registered)))
+          (should (equal "test-codex-token"
+                         (plist-get (nth 3 registered) :token)))
+          (should (equal (list (car registered) session-buffer) attached))
           (with-current-buffer session-buffer
             (should (fboundp 'ai-code-mcp-agent-buffer-status))
             (let ((status (ai-code-mcp-agent-buffer-status)))
               (should (eq 'codex (plist-get status :backend)))
-              (should (string-match-p
-                       "^http://127\\.0\\.0\\.1:8765/mcp/"
-                       (plist-get status :server-url)))))
+              (should (equal "http://127.0.0.1:8765/mcp"
+                             (plist-get status :server-url)))))
           (funcall captured-cleanup-fn)
           (should (equal (car registered) unregistered)))
       (when (buffer-live-p session-buffer)

--- a/test/test_ai-code-github-copilot-cli.el
+++ b/test/test_ai-code-github-copilot-cli.el
@@ -95,6 +95,7 @@
         (captured-sequence :unset)
         (captured-env-vars :unset)
         (registered nil)
+        (attached nil)
         (unregistered nil)
         (builtins-called nil)
         (ensure-called nil)
@@ -111,9 +112,15 @@
                    (lambda ()
                      (setq ensure-called t)
                      8765))
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () "test-copilot-token"))
                   ((symbol-function 'ai-code-mcp-register-session)
-                   (lambda (session-id project-dir buffer)
-                     (setq registered (list session-id project-dir buffer))))
+                   (lambda (session-id project-dir buffer metadata)
+                     (setq registered
+                           (list session-id project-dir buffer metadata))))
+                  ((symbol-function 'ai-code-mcp-attach-agent-buffer)
+                   (lambda (session-id buffer)
+                     (setq attached (list session-id buffer))))
                   ((symbol-function 'ai-code-mcp-unregister-session)
                    (lambda (session-id)
                      (setq unregistered session-id)))
@@ -139,21 +146,29 @@
             (should ensure-called)
             (should (string-match-p "--additional-mcp-config" captured-command))
             (should (string-match-p "127\\.0\\.0\\.1" captured-command))
-            (should (string-match-p "mcp/github-copilot-cli-" captured-command))
-            (should (equal captured-env-vars '("TERM_PROGRAM=vscode")))
+            (should (string-match-p "AI_CODE_MCP_BEARER_TOKEN"
+                                    captured-command))
+            (should-not (string-match-p "test-copilot-token" captured-command))
+            (should-not (string-match-p "mcp/github-copilot-cli-"
+                                        captured-command))
+            (should (equal captured-env-vars
+                           '("AI_CODE_MCP_BEARER_TOKEN=test-copilot-token"
+                             "TERM_PROGRAM=vscode")))
             (should (equal captured-sequence "\\\r\n"))
             (should (functionp captured-cleanup-fn))
             (should (functionp captured-post-start-fn))
             (funcall captured-post-start-fn session-buffer nil "default")
             (should (equal "/tmp/test-copilot" (nth 1 registered)))
-            (should (eq session-buffer (nth 2 registered)))
+            (should-not (eq session-buffer (nth 2 registered)))
+            (should (equal "test-copilot-token"
+                           (plist-get (nth 3 registered) :token)))
+            (should (equal (list (car registered) session-buffer) attached))
             (with-current-buffer session-buffer
               (should (fboundp 'ai-code-mcp-agent-buffer-status))
               (let ((status (ai-code-mcp-agent-buffer-status)))
                 (should (eq 'github-copilot-cli (plist-get status :backend)))
-                (should (string-match-p
-                         "^http://127\\.0\\.0\\.1:8765/mcp/"
-                         (plist-get status :server-url)))))
+                (should (equal "http://127.0.0.1:8765/mcp"
+                               (plist-get status :server-url)))))
             (funcall captured-cleanup-fn)
             (should (equal (car registered) unregistered))))
       (when (buffer-live-p session-buffer)

--- a/test/test_ai-code-mcp-agent.el
+++ b/test/test_ai-code-mcp-agent.el
@@ -17,6 +17,154 @@
   (provide 'magit))
 (require 'ai-code-mcp-agent)
 
+(ert-deftest ai-code-test-mcp-agent-prepare-launch-registers-source-before-process-start ()
+  "Preparing a launch should register its source before the CLI starts."
+  (let ((ai-code-mcp-agent-enabled-backends '(codex))
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-server-tools nil)
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (project-dir (make-temp-file "ai-code-mcp-launch-" t))
+        (source-buffer (generate-new-buffer " *ai-code-mcp-launch-source*"))
+        launch)
+    (unwind-protect
+        (progn
+          (with-current-buffer source-buffer
+            (setq-local default-directory project-dir)
+            (setq launch
+                  (ai-code-mcp-agent-prepare-launch
+                   'codex project-dir "codex")))
+          (let* ((session-id (plist-get launch :mcp-session-id))
+                 (context (and session-id
+                               (ai-code-mcp-get-session-context session-id))))
+            (should (stringp session-id))
+            (should (eq 'pending (plist-get context :state)))
+            (should (eq source-buffer (plist-get context :source-buffer)))
+            (should-not (plist-get context :agent-buffer))
+            (should (equal (file-name-as-directory project-dir)
+                           (file-name-as-directory
+                            (plist-get context :project-dir))))
+            (should (equal (format "http://127.0.0.1:%d/mcp"
+                                   ai-code-mcp-http-server--port)
+                           (plist-get launch :mcp-server-url)))))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-post-start-attaches-agent-without-replacing-source ()
+  "Post-start should attach the agent while preserving prompt origin."
+  (let ((ai-code-mcp-agent-enabled-backends '(codex))
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-server-tools nil)
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (project-dir (make-temp-file "ai-code-mcp-attach-" t))
+        (source-buffer (generate-new-buffer " *ai-code-mcp-attach-source*"))
+        (agent-buffer (generate-new-buffer " *ai-code-mcp-attach-agent*"))
+        launch)
+    (unwind-protect
+        (progn
+          (with-current-buffer source-buffer
+            (setq launch
+                  (ai-code-mcp-agent-prepare-launch
+                   'codex project-dir "codex")))
+          (funcall (plist-get launch :post-start-fn)
+                   agent-buffer nil "default")
+          (let* ((session-id (plist-get launch :mcp-session-id))
+                 (context (ai-code-mcp-get-session-context session-id))
+                 (status (ai-code-mcp-agent-buffer-status agent-buffer)))
+            (should (eq source-buffer (plist-get context :source-buffer)))
+            (should (eq agent-buffer (plist-get context :agent-buffer)))
+            (should (eq 'ready (plist-get context :state)))
+            (should (equal session-id (plist-get status :session-id)))))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (ai-code-mcp-http-server-stop)
+      (dolist (buffer (list source-buffer agent-buffer))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer)))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-backend-configs-reference-secret-environment ()
+  "Backend launch configs should authenticate without exposing the token."
+  (let ((ai-code-mcp-agent-enabled-backends
+         '(codex open-interpreter github-copilot-cli claude-code))
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (secret (make-string 64 ?a))
+        (source-buffer (generate-new-buffer " *ai-code-mcp-secret-source*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () secret))
+                  ((symbol-function 'ai-code-mcp-agent--make-session-id)
+                   (lambda (backend) (format "%s-test-session" backend))))
+          (dolist (backend ai-code-mcp-agent-enabled-backends)
+            (let* ((launch
+                    (with-current-buffer source-buffer
+                      (ai-code-mcp-agent-prepare-launch
+                       backend default-directory (symbol-name backend))))
+                   (command (plist-get launch :command))
+                   (session-id (plist-get launch :mcp-session-id))
+                   (context (ai-code-mcp-get-session-context session-id))
+                   (env-vars (plist-get launch :env-vars)))
+              (unwind-protect
+                  (progn
+                    (should (equal secret (plist-get context :token)))
+                    (should (plist-get context :expires-at))
+                    (should (equal
+                             (list (concat "AI_CODE_MCP_BEARER_TOKEN=" secret))
+                             env-vars))
+                    (should-not (string-match-p (regexp-quote secret) command))
+                    (pcase backend
+                      ((or 'codex 'open-interpreter)
+                       (let* ((args (split-string-shell-command command))
+                              (flag (member "-c" args)))
+                         (should flag)
+                         (should (string-match-p
+                                  "bearer_token_env_var[ ]*=[ ]*\\\"AI_CODE_MCP_BEARER_TOKEN\\\""
+                                  (cadr flag)))))
+                      ('github-copilot-cli
+                       (let* ((args (split-string-shell-command command))
+                              (flag (member "--additional-mcp-config" args))
+                              (config (json-parse-string
+                                       (cadr flag) :object-type 'alist))
+                              (server (alist-get
+                                       'emacs_tools
+                                       (alist-get 'mcpServers config))))
+                         (should flag)
+                         (should (equal
+                                  "Bearer ${AI_CODE_MCP_BEARER_TOKEN}"
+                                  (alist-get 'Authorization
+                                             (alist-get 'headers server))))))
+                      ('claude-code
+                       (let* ((args (split-string-shell-command command))
+                              (flag (member "--mcp-config" args))
+                              (config-file (cadr flag))
+                              (config
+                               (with-temp-buffer
+                                 (insert-file-contents config-file)
+                                 (json-parse-buffer :object-type 'alist)))
+                              (server (alist-get
+                                       'emacs_tools
+                                       (alist-get 'mcpServers config))))
+                         (should flag)
+                         (should (equal
+                                  "Bearer ${AI_CODE_MCP_BEARER_TOKEN}"
+                                  (alist-get 'Authorization
+                                             (alist-get 'headers server)))))))
+                    (should (equal "http://127.0.0.1:8765/mcp"
+                                   (plist-get launch :mcp-server-url))))
+                (funcall (plist-get launch :cleanup-fn))))))
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
 (ert-deftest ai-code-test-mcp-agent-show-buffer-status-displays-help-buffer ()
   "The interactive MCP status command should display current buffer status."
   (should (commandp 'ai-code-mcp-agent-show-buffer-status))
@@ -26,7 +174,7 @@
         (with-current-buffer source-buffer
           (setq-local ai-code-mcp-agent--backend 'codex
                       ai-code-mcp-agent--session-id "codex-session-1"
-                      ai-code-mcp-agent--server-url "http://127.0.0.1:8765/mcp/codex-session-1")
+                      ai-code-mcp-agent--server-url "http://127.0.0.1:8765/mcp")
           (save-window-excursion
             (ai-code-mcp-agent-show-buffer-status))
           (with-current-buffer status-buffer-name

--- a/test/test_ai-code-mcp-debug-tools.el
+++ b/test/test_ai-code-mcp-debug-tools.el
@@ -88,6 +88,31 @@
       (dolist (tool-name ai-code-test-mcp-debug-tools--tool-names)
         (should (member tool-name tool-names))))))
 
+(ert-deftest ai-code-test-mcp-tool-profile-hides-and-blocks-debug-tools ()
+  "A core profile should neither advertise nor execute debug tools."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp--current-session-id "core-profile")
+        (buffer (generate-new-buffer " *ai-code-mcp-core-profile*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "core-profile" default-directory buffer '(:tool-profile core))
+          (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
+                 (tool-names (mapcar (lambda (tool)
+                                       (alist-get 'name tool))
+                                     (alist-get 'tools tools-result))))
+            (should (member "editor_state" tool-names))
+            (should-not (member "get_variable_value" tool-names)))
+          (should-error
+           (ai-code-mcp-dispatch
+            "tools/call"
+            '((name . "get_variable_value")
+              (arguments . ((variable_name . "major-mode")))))
+           :type 'ai-code-mcp-protocol-error))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
 (ert-deftest ai-code-test-mcp-debug-tools-do-not-register-eval-elisp-by-default ()
   "Eval should remain opt-in even when debug tools are enabled."
   (let ((ai-code-mcp-server-tools nil)
@@ -114,6 +139,7 @@
   "Eval should register when the explicit opt-in is enabled."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t))
     (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
            (tool-names (mapcar (lambda (tool)
@@ -149,6 +175,7 @@
   "Eval tool metadata should warn about unrestricted side effects."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t))
     (let* ((tools-result (ai-code-mcp-dispatch "tools/list"))
            (eval-tool (seq-find
@@ -164,6 +191,7 @@
   "Eval should run against the requested buffer context."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t)
         (buffer (generate-new-buffer " *ai-code-mcp-eval*")))
     (unwind-protect
@@ -189,6 +217,7 @@
   "Eval should use the selected window buffer when no buffer context is given."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t)
         (ai-code-mcp--sessions (make-hash-table :test 'equal))
         (session-id "mcp-eval-session")
@@ -221,6 +250,7 @@
   "Eval should allow mutation symbols when eval is enabled."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t)
         (buffer (generate-new-buffer " *ai-code-mcp-eval-insert*")))
     (unwind-protect
@@ -240,6 +270,7 @@
   "Eval should still return JSON when the target buffer is killed."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t)
         (buffer (generate-new-buffer " *ai-code-mcp-eval-kill*")))
     (let ((payload
@@ -472,17 +503,14 @@
   "Feature load state should reject non-string feature names clearly."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t))
-    (let ((payload
-           (ai-code-test-mcp-debug-tools--read-json-payload
-            (ai-code-mcp-dispatch
-             "tools/call"
-             '((name . "get_feature_load_state")
-               (arguments . ((feature_name . 7))))))))
-      (should (equal :json-false (alist-get 'loaded payload)))
-      (should (equal "feature_name must be a non-empty string"
-                     (alist-get 'error_message payload)))
-      (should-not (alist-get 'library_path payload))
-      (should-not (alist-get 'load_path_matches payload)))))
+    (let ((err (should-error
+                (ai-code-mcp-dispatch
+                 "tools/call"
+                 '((name . "get_feature_load_state")
+                   (arguments . ((feature_name . 7)))))
+                :type 'ai-code-mcp-protocol-error)))
+      (should (= -32602 (nth 1 err)))
+      (should (string-match-p "must be string" (nth 2 err))))))
 
 (ert-deftest ai-code-test-mcp-get-recent-messages-returns-latest-messages ()
   "Recent messages should return the latest entries from `*Messages*'."
@@ -545,6 +573,7 @@
   "Eval should allow all symbols when enabled, including funcall."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t))
     (let ((payload
            (ai-code-test-mcp-debug-tools--read-json-payload
@@ -559,6 +588,7 @@
   "Eval should define a function and make it callable."
   (let ((ai-code-mcp-server-tools nil)
         (ai-code-mcp-debug-tools-enabled t)
+        (ai-code-mcp-default-tool-profile 'full)
         (ai-code-mcp-debug-tools-enable-eval-elisp t)
         (func-name "ai-code-test-mcp-eval-defined-func"))
     (unwind-protect

--- a/test/test_ai-code-mcp-http-server.el
+++ b/test/test_ai-code-mcp-http-server.el
@@ -19,80 +19,839 @@
 (require 'ai-code-mcp-server)
 (require 'ai-code-mcp-http-server nil t)
 
-(ert-deftest ai-code-test-mcp-http-server-tools-call-uses-session-context ()
-  "HTTP MCP transport should dispatch `tools/call' with the session path."
-  (should (fboundp 'ai-code-mcp-dispatch))
-  (should (fboundp 'ai-code-mcp-http-server--json-rpc-response))
-  (let* ((project-dir (make-temp-file "ai-code-mcp-http-" t))
-         (buffer (generate-new-buffer " *ai-code-mcp-http-project*"))
-         (ai-code-mcp--sessions (make-hash-table :test 'equal))
-         (ai-code-mcp-server-tools nil)
-         (session-id "session-http"))
+(cl-defstruct ai-code-test-mcp-http-response
+  status headers body)
+
+(defun ai-code-test-mcp-http--parse-response (payload)
+  "Parse raw HTTP response PAYLOAD independently of the server code."
+  (unless (string-match "\\`HTTP/1\\.[01] \\([0-9]+\\)[^\r\n]*\r\n" payload)
+    (ert-fail (format "Malformed HTTP response: %S" payload)))
+  (let* ((status (string-to-number (match-string 1 payload)))
+         (status-line-end (match-end 0))
+         (header-end (string-match "\r\n\r\n" payload))
+         (header-lines
+          (split-string (substring payload status-line-end header-end)
+                        "\r\n" t))
+         (headers
+          (mapcar
+           (lambda (line)
+             (unless (string-match "\\`\\([^:]+\\):[ 	]*\\(.*\\)\\'" line)
+               (ert-fail (format "Malformed HTTP header: %S" line)))
+             (cons (downcase (match-string 1 line)) (match-string 2 line)))
+           header-lines))
+         (body-start (+ header-end 4))
+         (content-length
+          (string-to-number (or (cdr (assoc "content-length" headers)) "0")))
+         (body (substring payload body-start (+ body-start content-length))))
+    (make-ai-code-test-mcp-http-response
+     :status status :headers headers :body body)))
+
+(defun ai-code-test-mcp-http--exchange (port method path headers body)
+  "Send one HTTP request to PORT using METHOD, PATH, HEADERS, and BODY."
+  (let* ((buffer (generate-new-buffer " *ai-code-mcp-http-response*"))
+         (process
+          (make-network-process
+           :name (generate-new-buffer-name "ai-code-mcp-http-client")
+           :buffer buffer
+           :host "127.0.0.1"
+           :service port
+           :coding 'binary
+           :noquery t
+           :nowait nil))
+         (deadline (+ (float-time) 2.0)))
     (unwind-protect
         (progn
-          (with-temp-file (expand-file-name "main.el" project-dir)
-            (insert "(message \"hello\")\n"))
-          (ai-code-mcp-builtins-setup)
-          (ai-code-mcp-register-session session-id project-dir buffer)
-          (let* ((result (ai-code-mcp-http-server--json-rpc-response
-                          (format "/mcp/%s" session-id)
-                          (json-encode
-                           '((jsonrpc . "2.0")
-                             (id . 1)
-                             (method . "tools/call")
-                             (params . ((name . "project_info")
-                                        (arguments . ((dummy . :json-false)))))))))
-                 (content (alist-get 'content (alist-get 'result result)))
-                 (text (alist-get 'text (car content))))
-            (should (string-match-p "Project:" text))
-            (should (string-match-p (regexp-quote project-dir) text))
-            (should (string-match-p "Files: 1" text))))
+          (set-process-sentinel process #'ignore)
+          (process-send-string
+           process
+           (concat
+            (format "%s %s HTTP/1.1\r\n" method path)
+            (format "Host: 127.0.0.1:%d\r\n" port)
+            (mapconcat (lambda (header)
+                         (format "%s: %s" (car header) (cdr header)))
+                       headers
+                       "\r\n")
+            (when headers "\r\n")
+            (unless (seq-some
+                     (lambda (header)
+                       (string= "content-length" (downcase (car header))))
+                     headers)
+              (format "Content-Length: %d\r\n" (string-bytes body)))
+            "Connection: close\r\n\r\n"
+            body))
+          (while (and (process-live-p process)
+                      (< (float-time) deadline))
+            (accept-process-output process 0.02))
+          (when (process-live-p process)
+            (ert-fail "Timed out waiting for MCP HTTP response"))
+          (with-current-buffer buffer
+            (ai-code-test-mcp-http--parse-response (buffer-string))))
+      (when (process-live-p process)
+        (delete-process process))
       (when (buffer-live-p buffer)
-        (kill-buffer buffer))
-      (ignore-errors
-        (delete-directory project-dir t)))))
+        (kill-buffer buffer)))))
 
-(ert-deftest ai-code-test-mcp-http-server-notification-returns-accepted ()
-  "Notification requests should return HTTP 202 with an empty body."
-  (let ((captured-response nil))
-    (cl-letf (((symbol-function 'ai-code-mcp-http-server--send-response)
-               (lambda (_process code content-type body)
-                 (setq captured-response
-                       (list :code code
-                             :content-type content-type
-                             :body body)))))
-      (ai-code-mcp-http-server--handle-post
-       nil
-       (list :path "/mcp/session-http"
-             :body (json-encode
-                    '((jsonrpc . "2.0")
-                      (method . "notifications/initialized")
-                      (params . ((dummy . :json-false)))))))
-      (should (equal 202 (plist-get captured-response :code)))
-      (should (equal "" (plist-get captured-response :body))))))
+(defun ai-code-test-mcp-http--legacy-initialize (port token)
+  "Initialize a legacy MCP session on PORT authenticated by TOKEN."
+  (ai-code-test-mcp-http--exchange
+   port "POST" "/mcp"
+   `(("Authorization" . ,(concat "Bearer " token))
+     ("Content-Type" . "application/json")
+     ("Accept" . "application/json, text/event-stream"))
+   (json-encode
+    '((jsonrpc . "2.0")
+      (id . 1)
+      (method . "initialize")
+                                (params . ((protocolVersion . "1900-01-01")
+                 (capabilities . ())
+                 (clientInfo . ((name . "ert") (version . "1")))))))))
 
-(ert-deftest ai-code-test-mcp-http-server-errors-keep-request-id ()
-  "JSON-RPC errors should preserve the originating request id."
-  (let ((captured-payload nil)
-        (captured-code nil))
-    (cl-letf (((symbol-function 'ai-code-mcp-http-server--send-json)
-               (lambda (_process code payload)
-                 (setq captured-code code)
-                 (setq captured-payload payload))))
-      (ai-code-mcp-http-server--handle-request
-       nil
-       (list :method "POST"
-             :path "/mcp/session-http"
-             :body (json-encode
+(defun ai-code-test-mcp-http--legacy-ready (port token)
+  "Initialize and ready a legacy MCP session on PORT using TOKEN."
+  (let* ((initialize-response
+          (ai-code-test-mcp-http--legacy-initialize port token))
+         (transport-session-id
+          (cdr (assoc "mcp-session-id"
+                      (ai-code-test-mcp-http-response-headers
+                       initialize-response))))
+         (headers
+          `(("Authorization" . ,(concat "Bearer " token))
+            ("Content-Type" . "application/json")
+            ("Accept" . "application/json, text/event-stream")
+            ("MCP-Session-Id" . ,transport-session-id)
+            ("MCP-Protocol-Version" . "2025-11-25"))))
+    (ai-code-test-mcp-http--exchange
+     port "POST" "/mcp" headers
+     (json-encode
+      '((jsonrpc . "2.0") (method . "notifications/initialized"))))
+    transport-session-id))
+
+(defun ai-code-test-mcp-http--modern-headers (token method &optional name)
+  "Return modern MCP HTTP headers for TOKEN, METHOD, and optional NAME."
+  (append
+   `(("Authorization" . ,(concat "Bearer " token))
+     ("Content-Type" . "application/json")
+     ("Accept" . "application/json, text/event-stream")
+     ("MCP-Protocol-Version" . "2026-07-28")
+     ("Mcp-Method" . ,method))
+   (when name `(("Mcp-Name" . ,name)))))
+
+(defun ai-code-test-mcp-http--modern-meta ()
+  "Return required per-request metadata for modern MCP tests."
+  `((_meta
+     . ((io.modelcontextprotocol/protocolVersion . "2026-07-28")
+        (io.modelcontextprotocol/clientInfo
+         . ((name . "ert") (version . "1")))
+        (io.modelcontextprotocol/clientCapabilities
+         . ,(make-hash-table :test 'equal))))))
+
+(cl-defmacro ai-code-test-mcp-http--with-server
+    ((port token state &optional session-id) &rest body)
+  "Run BODY with a real MCP server bound to PORT for TOKEN and STATE."
+  (declare (indent 1))
+  `(let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp-http-server-port nil)
+         (ai-code-mcp-http-server--server nil)
+         (ai-code-mcp-http-server--port nil)
+         (project-dir (make-temp-file "ai-code-mcp-http-fixture-" t))
+         (source-buffer (generate-new-buffer " *ai-code-mcp-http-fixture*")))
+     (unwind-protect
+         (progn
+           (ai-code-mcp-register-session
+            ,(or session-id "modern-session") project-dir source-buffer
+            (list :token ,token :state ,state))
+           (let ((,port (ai-code-mcp-http-server-ensure)))
+             ,@body))
+       (ai-code-mcp-http-server-stop)
+       (when (buffer-live-p source-buffer)
+         (kill-buffer source-buffer))
+       (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-http-server-discovers-modern-protocol-over-socket ()
+  "Modern clients should discover capabilities without a session handshake."
+  (ai-code-test-mcp-http--with-server
+      (port "modern-discover-token" 'pending)
+    (let* ((response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp"
+             (ai-code-test-mcp-http--modern-headers
+              "modern-discover-token" "server/discover")
+             (json-encode
+              `((jsonrpc . "2.0")
+                (id . "discover-1")
+                (method . "server/discover")
+                (params . ,(ai-code-test-mcp-http--modern-meta))))))
+           (payload
+            (json-parse-string
+             (ai-code-test-mcp-http-response-body response)
+             :object-type 'alist :array-type 'list
+             :false-object :json-false))
+           (result (alist-get 'result payload)))
+      (ert-info ((ai-code-test-mcp-http-response-body response))
+        (should (= 200 (ai-code-test-mcp-http-response-status response))))
+      (should (equal "complete" (alist-get 'resultType result)))
+      (should (member "2026-07-28" (alist-get 'supportedVersions result)))
+      (should (alist-get 'tools (alist-get 'capabilities result)))
+      (should-not (assoc "mcp-session-id"
+                         (ai-code-test-mcp-http-response-headers response))))))
+
+(ert-deftest ai-code-test-mcp-http-server-validates-modern-mirrored-headers ()
+  "Modern mirrored headers must agree with the JSON-RPC body."
+  (ai-code-test-mcp-http--with-server
+      (port "modern-mismatch-token" 'ready)
+    (let* ((response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp"
+             (ai-code-test-mcp-http--modern-headers
+              "modern-mismatch-token" "tools/list")
+             (json-encode
+              `((jsonrpc . "2.0")
+                (id . 7)
+                (method . "tools/call")
+                (params . ((name . "project_info")
+                           (arguments . ())
+                           ,@(ai-code-test-mcp-http--modern-meta)))))))
+           (payload
+            (json-parse-string
+             (ai-code-test-mcp-http-response-body response)
+             :object-type 'alist))
+           (error-object (alist-get 'error payload)))
+      (should (= 400 (ai-code-test-mcp-http-response-status response)))
+      (should (= -32020 (alist-get 'code error-object))))))
+
+(ert-deftest ai-code-test-mcp-http-server-requires-modern-request-metadata ()
+  "Every modern request should carry protocol and capability metadata."
+  (ai-code-test-mcp-http--with-server
+      (port "modern-meta-token" 'ready)
+    (let* ((response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp"
+             (ai-code-test-mcp-http--modern-headers
+              "modern-meta-token" "tools/list")
+             (json-encode
+              `((jsonrpc . "2.0")
+                (id . 3)
+                (method . "tools/list")
+                (params . ,(make-hash-table :test 'equal))))))
+           (payload
+            (json-parse-string
+             (ai-code-test-mcp-http-response-body response)
+             :object-type 'alist))
+           (error-object (alist-get 'error payload)))
+      (should (= 400 (ai-code-test-mcp-http-response-status response)))
+      (should (= -32602 (alist-get 'code error-object))))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-unsupported-modern-version ()
+  "Modern requests should receive the unsupported-version protocol error."
+  (ai-code-test-mcp-http--with-server
+      (port "modern-version-token" 'ready)
+    (let* ((headers
+            '(("Authorization" . "Bearer modern-version-token")
+              ("Content-Type" . "application/json")
+              ("Accept" . "application/json, text/event-stream")
+              ("MCP-Protocol-Version" . "1900-01-01")
+              ("Mcp-Method" . "tools/list")))
+           (response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp" headers
+             (json-encode
+              `((jsonrpc . "2.0")
+                (id . 4)
+                (method . "tools/list")
+                (params
+                 . ((_meta
+                     . ((io.modelcontextprotocol/protocolVersion
+                         . "1900-01-01")
+                        (io.modelcontextprotocol/clientCapabilities
+                         . ,(make-hash-table :test 'equal))))))))))
+           (payload
+            (json-parse-string
+             (ai-code-test-mcp-http-response-body response)
+             :object-type 'alist))
+           (error-object (alist-get 'error payload)))
+      (should (= 400 (ai-code-test-mcp-http-response-status response)))
+      (should (= -32022 (alist-get 'code error-object))))))
+
+(ert-deftest ai-code-test-mcp-http-server-modern-tool-call-is-structured ()
+  "A modern tool call should be stateless and return a complete result."
+  (ai-code-test-mcp-http--with-server
+      (port "modern-tool-token" 'ready)
+    (with-temp-file (expand-file-name "main.el" project-dir)
+      (insert "(message \"hello\")\n"))
+    (let* ((response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp"
+             (ai-code-test-mcp-http--modern-headers
+              "modern-tool-token" "tools/call" "project_info")
+             (json-encode
+              `((jsonrpc . "2.0")
+                (id . 8)
+                (method . "tools/call")
+                (params . ((name . "project_info")
+                           ,@(ai-code-test-mcp-http--modern-meta)))))))
+           (payload
+            (json-parse-string
+             (ai-code-test-mcp-http-response-body response)
+             :object-type 'alist :false-object :json-false))
+           (result (alist-get 'result payload)))
+      (ert-info ((ai-code-test-mcp-http-response-body response))
+        (should (= 200 (ai-code-test-mcp-http-response-status response))))
+      (should (equal "complete" (alist-get 'resultType result)))
+      (should (alist-get 'structuredContent result))
+      (should (string-match-p
+               (regexp-quote project-dir)
+               (alist-get 'text (aref (alist-get 'content result) 0))))
+      (ert-info ((ai-code-test-mcp-http-response-body response))
+        (should (eq :json-false (alist-get 'isError result)))))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-missing-bearer ()
+  "The real HTTP endpoint should reject requests without a bearer token."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-auth*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "auth-session" "/tmp/" source-buffer
+           '(:token "auth-test-token" :state pending))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode
                     '((jsonrpc . "2.0")
-                      (id . 17)
-                      (method . "unknown/method")
-                      (params . ((dummy . :json-false)))))))
-      (should (equal 500 captured-code))
-      (should (equal 17 (alist-get 'id captured-payload)))
-      (should (equal -32603
-                     (alist-get 'code
-                                (alist-get 'error captured-payload)))))))
+                      (id . 1)
+                      (method . "initialize")
+                      (params . ((protocolVersion . "2025-11-25")
+                                 (capabilities . ())
+                                 (clientInfo . ((name . "ert")
+                                                (version . "1")))))))))
+            (should (= 401 (ai-code-test-mcp-http-response-status response)))
+            (should (string-empty-p
+                     (ai-code-test-mcp-http-response-body response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer))))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-expired-bearer ()
+  "An expired per-launch bearer token should no longer authenticate."
+  (ai-code-test-mcp-http--with-server
+      (port "expired-token" 'ready "expired-session")
+    (let ((context (ai-code-mcp-get-session-context "expired-session")))
+      (puthash "expired-session"
+               (plist-put context :expires-at
+                          (time-subtract (current-time) (seconds-to-time 1)))
+               ai-code-mcp--sessions))
+    (let ((response
+           (ai-code-test-mcp-http--exchange
+            port "POST" "/mcp"
+            (ai-code-test-mcp-http--modern-headers
+             "expired-token" "server/discover")
+            (json-encode
+             `((jsonrpc . "2.0")
+               (id . 1)
+               (method . "server/discover")
+               (params . ,(ai-code-test-mcp-http--modern-meta)))))))
+      (should (= 401 (ai-code-test-mcp-http-response-status response))))))
+
+(ert-deftest ai-code-test-mcp-http-server-initializes-legacy-session-over-socket ()
+  "A valid bearer should initialize a 2025 MCP HTTP session."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-initialize*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "initialize-session" "/tmp/" source-buffer
+           '(:token "initialize-test-token" :state pending))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (body
+                  (json-encode
+                   '((jsonrpc . "2.0")
+                     (id . 1)
+                     (method . "initialize")
+                     (params . ((protocolVersion . "1900-01-01")
+                                (capabilities . ())
+                                (clientInfo . ((name . "ert")
+                                               (version . "1"))))))))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer initialize-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   body))
+                 (headers (ai-code-test-mcp-http-response-headers response))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (result (alist-get 'result payload))
+                 (transport-session-id (cdr (assoc "mcp-session-id" headers))))
+            (should (= 200 (ai-code-test-mcp-http-response-status response)))
+            (should (equal "2025-11-25"
+                           (alist-get 'protocolVersion result)))
+            (should (and (stringp transport-session-id)
+                         (not (string-empty-p transport-session-id))))
+            (should-not (equal "initialize-session" transport-session-id))
+            (should (string-match-p "\\`[[:xdigit:]]\\{64\\}\\'"
+                                    transport-session-id))
+            (let ((context (ai-code-mcp-get-session-context
+                            "initialize-session")))
+              (should (equal transport-session-id
+                             (plist-get context :transport-session-id)))
+              (should (equal "2025-11-25"
+                             (plist-get context :protocol-version)))
+              (should (eq 'initializing (plist-get context :state))))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-initialized-notification-makes-session-ready ()
+  "The initialized notification should complete the legacy lifecycle."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-ready*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "ready-session" "/tmp/" source-buffer
+           '(:token "ready-test-token" :state pending))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (common-headers
+                  '(("Authorization" . "Bearer ready-test-token")
+                    ("Content-Type" . "application/json")
+                    ("Accept" . "application/json, text/event-stream")))
+                 (initialize-response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp" common-headers
+                   (json-encode
+                    '((jsonrpc . "2.0")
+                      (id . 1)
+                      (method . "initialize")
+                      (params . ((protocolVersion . "2025-11-25")
+                                 (capabilities . ())
+                                 (clientInfo . ((name . "ert")
+                                                (version . "1")))))))))
+                 (transport-session-id
+                  (cdr (assoc
+                        "mcp-session-id"
+                        (ai-code-test-mcp-http-response-headers
+                         initialize-response))))
+                 (notification-headers
+                  (append common-headers
+                          `(("MCP-Session-Id" . ,transport-session-id)
+                            ("MCP-Protocol-Version" . "2025-11-25"))))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp" notification-headers
+                   (json-encode
+                    '((jsonrpc . "2.0")
+                      (method . "notifications/initialized"))))))
+            (should (= 202 (ai-code-test-mcp-http-response-status response)))
+            (should (string-empty-p
+                     (ai-code-test-mcp-http-response-body response)))
+            (should (eq 'ready
+                        (plist-get
+                         (ai-code-mcp-get-session-context "ready-session")
+                         :state)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-tools-before-ready ()
+  "Legacy tool requests should fail before initialization completes."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-pending*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "pending-session" "/tmp/" source-buffer
+           '(:token "pending-test-token" :state pending))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer pending-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode
+                    '((jsonrpc . "2.0")
+                      (id . 9)
+                      (method . "tools/list")))))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (error-object (alist-get 'error payload)))
+            (should (= 400 (ai-code-test-mcp-http-response-status response)))
+            (should (= 9 (alist-get 'id payload)))
+            (should (= -32600 (alist-get 'code error-object)))
+            (should (eq 'pending
+                        (plist-get
+                         (ai-code-mcp-get-session-context "pending-session")
+                         :state)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-missing-legacy-session-header ()
+  "Ready legacy requests should require their transport session header."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-session-header*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "header-session" "/tmp/" source-buffer
+           '(:token "header-test-token" :state pending))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (_transport-session-id
+                  (ai-code-test-mcp-http--legacy-ready
+                   port "header-test-token"))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer header-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream")
+                     ("MCP-Protocol-Version" . "2025-11-25"))
+                   (json-encode
+                    '((jsonrpc . "2.0")
+                      (id . 2)
+                      (method . "tools/list"))))))
+            (should (= 400 (ai-code-test-mcp-http-response-status response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-untrusted-origin ()
+  "The localhost endpoint should reject browser origins before dispatch."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-origin*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "origin-session" "/tmp/" source-buffer
+           '(:token "origin-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer origin-test-token")
+                     ("Origin" . "https://attacker.example")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode
+                    '((jsonrpc . "2.0") (id . 3) (method . "ping"))))))
+            (should (= 403 (ai-code-test-mcp-http-response-status response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-unsupported-content-type ()
+  "The endpoint should reject non-JSON request bodies before parsing."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-media*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "media-session" "/tmp/" source-buffer
+           '(:token "media-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer media-test-token")
+                     ("Content-Type" . "text/plain")
+                     ("Accept" . "application/json, text/event-stream"))
+                   "not-json")))
+            (should (= 415 (ai-code-test-mcp-http-response-status response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-incompatible-accept-header ()
+  "The endpoint should require JSON and event-stream response support."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-accept*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "accept-session" "/tmp/" source-buffer
+           '(:token "accept-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer accept-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/xml"))
+                   (json-encode
+                    '((jsonrpc . "2.0") (id . 4) (method . "ping"))))))
+            (should (= 406 (ai-code-test-mcp-http-response-status response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-oversized-body ()
+  "The endpoint should reject requests above its configured byte limit."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (ai-code-mcp-http-server-max-request-bytes 16)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-size*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "size-session" "/tmp/" source-buffer
+           '(:token "size-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer size-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   "12345678901234567")))
+            (should (= 413 (ai-code-test-mcp-http-response-status response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-invalid-content-length ()
+  "Malformed Content-Length input should receive a bounded bad request."
+  (ai-code-test-mcp-http--with-server
+      (port "length-test-token" 'ready "length-session")
+    (let ((response
+           (ai-code-test-mcp-http--exchange
+            port "POST" "/mcp"
+            '(("Authorization" . "Bearer length-test-token")
+              ("Content-Type" . "application/json")
+              ("Accept" . "application/json, text/event-stream")
+              ("Content-Length" . "-1"))
+            "{}")))
+      (should (= 400 (ai-code-test-mcp-http-response-status response))))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-oversized-headers ()
+  "The unauthenticated request header buffer should have a fixed upper bound."
+  (ai-code-test-mcp-http--with-server
+      (port "header-size-token" 'ready "header-size-session")
+    (let* ((ai-code-mcp-http-server-max-header-bytes 128)
+           (response
+            (ai-code-test-mcp-http--exchange
+             port "POST" "/mcp"
+             `(("Authorization" . "Bearer header-size-token")
+               ("Content-Type" . "application/json")
+               ("Accept" . "application/json, text/event-stream")
+               ("X-Fill" . ,(make-string 256 ?x)))
+             "{}")))
+      (should (= 431 (ai-code-test-mcp-http-response-status response))))))
+
+(ert-deftest ai-code-test-mcp-http-server-rate-limits-authenticated-session ()
+  "The endpoint should cap request bursts per authenticated session."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (ai-code-mcp-http-server-rate-limit 2)
+        (ai-code-mcp-http-server-rate-window-seconds 60)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-rate*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "rate-session" "/tmp/" source-buffer
+           '(:token "rate-test-token" :state ready))
+          (let ((port (ai-code-mcp-http-server-ensure))
+                responses)
+            (dotimes (index 3)
+              (push
+               (ai-code-test-mcp-http--exchange
+                port "POST" "/mcp"
+                '(("Authorization" . "Bearer rate-test-token")
+                  ("Content-Type" . "application/json")
+                  ("Accept" . "application/json, text/event-stream"))
+                (json-encode
+                 `((jsonrpc . "2.0")
+                   (id . ,(1+ index))
+                   (method . "ping"))))
+               responses))
+            (setq responses (nreverse responses))
+            (should (equal '(200 200 429)
+                           (mapcar #'ai-code-test-mcp-http-response-status
+                                   responses)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-returns-json-rpc-parse-error ()
+  "Malformed JSON should produce a standard parse error without HTTP 500."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-json*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "json-session" "/tmp/" source-buffer
+           '(:token "json-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer json-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   "{not-json"))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (error-object (alist-get 'error payload)))
+            (should (= 200 (ai-code-test-mcp-http-response-status response)))
+            (should (= -32700 (alist-get 'code error-object)))
+            (should (equal "Parse error" (alist-get 'message error-object)))
+            (should (eq :null (alist-get 'id payload)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-unknown-method-keeps-zero-id ()
+  "Unknown methods should return method-not-found and preserve id zero."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-method*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "method-session" "/tmp/" source-buffer
+           '(:token "method-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer method-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode
+                    '((jsonrpc . "2.0")
+                      (id . 0)
+                      (method . "unknown/method")))))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (error-object (alist-get 'error payload)))
+            (should (= 200 (ai-code-test-mcp-http-response-status response)))
+            (should (= 0 (alist-get 'id payload)))
+            (should (= -32601 (alist-get 'code error-object)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-rejects-invalid-json-rpc-envelope ()
+  "A malformed JSON-RPC envelope should return invalid-request."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-envelope*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "envelope-session" "/tmp/" source-buffer
+           '(:token "envelope-test-token" :state ready))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer envelope-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode '((id . 5) (method . "ping")))))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (error-object (alist-get 'error payload)))
+            (should (= 200 (ai-code-test-mcp-http-response-status response)))
+            (should (= 5 (alist-get 'id payload)))
+            (should (= -32600 (alist-get 'code error-object)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-http-server-maps-invalid-tool-params ()
+  "Malformed tool calls should return JSON-RPC invalid-params."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-server-tools nil)
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-params*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "params-session" "/tmp/" source-buffer
+           '(:token "params-test-token" :state ready))
+          (ai-code-mcp-make-tool
+           :function #'identity
+           :name "echo_name"
+           :description "Echo one name."
+           :args '((:name "name" :type string :description "Name.")))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   '(("Authorization" . "Bearer params-test-token")
+                     ("Content-Type" . "application/json")
+                     ("Accept" . "application/json, text/event-stream"))
+                   (json-encode
+                    `((jsonrpc . "2.0")
+                      (id . 6)
+                      (method . "tools/call")
+                      (params . ((name . "echo_name")
+                                 (arguments . ,(make-hash-table
+                                                :test 'equal))))))))
+                 (payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body response)
+                   :object-type 'alist))
+                 (error-object (alist-get 'error payload)))
+            (should (= 200 (ai-code-test-mcp-http-response-status response)))
+            (should (= -32602 (alist-get 'code error-object)))
+            (should (string-match-p "name"
+                                    (alist-get 'message error-object)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer)))))
 
 (provide 'test_ai-code-mcp-http-server)
 

--- a/test/test_ai-code-mcp-server.el
+++ b/test/test_ai-code-mcp-server.el
@@ -74,7 +74,7 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
   "Initialize should expose MCP protocol metadata."
   (should (fboundp 'ai-code-mcp-dispatch))
   (let ((result (ai-code-mcp-dispatch "initialize")))
-    (should (equal "2024-11-05"
+    (should (equal "2025-11-25"
                    (alist-get 'protocolVersion result)))
     (should (alist-get 'tools (alist-get 'capabilities result)))
     (should (equal "ai-code-mcp-tools"
@@ -95,7 +95,11 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
               :type string
               :description "Trailing punctuation."
               :optional t)))
-    (let* ((tool-entry (car (alist-get 'tools (ai-code-mcp-dispatch "tools/list"))))
+    (let* ((tool-entry
+            (seq-find
+             (lambda (tool)
+               (equal "greet_user" (alist-get 'name tool)))
+             (alist-get 'tools (ai-code-mcp-dispatch "tools/list"))))
            (input-schema (alist-get 'inputSchema tool-entry))
            (properties (alist-get 'properties input-schema))
            (required (append (alist-get 'required input-schema) nil)))
@@ -127,6 +131,55 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       '((name . "echo_name")
         (arguments . ())))
      :type 'error)))
+
+(ert-deftest ai-code-test-mcp-tools-call-rejects-extra-and-mistyped-arguments ()
+  "Tool arguments should match the advertised closed JSON schema."
+  (let ((ai-code-mcp-server-tools nil))
+    (ai-code-mcp-make-tool
+     :function (lambda (count enabled) (list count enabled))
+     :name "typed_tool"
+     :description "Exercise argument validation."
+     :args '((:name "count" :type integer :description "A count.")
+             (:name "enabled" :type boolean :description "A flag.")))
+    (dolist (arguments '(((count . "one") (enabled . t))
+                         ((count . 1) (enabled . t) (surprise . 2))))
+      (let ((err (should-error
+                  (ai-code-mcp-dispatch
+                   "tools/call"
+                   `((name . "typed_tool") (arguments . ,arguments)))
+                  :type 'ai-code-mcp-protocol-error)))
+        (should (= -32602 (nth 1 err)))))))
+
+(ert-deftest ai-code-test-mcp-tools-call-returns-structured-success-and-error ()
+  "Tool results should expose structured content and semantic error state."
+  (let ((ai-code-mcp-server-tools nil))
+    (ai-code-mcp-make-tool
+     :function (lambda () (json-encode '((ok . t) (answer . 42))))
+     :name "structured_success"
+     :description "Return structured JSON."
+     :args nil)
+    (ai-code-mcp-make-tool
+     :function (lambda () (error "Tool exploded"))
+     :name "structured_failure"
+     :description "Fail semantically."
+     :args nil)
+    (let ((success (ai-code-mcp-dispatch
+                    "tools/call"
+                    '((name . "structured_success") (arguments . ())))))
+      (should (eq :json-false (alist-get 'isError success)))
+      (should (= 42 (alist-get 'answer
+                               (alist-get 'structuredContent success)))))
+    (let ((failure (ai-code-mcp-dispatch
+                    "tools/call"
+                    '((name . "structured_failure") (arguments . ())))))
+      (should (eq t (alist-get 'isError failure)))
+      (should (string-match-p "Tool exploded"
+                              (ai-code-test-mcp--content-text failure)))
+      (should (equal "tool_execution_error"
+                     (alist-get 'type
+                                (alist-get 'error
+                                           (alist-get 'structuredContent
+                                                      failure))))))))
 
 (ert-deftest ai-code-test-mcp-session-context-roundtrip ()
   "Session registration should provide project-local execution context."
@@ -188,21 +241,26 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       (should (equal ai-code-test-mcp--builtin-tool-names
                      tool-names)))))
 
-(ert-deftest ai-code-test-mcp-editor-state-reports-selected-buffer ()
-  "Editor state should describe the selected window buffer."
+(ert-deftest ai-code-test-mcp-editor-state-uses-prompt-origin-after-terminal-focus ()
+  "Editor state should describe the session source after terminal focus."
   (let ((ai-code-mcp-server-tools nil)
-        (buffer (generate-new-buffer " *ai-code-mcp-editor-state*")))
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (session-id "editor-state-source")
+        (source-buffer (generate-new-buffer " *ai-code-mcp-editor-source*"))
+        (terminal-buffer (generate-new-buffer " *ai-code-mcp-editor-terminal*")))
     (unwind-protect
         (save-window-excursion
-          (switch-to-buffer buffer)
-          (with-current-buffer buffer
+          (with-current-buffer source-buffer
             (emacs-lisp-mode)
             (setq-local default-directory "/tmp/")
             (insert "alpha\nbeta\n")
             (goto-char (point-min))
             (forward-line 1)
             (move-to-column 2))
-          (let* ((result (ai-code-mcp-dispatch "tools/call"
+          (ai-code-mcp-register-session session-id "/tmp/" source-buffer)
+          (switch-to-buffer terminal-buffer)
+          (let* ((ai-code-mcp--current-session-id session-id)
+                 (result (ai-code-mcp-dispatch "tools/call"
                                                '((name . "editor_state")
                                                  (arguments . ()))))
                  (payload (let ((json-object-type 'alist)
@@ -211,15 +269,71 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
                             (json-read-from-string
                              (ai-code-test-mcp--content-text result)))))
             (should (equal t (alist-get 'ok payload)))
-            (should (equal (buffer-name buffer)
+            (should (equal (buffer-name source-buffer)
                            (alist-get 'buffer_name payload)))
             (should (equal "emacs-lisp-mode"
                            (alist-get 'major_mode payload)))
             (should (equal t (alist-get 'modified payload)))
             (should (= 2 (alist-get 'line payload)))
             (should (= 2 (alist-get 'column payload)))))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer))
+      (when (buffer-live-p terminal-buffer)
+        (kill-buffer terminal-buffer)))))
+
+(ert-deftest ai-code-test-mcp-editor-state-reports-killed-source-unavailable ()
+  "Editor state should not fall back after its prompt origin is killed."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (session-id "editor-state-killed-source")
+        (source-buffer (generate-new-buffer " *ai-code-mcp-killed-source*"))
+        (terminal-buffer (generate-new-buffer " *ai-code-mcp-killed-terminal*")))
+    (unwind-protect
+        (save-window-excursion
+          (ai-code-mcp-register-session session-id "/tmp/" source-buffer)
+          (kill-buffer source-buffer)
+          (switch-to-buffer terminal-buffer)
+          (let* ((ai-code-mcp--current-session-id session-id)
+                 (result (ai-code-mcp-dispatch
+                          "tools/call"
+                          '((name . "editor_state") (arguments . ()))))
+                 (payload (ai-code-test-mcp--read-json
+                           (ai-code-test-mcp--content-text result))))
+            (should (eq :json-false (alist-get 'ok payload)))
+            (should (equal "unavailable" (alist-get 'status payload)))
+            (should-not (equal (buffer-name terminal-buffer)
+                               (alist-get 'buffer_name payload)))))
+      (dolist (buffer (list source-buffer terminal-buffer))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
+(ert-deftest ai-code-test-mcp-editor-state-remains-at-last-prompt-snapshot ()
+  "Editor state should not drift when point moves after a prompt snapshot."
+  (let ((ai-code-mcp-server-tools nil)
+        (ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (session-id "editor-state-snapshot")
+        (source-buffer (generate-new-buffer " *ai-code-mcp-snapshot-source*"))
+        (terminal-buffer (generate-new-buffer " *ai-code-mcp-snapshot-terminal*")))
+    (unwind-protect
+        (save-window-excursion
+          (with-current-buffer source-buffer
+            (insert "first\nsecond\n")
+            (goto-char (point-min)))
+          (ai-code-mcp-register-session session-id "/tmp/" source-buffer)
+          (with-current-buffer source-buffer
+            (forward-line 1))
+          (switch-to-buffer terminal-buffer)
+          (let* ((ai-code-mcp--current-session-id session-id)
+                 (result (ai-code-mcp-dispatch
+                          "tools/call"
+                          '((name . "editor_state") (arguments . ()))))
+                 (payload (ai-code-test-mcp--read-json
+                           (ai-code-test-mcp--content-text result))))
+            (should (= 1 (alist-get 'line payload)))
+            (should (= 1 (alist-get 'point payload)))))
+      (dolist (buffer (list source-buffer terminal-buffer))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
 
 (ert-deftest ai-code-test-mcp-visible-buffers-lists-current-windows ()
   "Visible buffers should mirror the selected frame windows."
@@ -286,7 +400,31 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
       (should project-tool)
       (should (string-match-p
                "\"properties\":{}"
-               encoded)))))
+               encoded))
+      (should (eq :json-false
+                  (alist-get 'additionalProperties
+                             (alist-get 'inputSchema project-tool)))))))
+
+(ert-deftest ai-code-test-mcp-tools-list-advertises-effect-annotations ()
+  "Built-in tools should distinguish read-only queries from side effects."
+  (let* ((ai-code-mcp-server-tools nil)
+         (tools (alist-get 'tools (ai-code-mcp-dispatch "tools/list")))
+         (project-tool (seq-find
+                        (lambda (tool)
+                          (equal "project_info" (alist-get 'name tool)))
+                        tools))
+         (notify-tool (seq-find
+                       (lambda (tool)
+                         (equal "notify_user" (alist-get 'name tool)))
+                       tools)))
+    (should (eq t (alist-get 'readOnlyHint
+                             (alist-get 'annotations project-tool))))
+    (should (eq :json-false
+                (alist-get 'readOnlyHint
+                           (alist-get 'annotations notify-tool))))
+    (should (eq :json-false
+                (alist-get 'destructiveHint
+                           (alist-get 'annotations notify-tool))))))
 
 (ert-deftest ai-code-test-mcp-tools-call-runs-inside-session-context ()
   "Tool calls should run with the registered session buffer and directory."
@@ -576,6 +714,122 @@ DIAGNOSTICS is an expression returning a list of mock diagnostic structs."
                 (should (equal "clean" (alist-get 'status envelope)))
                 (should (= 0 (length (alist-get 'files envelope))))
                 (should (= 0 (length (alist-get 'next_actions envelope))))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-reports-unavailable-without-backend ()
+  "A requested buffer without an active checker must not look clean."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-unavailable-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (file-uri (concat "file://" file-path))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-unavailable*"))
+         (ai-code-mcp-diagnostics-backend 'auto)
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-unavailable")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode nil)
+            (when (boundp 'flycheck-mode)
+              (setq-local flycheck-mode nil)))
+          (ai-code-mcp-register-session
+           "session-unavailable" project-dir session-buffer)
+          (let* ((envelope (ai-code-test-mcp--read-json
+                            (ai-code-mcp-get-diagnostics file-uri)))
+                 (coverage (alist-get 'coverage envelope))
+                 (freshness (alist-get 'freshness envelope))
+                 (buffers (alist-get 'buffers freshness)))
+            (should (equal "unavailable" (alist-get 'status envelope)))
+            (should (= 1 (alist-get 'requested_files coverage)))
+            (should (= 0 (alist-get 'checked_files coverage)))
+            (should (= 1 (alist-get 'unavailable_files coverage)))
+            (should (eq :json-false (alist-get 'complete coverage)))
+            (should (stringp (alist-get 'observed_at freshness)))
+            (should (= 1 (length buffers)))
+            (should (equal "unavailable"
+                           (alist-get 'state (aref buffers 0))))))
+      (when (buffer-live-p visited-buffer)
+        (kill-buffer visited-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-get-diagnostics-reports-incomplete-project-coverage ()
+  "A partially checked project must report incomplete coverage, not clean."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-incomplete-" t))
+         (checked-path (expand-file-name "checked.el" project-dir))
+         (unchecked-path (expand-file-name "unchecked.el" project-dir))
+         (session-buffer (generate-new-buffer " *ai-code-mcp-incomplete*"))
+         (ai-code-mcp-diagnostics-backend 'auto)
+         (ai-code-mcp-server-tools nil)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-incomplete")
+         checked-buffer
+         unchecked-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file checked-path (insert "(message \"checked\")\n"))
+          (with-temp-file unchecked-path (insert "(message \"unchecked\")\n"))
+          (setq checked-buffer (find-file-noselect checked-path t)
+                unchecked-buffer (find-file-noselect unchecked-path t))
+          (with-current-buffer checked-buffer
+            (setq-local flymake-mode t))
+          (with-current-buffer unchecked-buffer
+            (setq-local flymake-mode nil)
+            (when (boundp 'flycheck-mode)
+              (setq-local flycheck-mode nil)))
+          (ai-code-mcp-register-session
+           "session-incomplete" project-dir session-buffer)
+          (ai-code-test-mcp--with-flymake-diagnostics nil
+            (let* ((envelope (ai-code-test-mcp--read-json
+                              (ai-code-mcp-get-diagnostics)))
+                   (coverage (alist-get 'coverage envelope)))
+              (should (equal "incomplete" (alist-get 'status envelope)))
+              (should (= 2 (alist-get 'requested_files coverage)))
+              (should (= 1 (alist-get 'checked_files coverage)))
+              (should (= 1 (alist-get 'unavailable_files coverage)))
+              (should (eq :json-false (alist-get 'complete coverage))))))
+      (when (buffer-live-p checked-buffer)
+        (kill-buffer checked-buffer))
+      (when (buffer-live-p unchecked-buffer)
+        (kill-buffer unchecked-buffer))
+      (when (buffer-live-p session-buffer)
+        (kill-buffer session-buffer))
+      (delete-directory project-dir t))))
+
+(ert-deftest ai-code-test-mcp-diagnostics-baseline-rejects-incomplete-coverage ()
+  "An unavailable checker must not create a misleading empty baseline."
+  (let* ((project-dir (make-temp-file "ai-code-mcp-baseline-unavailable-" t))
+         (file-path (expand-file-name "sample.el" project-dir))
+         (session-buffer
+          (generate-new-buffer " *ai-code-mcp-baseline-unavailable*"))
+         (ai-code-mcp-diagnostics-backend 'auto)
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp--diagnostics-baselines (make-hash-table :test 'equal))
+         (ai-code-mcp--current-session-id "session-baseline-unavailable")
+         visited-buffer)
+    (unwind-protect
+        (progn
+          (with-temp-file file-path (insert "(message \"alpha\")\n"))
+          (setq visited-buffer (find-file-noselect file-path t))
+          (with-current-buffer visited-buffer
+            (setq-local flymake-mode nil)
+            (when (boundp 'flycheck-mode)
+              (setq-local flycheck-mode nil)))
+          (ai-code-mcp-register-session
+           "session-baseline-unavailable" project-dir session-buffer)
+          (let ((envelope (ai-code-test-mcp--read-json
+                           (ai-code-mcp-diagnostics-baseline))))
+            (should (equal "baseline_unavailable"
+                           (alist-get 'status envelope)))
+            (should-not (ai-code-mcp--diagnostics-baseline-recorded-p))))
       (when (buffer-live-p visited-buffer)
         (kill-buffer visited-buffer))
       (when (buffer-live-p session-buffer)

--- a/test/test_ai-code-open-interpreter-cli.el
+++ b/test/test_ai-code-open-interpreter-cli.el
@@ -58,7 +58,9 @@
   (let ((captured-command nil)
         (captured-cleanup-fn nil)
         (captured-post-start-fn nil)
+        (captured-env-vars nil)
         (registered nil)
+        (attached nil)
         (unregistered nil)
         (builtins-called nil)
         (ensure-called nil)
@@ -79,9 +81,15 @@
                    (lambda ()
                      (setq ensure-called t)
                      8765))
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () "test-interpreter-token"))
                   ((symbol-function 'ai-code-mcp-register-session)
-                   (lambda (session-id project-dir buffer)
-                     (setq registered (list session-id project-dir buffer))))
+                   (lambda (session-id project-dir buffer metadata)
+                     (setq registered
+                           (list session-id project-dir buffer metadata))))
+                  ((symbol-function 'ai-code-mcp-attach-agent-buffer)
+                   (lambda (session-id buffer)
+                     (setq attached (list session-id buffer))))
                   ((symbol-function 'ai-code-mcp-unregister-session)
                    (lambda (session-id)
                      (setq unregistered session-id)))
@@ -92,11 +100,12 @@
                          (_working-dir _buffer-name _process-table command
                                        &optional _escape-fn cleanup-fn
                                        _instance-name _prefix _force-prompt
-                                       _env-vars _multiline-input-sequence
+                                       env-vars _multiline-input-sequence
                                        post-start-fn)
                          args
                        (setq captured-command command
                              captured-cleanup-fn cleanup-fn
+                             captured-env-vars env-vars
                              captured-post-start-fn post-start-fn))
                      nil)))
           (ai-code-open-interpreter-cli)
@@ -106,20 +115,28 @@
                    "\\`interpreter --model test " captured-command))
           (should (string-match-p
                    "mcp_servers\\.emacs_tools" captured-command))
-          (should (string-match-p
-                   "mcp/open-interpreter-" captured-command))
+          (should (string-match-p "bearer_token_env_var" captured-command))
+          (should-not (string-match-p "test-interpreter-token"
+                                      captured-command))
+          (should-not (string-match-p
+                       "mcp/open-interpreter-" captured-command))
+          (should (equal
+                   '("AI_CODE_MCP_BEARER_TOKEN=test-interpreter-token")
+                   captured-env-vars))
           (should (functionp captured-cleanup-fn))
           (should (functionp captured-post-start-fn))
           (funcall captured-post-start-fn session-buffer nil "default")
           (should (string-prefix-p "open-interpreter-" (car registered)))
           (should (equal "/tmp/test-open-interpreter" (nth 1 registered)))
-          (should (eq session-buffer (nth 2 registered)))
+          (should-not (eq session-buffer (nth 2 registered)))
+          (should (equal "test-interpreter-token"
+                         (plist-get (nth 3 registered) :token)))
+          (should (equal (list (car registered) session-buffer) attached))
           (with-current-buffer session-buffer
             (let ((status (ai-code-mcp-agent-buffer-status)))
               (should (eq 'open-interpreter (plist-get status :backend)))
-              (should (string-match-p
-                       "^http://127\\.0\\.0\\.1:8765/mcp/open-interpreter-"
-                       (plist-get status :server-url)))))
+              (should (equal "http://127.0.0.1:8765/mcp"
+                             (plist-get status :server-url)))))
           (funcall captured-cleanup-fn)
           (should (equal (car registered) unregistered)))
       (when (buffer-live-p session-buffer)

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -12,6 +12,7 @@
 (require 'ai-code-prompt-mode)
 (require 'ai-code-git)
 (require 'ai-code-backends-infra)
+(require 'ai-code-mcp-agent)
 (require 'magit)
 (require 'cl-lib)
 
@@ -22,6 +23,44 @@
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 (defvar org-roam-directory)
+
+(ert-deftest ai-code-test-send-prompt-refreshes-mcp-source-before-terminal-io ()
+  "Sending a prompt should snapshot its source before terminal output."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (session-id "prompt-source-refresh")
+        (source-buffer (generate-new-buffer " *ai-code-prompt-source*"))
+        (agent-buffer (generate-new-buffer "*codex[prompt-source]*"))
+        snapshot-at-send)
+    (unwind-protect
+        (progn
+          (with-current-buffer source-buffer
+            (insert "first\nsecond\n")
+            (goto-char (point-min)))
+          (ai-code-mcp-register-session session-id "/tmp/" source-buffer)
+          (ai-code-mcp-attach-agent-buffer session-id agent-buffer)
+          (with-current-buffer agent-buffer
+            (setq-local ai-code-mcp-agent--session-id session-id))
+          (with-current-buffer source-buffer
+            (forward-line 1)
+            (cl-letf (((symbol-function 'ai-code-backends-infra--terminal-send-string)
+                       (lambda (&rest _args)
+                         (setq snapshot-at-send
+                               (plist-get
+                                (ai-code-mcp-get-session-context session-id)
+                                :source-snapshot))))
+                      ((symbol-function 'ai-code-backends-infra--terminal-send-return)
+                       #'ignore)
+                      ((symbol-function 'get-buffer-window)
+                       (lambda (&rest _args) nil))
+                      ((symbol-function 'ai-code-backends-infra--display-buffer-in-side-window)
+                       #'ignore)
+                      ((symbol-function 'sit-for) #'ignore))
+              (ai-code--send-prompt-to-session-buffer "Inspect this" agent-buffer)))
+          (should (eq source-buffer (plist-get snapshot-at-send :buffer)))
+          (should (= 2 (plist-get snapshot-at-send :line))))
+      (dolist (buffer (list source-buffer agent-buffer))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
 
 (ert-deftest ai-code-test-direct-command-p-accepts-single-token-command ()
   "A single-token slash command should use direct command routing."


### PR DESCRIPTION
## Summary

This hardens the Emacs MCP integration and makes session lifecycle handling explicit across supported CLI backends. Each AI session now receives a short-lived bearer token, tracks its source and agent buffers, and gets backend-specific MCP configuration without writing the token into generated config files.

- Expand the loopback HTTP transport with modern discovery and legacy initialization negotiation, stricter JSON-RPC/header/content validation, origin checks, request limits, and per-session rate limiting.
- Add tool profiles, argument schemas and annotations, structured tool results, richer diagnostics coverage/freshness reporting, and prompt-source refresh before terminal input is sent.
- Keep backend startup and cleanup paired, with broader ERT coverage for the MCP agent, server, HTTP transport, diagnostics, and backend wiring.

## Verification

- Full ERT suite: 1,312 total (1,299 passed, 13 skipped, 0 unexpected).
- MCP-focused ERT suite: 340 passed.
- Touched Emacs Lisp files byte-compiled without warnings; checkdoc, check-parens, and diff checks passed.