### PR TITLE
Add Muse Code CLI backend support

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,7 +2,8 @@
 * Release history
 
 ** Main branch change
-- Feat: add Muse Code CLI backend support
+- Feat: Add Muse Code CLI backend support
+- Feat: Add maintainability sensors to Uncle Bob coding harness as plus version
 
 ** 1.92
 - fix for agent-shell new api, by baohaojun

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -2,6 +2,7 @@
 * Release history
 
 ** Main branch change
+- Feat: add Muse Code CLI backend support
 
 ** 1.92
 - fix for agent-shell new api, by baohaojun

--- a/README.org
+++ b/README.org
@@ -13,6 +13,7 @@ An Emacs interface for AI-assisted software development. *The purpose is to prov
   - [[https://github.com/openai/codex][OpenAI Codex]]
   - [[https://pi.dev/][Pi]]
   - [[https://antigravity.google/product/antigravity-cli][Antigravity CLI]]
+  - [[https://developer.meta.com/ai/products/muse-code][Muse Code]]
   - [[https://opencode.ai/][Opencode]]
   - [[https://github.com/anthropics/claude-code][Claude Code]]
   - [[https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli][GitHub Copilot CLI]]
@@ -466,6 +467,7 @@ To transfer development work between different AI coding backends (e.g., from Co
    - [[https://github.com/openai/codex][OpenAI codex CLI]] (`[[./ai-code-codex-cli.el][ai-code-codex-cli.el]]`)
    - [[https://pi.dev/][Pi]] (`[[./ai-code-pi.el][ai-code-pi.el]]`)
    - [[https://antigravity.google/product/antigravity-cli][Antigravity CLI]] (`[[./ai-code-antigravity-cli.el][ai-code-antigravity-cli.el]]`)
+   - [[https://developer.meta.com/ai/products/muse-code][Muse Code]] (`[[./ai-code-muse-cli.el][ai-code-muse-cli.el]]`)
    - [[https://opencode.ai/][Opencode]] (`[[./ai-code-opencode.el][ai-code-opencode.el]]`)
    - [[https://github.com/anthropics/claude-code][Claude Code]] (`[[./ai-code-claude-code.el][ai-code-claude-code.el]]`)
      - Binds =Shift+Enter=/=Ctrl+Enter= inside Claude sessions to send Claude's
@@ -538,6 +540,16 @@ To transfer development work between different AI coding backends (e.g., from Co
      point at a different binary or pass additional flags. After that, select the backend through
      `ai-code-select-backend` or bind a helper in your config.
      The resume command adds =--continue= automatically.
+
+**** Muse Code setup
+     Install Muse Code on macOS or Linux with:
+     =curl -fsSL https://dev.meta.ai/install.sh | bash=
+     Review the script before piping it to your shell, then ensure the =muse=
+     executable is available to Emacs through =PATH= and =exec-path=.
+     Customize =ai-code-muse-cli-program= or
+     =ai-code-muse-cli-program-switches= to use a different executable or pass
+     additional startup flags. Select the backend with =ai-code-select-backend=.
+     The resume command runs =muse resume=.
 
 **** Open Interpreter CLI setup
      [[https://github.com/openinterpreter/openinterpreter][Open Interpreter CLI]] is treated as a Codex-compatible CLI. It can be installed with:

--- a/ai-code-backends.el
+++ b/ai-code-backends.el
@@ -273,6 +273,19 @@ so the CLI itself handles the installation details."
      :upgrade "agy update"
      :install-skills nil
      :cli     "agy")
+    (muse
+     :label "Muse Code"
+     :require ai-code-muse-cli
+     :start   ai-code-muse-cli
+     :switch  ai-code-muse-cli-switch-to-buffer
+     :send    ai-code-muse-cli-send-command
+     :resume  ai-code-muse-cli-resume
+     :config  nil
+     :agent-file nil
+     :install "curl -fsSL https://dev.meta.ai/install.sh | bash"
+     :upgrade nil
+     :install-skills nil
+     :cli     "muse")
     (github-copilot-cli
      :label "GitHub Copilot CLI"
      :require ai-code-github-copilot-cli

--- a/ai-code-behaviors.el
+++ b/ai-code-behaviors.el
@@ -2246,6 +2246,7 @@ Call this when completely disabling ai-code-behaviors."
     (github-copilot-cli . "copilot")
     (codex . "codex")
     (pi . "pi")
+    (muse . "muse")
     (cursor . "cursor")
     (aider . "aider")
     (grok . "grok")

--- a/ai-code-muse-cli.el
+++ b/ai-code-muse-cli.el
@@ -77,7 +77,9 @@ Argument ARG is passed to the start command."
   (interactive "P")
   (let ((ai-code-muse-cli-program-switches
          (append ai-code-muse-cli-program-switches '("resume"))))
-    (ai-code-muse-cli arg)))
+    (ai-code-muse-cli arg)
+    (ai-code-backends-infra--cli-show-resume-picker
+     ai-code-muse-cli--session-prefix)))
 
 (provide 'ai-code-muse-cli)
 

--- a/ai-code-muse-cli.el
+++ b/ai-code-muse-cli.el
@@ -1,0 +1,84 @@
+;;; ai-code-muse-cli.el --- Thin wrapper for Muse Code CLI  -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;;
+;; Thin wrapper that reuses `ai-code-backends-infra' to run Muse Code CLI.
+;; Provides interactive commands for the AI Code suite.
+;;
+;;; Code:
+
+(require 'ai-code-backends)
+(require 'ai-code-backends-infra)
+
+(defgroup ai-code-muse-cli nil
+  "Muse Code CLI integration via `ai-code-backends-infra'."
+  :group 'tools
+  :prefix "ai-code-muse-cli-")
+
+(defcustom ai-code-muse-cli-program "muse"
+  "Path to the Muse Code CLI executable."
+  :type 'string
+  :group 'ai-code-muse-cli)
+
+(defcustom ai-code-muse-cli-program-switches nil
+  "Command line switches to pass to Muse Code CLI on startup."
+  :type '(repeat string)
+  :group 'ai-code-muse-cli)
+
+(defconst ai-code-muse-cli--session-prefix "muse"
+  "Session prefix used in Muse Code CLI buffer names.")
+
+(defvar ai-code-muse-cli--processes (make-hash-table :test 'equal)
+  "Hash table mapping Muse Code session keys to processes.")
+
+;;;###autoload
+(defun ai-code-muse-cli (&optional arg)
+  "Start Muse Code CLI using `ai-code-backends-infra' logic.
+With prefix ARG, prompt for CLI args using
+`ai-code-muse-cli-program-switches' as the default input."
+  (interactive "P")
+  (ai-code-backends-infra--start-cli-session
+   (list :program ai-code-muse-cli-program
+         :switches ai-code-muse-cli-program-switches
+         :label "Muse Code"
+         :process-table ai-code-muse-cli--processes
+         :session-prefix ai-code-muse-cli--session-prefix
+         :escape-function #'ai-code-muse-cli-send-escape)
+   arg))
+
+;;;###autoload
+(defun ai-code-muse-cli-switch-to-buffer (&optional force-prompt)
+  "Switch to the Muse Code CLI buffer.
+When FORCE-PROMPT is non-nil, prompt to select a session."
+  (interactive "P")
+  (ai-code-backends-infra--cli-switch-to-buffer
+   "Muse Code" ai-code-muse-cli--session-prefix force-prompt))
+
+;;;###autoload
+(defun ai-code-muse-cli-send-command (line)
+  "Send LINE to Muse Code CLI."
+  (interactive "sMuse Code> ")
+  (ai-code-backends-infra--cli-send-command
+   "Muse Code" ai-code-muse-cli--session-prefix line))
+
+;;;###autoload
+(defun ai-code-muse-cli-send-escape ()
+  "Send escape key to Muse Code CLI."
+  (interactive)
+  (ai-code-backends-infra--terminal-send-escape))
+
+;;;###autoload
+(defun ai-code-muse-cli-resume (&optional arg)
+  "Resume a previous Muse Code CLI session.
+Argument ARG is passed to the start command."
+  (interactive "P")
+  (let ((ai-code-muse-cli-program-switches
+         (append ai-code-muse-cli-program-switches '("resume"))))
+    (ai-code-muse-cli arg)))
+
+(provide 'ai-code-muse-cli)
+
+;;; ai-code-muse-cli.el ends here

--- a/test/test_ai-code-muse-cli.el
+++ b/test/test_ai-code-muse-cli.el
@@ -17,7 +17,7 @@
     (should spec)
     (should (equal (plist-get (cdr spec) :label) "Muse Code"))
     (should (eq (plist-get (cdr spec) :require) 'ai-code-muse-cli))
-    (should (eq (plist-get (cdr spec) :cli) "muse"))))
+    (should (equal (plist-get (cdr spec) :cli) "muse"))))
 
 (ert-deftest ai-code-test-muse-cli-start-uses-generic-helper ()
   "Muse startup should delegate generic session setup to the shared helper."

--- a/test/test_ai-code-muse-cli.el
+++ b/test/test_ai-code-muse-cli.el
@@ -1,0 +1,91 @@
+;;; test_ai-code-muse-cli.el --- Tests for ai-code-muse-cli.el -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for the ai-code-muse-cli module.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'ai-code-muse-cli)
+
+(ert-deftest ai-code-test-muse-cli-backend-registered ()
+  "Muse backend should be registered in `ai-code-backends'."
+  (let ((spec (assq 'muse ai-code-backends)))
+    (should spec)
+    (should (equal (plist-get (cdr spec) :label) "Muse Code"))
+    (should (eq (plist-get (cdr spec) :require) 'ai-code-muse-cli))
+    (should (eq (plist-get (cdr spec) :cli) "muse"))))
+
+(ert-deftest ai-code-test-muse-cli-start-uses-generic-helper ()
+  "Muse startup should delegate generic session setup to the shared helper."
+  (let (captured-options
+        captured-arg)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
+               (lambda (options arg)
+                 (setq captured-options options
+                       captured-arg arg)))
+              ((symbol-function 'ai-code-backends-infra--session-working-directory)
+               (lambda () "/tmp/test"))
+              ((symbol-function 'ai-code-backends-infra--resolve-start-command)
+               (lambda (&rest _args) '(:command "muse --debug")))
+              ((symbol-function 'ai-code-backends-infra--toggle-or-create-session)
+               (lambda (&rest _args) nil)))
+      (let ((ai-code-muse-cli-program "muse-test")
+            (ai-code-muse-cli-program-switches '("--debug")))
+        (ai-code-muse-cli 'prefix-arg)))
+    (should (eq captured-arg 'prefix-arg))
+    (should (equal (plist-get captured-options :program) "muse-test"))
+    (should (equal (plist-get captured-options :switches) '("--debug")))
+    (should (equal (plist-get captured-options :label) "Muse Code"))
+    (should (eq (plist-get captured-options :process-table)
+                ai-code-muse-cli--processes))
+    (should (equal (plist-get captured-options :session-prefix) "muse"))
+    (should (eq (plist-get captured-options :escape-function)
+                #'ai-code-muse-cli-send-escape))))
+
+(ert-deftest ai-code-test-muse-cli-resume-appends-resume-without-mutating-global ()
+  "Resume should append \"resume\" via let-binding and not mutate global switches."
+  (let ((ai-code-muse-cli-program-switches '("--foo"))
+        (captured-switches nil))
+    (cl-letf (((symbol-function 'ai-code-muse-cli)
+               (lambda (&optional _arg)
+                 (setq captured-switches ai-code-muse-cli-program-switches)))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (_prefix) nil)))
+      (ai-code-muse-cli-resume nil)
+      (should (equal captured-switches '("--foo" "resume")))
+      (should (equal ai-code-muse-cli-program-switches '("--foo"))))))
+
+(ert-deftest ai-code-test-muse-cli-resume-shows-picker ()
+  "Resume should invoke the resume picker for the muse prefix."
+  (let ((picker-called nil)
+        (picker-prefix nil))
+    (cl-letf (((symbol-function 'ai-code-muse-cli)
+               (lambda (&optional _arg) nil))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (prefix)
+                 (setq picker-called t
+                       picker-prefix prefix))))
+      (ai-code-muse-cli-resume 'some-arg)
+      (should picker-called)
+      (should (equal picker-prefix "muse")))))
+
+(ert-deftest ai-code-test-muse-cli-resume-passes-arg-through ()
+  "Resume should forward ARG to the start command."
+  (let ((forwarded-arg 'not-set)
+        (picker-called nil))
+    (cl-letf (((symbol-function 'ai-code-muse-cli)
+               (lambda (&optional arg)
+                 (setq forwarded-arg arg)))
+              ((symbol-function 'ai-code-backends-infra--cli-show-resume-picker)
+               (lambda (_prefix) (setq picker-called t))))
+      (ai-code-muse-cli-resume 'my-arg)
+      (should (eq forwarded-arg 'my-arg))
+      (should picker-called))))
+
+(provide 'test_ai-code-muse-cli)
+
+;;; test_ai-code-muse-cli.el ends here


### PR DESCRIPTION
## Summary

Add Muse Code as a native backend so it can be selected and used through the existing AI Code session workflow.

- Add a thin terminal wrapper for starting, switching to, sending commands to, and resuming Muse Code sessions with `muse resume`.
- Register Muse Code installation metadata and session-prefix detection so existing sessions are recognized correctly.
- Document installation and configuration, and record the feature in the release history.

## Verification

`git diff --check main...kang_feat` passes. Tests were not run per request.

Closes #473.