### PR TITLE
Tighten GPTel code-change prompt classification

### DIFF
--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -437,21 +437,25 @@ Use simple string matching first, then fall back to GPTel."
 (defun ai-code--gptel-classify-prompt-code-change (prompt-text)
   "Classify whether PROMPT-TEXT requests a code change using GPTel.
 Return one of: `code-change`, `non-code-change`, or `unknown`."
+  ;; TODO DONE: Make prompt code-change classification more strict.
   (let ((classification
          (condition-case err
              (if (require 'gptel nil t)
                  (let* ((raw-answer (ai-code-call-gptel-sync
                                      (concat "Classify whether this user prompt requests program code changes in a repository.\n"
                                              "Reply with exactly one token: CODE_CHANGE or NOT_CODE_CHANGE.\n"
+                                             "Focus only on the action explicitly requested; ignore code or files supplied as context.\n"
                                              "Return CODE_CHANGE only for changes to program code or test code.\n"
+                                             "Only return CODE_CHANGE when the prompt explicitly asks to create, modify, fix, refactor, or delete program code or test code.\n"
+                                             "Do not infer a code change merely because the prompt mentions or includes code, repository files, bugs, or implementation details.\n"
                                              "Treat documentation changes and any other non-program-code actions as NOT_CODE_CHANGE.\n"
                                              "Treat explain/summarize/discuss/review without editing as NOT_CODE_CHANGE.\n\n"
                                              "Prompt:\n" prompt-text)))
                         (answer (upcase (string-trim (or raw-answer "")))))
-                   (cond
-                    ((string-match-p "\\`CODE_CHANGE\\b" answer) 'code-change)
-                    ((string-match-p "\\`NOT_CODE_CHANGE\\b" answer) 'non-code-change)
-                    (t 'unknown)))
+                   (pcase answer
+                     ("CODE_CHANGE" 'code-change)
+                     ("NOT_CODE_CHANGE" 'non-code-change)
+                     (_ 'unknown)))
                'unknown)
            (error
             (message "GPTel prompt classification failed: %s" (error-message-string err))

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -1042,6 +1042,31 @@
         "Treat documentation changes and any other non-program-code actions as NOT_CODE_CHANGE\\."
         captured-prompt)))))
 
+(ert-deftest ai-code-test-gptel-classifier-requires-explicit-edit-intent-and-exact-token ()
+  "Test that GPTel classifies code changes only from explicit edit requests."
+  (let ((captured-prompt nil)
+        (original-require (symbol-function 'require)))
+    (cl-letf (((symbol-function 'require)
+               (lambda (feature &optional filename noerror)
+                 (if (eq feature 'gptel)
+                     t
+                   (funcall original-require feature filename noerror))))
+              ((symbol-function 'ai-code-call-gptel-sync)
+               (lambda (prompt)
+                 (setq captured-prompt prompt)
+                 "CODE_CHANGE because the prompt mentions code")))
+      (should (eq 'unknown
+                  (ai-code--gptel-classify-prompt-code-change
+                   "Explain @ai-code-harness.el.")))
+      (should
+       (string-match-p
+        "Only return CODE_CHANGE when the prompt explicitly asks to"
+        captured-prompt))
+      (should
+       (string-match-p
+        "Do not infer a code change merely because the prompt mentions or includes code"
+        captured-prompt)))))
+
 (ert-deftest ai-code-test-simple-classifier-reuses-shared-prompt-markers ()
   "Test that classifier markers reuse shared prompt-builder constants."
   (should (boundp 'ai-code-change--selected-region-note))


### PR DESCRIPTION
## Summary

Tighten GPTel prompt classification so code references and repository context do not cause discussion-only prompts to be routed as code changes.

- Require an explicit request to create, modify, fix, refactor, or delete program or test code before returning `CODE_CHANGE`.
- Accept only the exact classifier tokens and fall back to `unknown` for verbose or malformed responses.
- Add regression coverage for prompts that mention code without requesting an edit.

## Verification

The harness ERT suite passed all 79 tests, and the touched files passed byte compilation, checkdoc, and diagnostics checks before publishing.