### PR TITLE
Fix session lookup across symlinks and worktrees

### DIFF
--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -121,7 +121,7 @@ that process character-by-character input slowly."
   "Hash table mapping (prefix . directory) to last selected session buffer.")
 
 (defvar ai-code-backends-infra--file-session-map (make-hash-table :test 'equal)
-  "Hash table mapping (prefix . file) to attached AI session buffer.")
+  "Hash table mapping (prefix workspace file) to attached session buffers.")
 
 (defvar ai-code-backends-infra--preferred-session-buffer nil
   "Preferred session buffer to place first when prompting for session selection.")
@@ -741,13 +741,16 @@ use the branch name."
   (ai-code-backends-infra--branch-instance-name existing-instance-names))
 
 (defun ai-code-backends-infra--file-session-map-key (prefix source-buffer)
-  "Return file-session map key for PREFIX and SOURCE-BUFFER."
+  "Return workspace-scoped file-session key for PREFIX and SOURCE-BUFFER."
   (when (and prefix (buffer-live-p source-buffer))
     (with-current-buffer source-buffer
       (when (and (stringp buffer-file-name)
                  (> (length buffer-file-name) 0))
-        (cons prefix
-              (ai-code-backends-infra--normalize-file-path buffer-file-name))))))
+        (list prefix
+              (ai-code-backends-infra--normalize-session-directory
+               (ai-code--session-project-root))
+              (ai-code-backends-infra--normalize-file-path
+               buffer-file-name))))))
 
 (defun ai-code-backends-infra--remember-file-session-buffer (prefix source-buffer session-buffer)
   "Remember SESSION-BUFFER as attached session for SOURCE-BUFFER and PREFIX."
@@ -775,11 +778,16 @@ use the branch name."
   "Return live sessions explicitly attached to SOURCE's file."
   (when-let* ((file (buffer-local-value 'buffer-file-name source))
               (normalized-file
-               (ai-code-backends-infra--normalize-file-path file)))
+               (ai-code-backends-infra--normalize-file-path file))
+              (root (with-current-buffer source
+                      (ai-code--session-project-root)))
+              (normalized-root
+               (ai-code-backends-infra--normalize-session-directory root)))
     (let (sessions)
       (maphash
        (lambda (key session)
-         (when (and (equal (cdr-safe key) normalized-file)
+         (when (and (equal (nth 1 key) normalized-root)
+                    (equal (nth 2 key) normalized-file)
                     (ai-code-backends-infra--live-terminal-session-p session))
            (push session sessions)))
        ai-code-backends-infra--file-session-map)
@@ -859,12 +867,9 @@ Return a cons of (BUFFER . MISSING-P)."
         (cons nil nil)
       (let* ((attached (gethash key ai-code-backends-infra--file-session-map))
              (valid (and (buffer-live-p attached)
-                         (or (ai-code-backends-infra--parse-session-buffer-name
-                             (buffer-name attached)
-                              prefix)
-                             (ai-code-backends-infra--session-buffer-matches-directory-p
-                              attached
-                              working-dir)))))
+                         (ai-code-backends-infra--session-buffer-matches-directory-p
+                          attached
+                          working-dir))))
         (cond
          (valid
           (cons attached nil))
@@ -990,7 +995,8 @@ When INSTANCE-NAME is non-nil and not \"default\", include it in the name."
 
 (defun ai-code-backends-infra--session-key (directory instance-name)
   "Return a session key for DIRECTORY and INSTANCE-NAME."
-  (cons directory (ai-code-backends-infra--normalize-instance-name instance-name)))
+  (cons (ai-code-backends-infra--normalize-session-directory directory)
+        (ai-code-backends-infra--normalize-instance-name instance-name)))
 
 (defun ai-code-backends-infra--session-map-key (prefix directory)
   "Return a map key for PREFIX and DIRECTORY."
@@ -1335,20 +1341,23 @@ behavior."
 
 (defun ai-code-backends-infra--start-cli-session (options arg)
   "Start a generic CLI session described by OPTIONS and prefix ARG.
-When ARG is non-nil, prompt for CLI args, working directory, and instance name.
+When ARG is non-nil, prompt for CLI args, working directory, and
+instance name.
 OPTIONS is a plist with these keys:
 :program is the CLI executable.
 :switches is the default list of CLI switches.
 :label is the user-facing CLI label.
 :process-table maps session keys to processes.
 :session-prefix is the session buffer prefix.
-:escape-function is an optional function bound to escape in the session buffer.
+:escape-function is an optional function bound to escape in the
+session buffer.
 :env-vars is an optional list of environment variable strings.
-:multiline-input-sequence is an optional terminal sequence for multiline input.
+:multiline-input-sequence is an optional terminal sequence for
+multiline input.
 :prepare-launch is an optional function called with (WORKING-DIR ARGV).
-When :prepare-launch is present, it may return :argv, :env-vars, :cleanup-fn, and
-:post-start-fn entries to customize session creation.  A legacy :command
-entry is normalized to argv for compatibility."
+When :prepare-launch is present, it may return :argv, :env-vars,
+:cleanup-fn, and :post-start-fn entries to customize session creation.
+A legacy :command entry is normalized to argv for compatibility."
   (let* ((resolved (ai-code-backends-infra--resolve-start-command
                     (plist-get options :program)
                     (plist-get options :switches)

--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -54,6 +54,7 @@ Candidate values:
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function ai-code--generate-task-filename "ai-code-task" (task-name))
 (declare-function ai-code--initialize-task-file-content "ai-code-task" (task-name task-url))
+(declare-function ai-code--set-session-project-root "ai-code-utils" (root))
 
 (defvar ai-code-files-dir-name)
 
@@ -741,8 +742,9 @@ BRANCH is used as the default task name."
           (ai-code--initialize-task-file-content task-name "")))
       (let ((symlink-path (expand-file-name confirmed-filename worktree-path)))
         (unless (file-exists-p symlink-path)
-          (make-symbolic-link task-file symlink-path)))
-      (find-file-other-window task-file))))
+          (make-symbolic-link task-file symlink-path))
+        (with-current-buffer (find-file-other-window symlink-path)
+          (ai-code--set-session-project-root worktree-path))))))
 
 ;;;###autoload
 (defun ai-code-git-worktree-action (&optional prefix)

--- a/ai-code-session.el
+++ b/ai-code-session.el
@@ -45,10 +45,11 @@
    (t nil)))
 
 (defun ai-code-session--normalize-directory (directory)
-  "Return DIRECTORY normalized as an absolute directory path."
+  "Return DIRECTORY as a canonical absolute directory path."
   (when (and (stringp directory)
              (not (string-empty-p directory)))
-    (file-name-as-directory (expand-file-name directory))))
+    (file-name-as-directory
+     (file-truename (expand-file-name directory)))))
 
 (defun ai-code-session--normalize-file (file)
   "Return FILE normalized as an absolute file path."

--- a/ai-code-task.el
+++ b/ai-code-task.el
@@ -23,6 +23,7 @@
 (declare-function ai-code--confirm-and-send "ai-code-input"
                   (prompt-label initial-prompt))
 (declare-function ai-code-current-backend-label "ai-code-backends" ())
+(declare-function ai-code--set-session-project-root "ai-code-utils" (root))
 
 ;;;###autoload
 (defcustom ai-code-task-use-gptel-filename nil
@@ -123,14 +124,16 @@ TASK-NAME and TASK-URL are used to initialize new files."
   (message "Opened task file: %s" task-file))
 
 (defun ai-code--maybe-symlink-task-to-worktree (task-file)
-  "Symlink TASK-FILE into the worktree root when inside a git worktree."
+  "Symlink TASK-FILE and bind its buffer to the current worktree."
   (when-let* ((worktree-root (ai-code--git-root))
               (main-repo-root (ai-code--worktree-main-repo-root)))
     (let ((symlink-path (expand-file-name (file-name-nondirectory task-file)
                                           worktree-root)))
       (unless (file-exists-p symlink-path)
         (make-symbolic-link task-file symlink-path)
-        (message "Linked task file to worktree: %s" symlink-path)))))
+        (message "Linked task file to worktree: %s" symlink-path))
+      (ai-code--set-session-project-root worktree-root)
+      symlink-path)))
 
 (defun ai-code--select-task-target-directory (ai-code-files-dir current-dir)
   "Prompt user to select target directory.

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -19,9 +19,13 @@
 (declare-function projectile-project-root "projectile")
 (declare-function project-current "project" (&optional maybe-prompt dir))
 (declare-function project-root "project" (project))
+(declare-function magit-git-string "magit-git" (&rest args))
 
 (defvar ai-code--repo-context-info (make-hash-table :test #'equal)
   "Hash table storing context info lists per Git repository root.")
+
+(defvar-local ai-code--session-project-root-override nil
+  "Explicit session project root associated with the current buffer.")
 
 ;;; Path Utilities
 
@@ -59,11 +63,18 @@ main repo root from it."
 
 (defun ai-code--session-project-root ()
   "Return the best available project root for the current session.
-Tries project.el first, then Git root, then `default-directory'."
-  (or (when-let ((project (ignore-errors (project-current nil default-directory))))
-        (expand-file-name (project-root project)))
+Uses the current buffer override first, then Git root, project.el, and
+finally `default-directory'."
+  (or ai-code--session-project-root-override
       (ai-code--git-root)
+      (when-let ((project (ignore-errors (project-current nil default-directory))))
+        (expand-file-name (project-root project)))
       (expand-file-name default-directory)))
+
+(defun ai-code--set-session-project-root (root)
+  "Associate the current buffer's AI sessions with ROOT."
+  (setq-local ai-code--session-project-root-override
+              (file-truename (expand-file-name root))))
 
 (defun ai-code--get-files-directory ()
   "Get the task directory path.

--- a/test/test_00-bootstrap.el
+++ b/test/test_00-bootstrap.el
@@ -45,7 +45,7 @@
               (if (and (not ai-code-test--in-read-string-advice)
                        (fboundp 'ai-code-read-string))
                   (let ((ai-code-test--in-read-string-advice t))
-                    (apply #'ai-code-read-string prompt initial-input args))
+                    (ai-code-read-string prompt initial-input))
                 (apply orig-fun prompt initial-input args))))
 
 (provide 'test_00-bootstrap)

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -2007,6 +2007,32 @@ The prefix argument should also force instance-name prompting."
       (ignore-errors
         (delete-directory root t)))))
 
+(ert-deftest test-ai-code-backends-infra-session-key-canonicalizes-directory-aliases ()
+  "Use one process-table key for real and symlinked workspace paths."
+  (let* ((root (make-temp-file "ai-code-session-key-root-" t))
+         (alias-parent (make-temp-file "ai-code-session-key-alias-" t))
+         (alias-root (expand-file-name "repo" alias-parent)))
+    (unwind-protect
+        (progn
+          (make-symbolic-link root alias-root)
+          (dolist (instance '(nil "" "default" "feature/test"))
+            (let ((expected
+                   (ai-code-backends-infra--session-key root instance)))
+              (dolist (candidate
+                       (list root
+                             (file-name-as-directory root)
+                             (expand-file-name "./" root)
+                             alias-root
+                             (file-name-as-directory alias-root)
+                             (expand-file-name "./" alias-root)))
+                (should
+                 (equal expected
+                        (ai-code-backends-infra--session-key
+                         candidate
+                         instance)))))))
+      (ignore-errors (delete-directory alias-parent t))
+      (ignore-errors (delete-directory root t)))))
+
 (ert-deftest test-ai-code-backends-infra-toggle-or-create-session-default-process-table ()
   "Fallback to global process table when PROCESS-TABLE is nil."
   (let* ((ai-code-backends-infra--processes (make-hash-table :test 'equal))
@@ -3136,13 +3162,14 @@ The prefix argument should also force instance-name prompting."
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
 
-(ert-deftest test-ai-code-backends-infra-switch-reuses-live-attached-session-despite-working-dir-mismatch ()
-  "Reuse a live attached session even when WORKING-DIR no longer matches it."
+(ert-deftest test-ai-code-backends-infra-switch-rejects-attached-session-on-working-dir-mismatch ()
+  "Reject a live attached session when WORKING-DIR does not match it."
   (let* ((prefix "codex")
          (session-dir "/tmp/ai-code-file-attached-root/")
          (working-dir "/tmp/ai-code-file-attached-root/subdir/")
          (source (generate-new-buffer " *ai-code-source-attached-live*"))
          (attached (get-buffer-create "*codex[file-attached-root:attached]*"))
+         (select-called nil)
          (displayed nil))
     (unwind-protect
         (progn
@@ -3160,8 +3187,9 @@ The prefix argument should also force instance-name prompting."
           (cl-letf (((symbol-function 'ai-code-backends-infra--find-session-buffers)
                      (lambda (_prefix _dir) nil))
                     ((symbol-function 'ai-code-backends-infra--select-session-buffer)
-                     (lambda (&rest _args)
-                       (ert-fail "Should reuse the live attached session without prompting.")))
+                     (lambda (_prefix _directory &optional force-prompt)
+                       (setq select-called force-prompt)
+                       nil))
                     ((symbol-function 'get-buffer-window)
                      (lambda (&rest _args) nil))
                     ((symbol-function 'ai-code-backends-infra--display-buffer-in-side-window)
@@ -3169,18 +3197,21 @@ The prefix argument should also force instance-name prompting."
                        (setq displayed buffer)
                        nil)))
             (with-current-buffer source
-              (ai-code-backends-infra--switch-to-session-buffer
-               nil
-               "missing"
-               prefix
-               working-dir
-               nil)))
+              (should-error
+               (ai-code-backends-infra--switch-to-session-buffer
+                nil
+                "missing"
+                prefix
+                working-dir
+                nil)
+               :type 'user-error)))
 
-          (should (eq displayed attached))
-          (should (eq (gethash
-                       (ai-code-backends-infra--file-session-map-key prefix source)
-                       ai-code-backends-infra--file-session-map)
-                      attached)))
+          (should select-called)
+          (should-not displayed)
+          (should-not
+           (gethash
+            (ai-code-backends-infra--file-session-map-key prefix source)
+            ai-code-backends-infra--file-session-map)))
       (dolist (buf (list source attached))
         (when (buffer-live-p buf)
           (kill-buffer buf))))))
@@ -3908,8 +3939,8 @@ The prefix argument should also force instance-name prompting."
       (should (equal (ai-code-backends-infra--session-working-directory)
                      "/git/repo/")))))
 
-(ert-deftest test-ai-code-backends-infra-session-working-directory-returns-project-root ()
-  "Session working directory should return project.el root when available."
+(ert-deftest test-ai-code-backends-infra-session-working-directory-prefers-git-root ()
+  "Session working directory should prefer the Git worktree root."
   (let ((default-directory "/tmp/fallback/"))
     (cl-letf (((symbol-function 'project-current)
                (lambda (&optional _maybe-prompt _dir)
@@ -3918,6 +3949,20 @@ The prefix argument should also force instance-name prompting."
                (lambda (_project) "/projects/myapp/"))
               ((symbol-function 'magit-toplevel)
                (lambda (&optional _dir) "/git/other/")))
+      (should (equal (ai-code-backends-infra--session-working-directory)
+                     (file-name-as-directory
+                      (file-truename "/git/other/")))))))
+
+(ert-deftest test-ai-code-backends-infra-session-working-directory-uses-project-outside-git ()
+  "Session working directory should use project.el outside Git."
+  (let ((default-directory "/tmp/fallback/"))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&optional _maybe-prompt _dir)
+                 '(transient . "/projects/myapp/")))
+              ((symbol-function 'project-root)
+               (lambda (_project) "/projects/myapp/"))
+              ((symbol-function 'magit-toplevel)
+               (lambda (&optional _dir) nil)))
       (should (equal (ai-code-backends-infra--session-working-directory)
                      "/projects/myapp/")))))
 

--- a/test/test_ai-code-codex-cli.el
+++ b/test/test_ai-code-codex-cli.el
@@ -19,6 +19,151 @@
 (require 'ai-code-codex-cli)
 (require 'ai-code-mcp-agent nil t)
 
+(declare-function ai-code--set-session-project-root "ai-code-utils" (root))
+
+(ert-deftest ai-code-test-codex-cli-reuses-session-across-repo-alias-and-nested-project ()
+  "Reuse one Git worktree session across path aliases and nested projects."
+  (let* ((root (make-temp-file "ai-code-session-repo-" t))
+         (alias-parent (make-temp-file "ai-code-session-alias-" t))
+         (alias-root (expand-file-name "repo" alias-parent))
+         (task-dir (expand-file-name ".ai.code.files" alias-root))
+         (task-file (expand-file-name "task.org" task-dir))
+         (nested-dir (expand-file-name "packages/app" root))
+         (code-file (expand-file-name "main.el" nested-dir))
+         (task-buffer (generate-new-buffer " *ai-code-task-source*"))
+         (code-buffer (generate-new-buffer " *ai-code-code-source*"))
+         (session-buffer (generate-new-buffer " *ai-code-session-target*"))
+         (ai-code-codex-cli--processes (make-hash-table :test #'equal))
+         process
+         sent-from)
+    (unwind-protect
+        (progn
+          (should (zerop (process-file "git" nil nil nil "-C" root "init" "--quiet")))
+          (make-symbolic-link root alias-root)
+          (make-directory task-dir t)
+          (make-directory nested-dir t)
+          (with-temp-file task-file (insert "* Task\n"))
+          (with-temp-file code-file (insert ";;; main.el\n"))
+          (with-current-buffer task-buffer
+            (setq buffer-file-name task-file
+                  default-directory task-dir))
+          (with-current-buffer code-buffer
+            (setq buffer-file-name code-file
+                  default-directory nested-dir))
+          (setq process (start-process "ai-code-session-test" session-buffer "cat"))
+          (cl-letf (((symbol-function 'magit-toplevel)
+                     (lambda (&optional dir)
+                       (car (process-lines
+                             "git" "-C" (or dir default-directory)
+                             "rev-parse" "--show-toplevel"))))
+                    ((symbol-function 'project-current)
+                     (lambda (&optional _maybe-prompt dir)
+                       (cons 'test-project
+                             (if (file-in-directory-p
+                                  (expand-file-name (or dir default-directory))
+                                  nested-dir)
+                                 nested-dir
+                               alias-root))))
+                    ((symbol-function 'project-root) #'cdr)
+                    ((symbol-function 'ai-code-mcp-agent-prepare-launch)
+                     (lambda (_backend _working-dir argv)
+                       (list :argv argv)))
+                    ((symbol-function 'ai-code-backends-infra--create-terminal-session)
+                     (lambda (buffer-name working-dir _command _env-vars)
+                       (with-current-buffer session-buffer
+                         (rename-buffer buffer-name t)
+                         (setq-local ai-code-backends-infra--session-directory
+                                     (ai-code-backends-infra--normalize-session-directory
+                                      working-dir)))
+                       (cons session-buffer process)))
+                    ((symbol-function 'ai-code-backends-infra--configure-session-buffer)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'ai-code-backends-infra--display-buffer-in-side-window)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'ai-code-backends-infra--terminal-send-string)
+                     (lambda (_line &optional _paste)
+                       (setq sent-from (current-buffer))))
+                    ((symbol-function 'ai-code-backends-infra--terminal-send-return)
+                     (lambda () nil))
+                    ((symbol-function 'sleep-for) (lambda (&rest _args) nil))
+                    ((symbol-function 'sit-for) (lambda (&rest _args) nil)))
+            (with-current-buffer task-buffer
+              (ai-code-codex-cli))
+            (with-current-buffer code-buffer
+              (ai-code-codex-cli-send-command "Explain this file"))
+            (should (eq sent-from session-buffer))))
+      (when (and process (process-live-p process))
+        (delete-process process))
+      (dolist (buffer (list task-buffer code-buffer session-buffer))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer)))
+      (ignore-errors (delete-directory alias-parent t))
+      (ignore-errors (delete-directory root t)))))
+
+(ert-deftest ai-code-test-codex-cli-keeps-shared-task-attachments-worktree-local ()
+  "Keep public session switching local when worktrees share one task file."
+  (let* ((main-root (make-temp-file "ai-code-main-worktree-" t))
+         (linked-root (make-temp-file "ai-code-linked-worktree-" t))
+         (shared-file (expand-file-name "shared-task.org" main-root))
+         (main-source (generate-new-buffer " *ai-code-main-task*"))
+         (linked-source (generate-new-buffer " *ai-code-linked-task*"))
+         (main-session (generate-new-buffer "*codex[main:default]*"))
+         (linked-session (generate-new-buffer "*codex[linked:default]*"))
+         displayed)
+    (unwind-protect
+        (progn
+          (clrhash ai-code-backends-infra--directory-buffer-map)
+          (clrhash ai-code-backends-infra--file-session-map)
+          (with-temp-file shared-file (insert "* Shared task\n"))
+          (dolist (source (list main-source linked-source))
+            (with-current-buffer source
+              (setq buffer-file-name shared-file)))
+          (with-current-buffer main-source
+            (setq default-directory main-root)
+            (ai-code--set-session-project-root main-root))
+          (with-current-buffer linked-source
+            (setq default-directory linked-root)
+            (ai-code--set-session-project-root linked-root))
+          (with-current-buffer main-session
+            (setq-local ai-code-backends-infra--session-directory
+                        (ai-code-backends-infra--normalize-session-directory
+                         main-root)))
+          (ai-code-backends-infra--remember-file-session-buffer
+           "codex" main-source main-session)
+          (cl-letf (((symbol-function 'get-buffer-window)
+                     (lambda (&rest _args) nil))
+                    ((symbol-function 'ai-code-backends-infra--display-buffer-in-side-window)
+                     (lambda (buffer)
+                       (push buffer displayed))))
+            (with-current-buffer linked-source
+              (should-error (ai-code-codex-cli-switch-to-buffer)
+                            :type 'user-error))
+            (with-current-buffer linked-session
+              (setq-local ai-code-backends-infra--session-directory
+                          (ai-code-backends-infra--normalize-session-directory
+                           linked-root)))
+            (ai-code-backends-infra--remember-file-session-buffer
+             "codex" linked-source linked-session)
+            (should-not
+             (equal
+              (ai-code-backends-infra--file-session-map-key
+               "codex" main-source)
+              (ai-code-backends-infra--file-session-map-key
+               "codex" linked-source)))
+            (with-current-buffer main-source
+              (ai-code-codex-cli-switch-to-buffer))
+            (with-current-buffer linked-source
+              (ai-code-codex-cli-switch-to-buffer)))
+          (should (equal (nreverse displayed)
+                         (list main-session linked-session))))
+      (clrhash ai-code-backends-infra--directory-buffer-map)
+      (clrhash ai-code-backends-infra--file-session-map)
+      (dolist (buffer (list main-source linked-source main-session linked-session))
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer)))
+      (ignore-errors (delete-directory linked-root t))
+      (ignore-errors (delete-directory main-root t)))))
+
 (ert-deftest ai-code-test-codex-cli-start-injects-session-mcp-config ()
   "Starting Codex should inject an Emacs MCP server URL and lifecycle hooks."
   (should (fboundp 'ai-code-codex-cli))

--- a/test/test_ai-code-file.el
+++ b/test/test_ai-code-file.el
@@ -926,8 +926,8 @@ everything is cleaned up afterward."
 
 ;;; --- ai-code--session-project-root tests ---
 
-(ert-deftest test-ai-code-session-project-root-prefers-project-el ()
-  "Should return project.el root when available."
+(ert-deftest test-ai-code-session-project-root-prefers-git-root ()
+  "Should return Git root when project.el reports a nested root."
   (let ((default-directory "/tmp/fallback/"))
     (cl-letf (((symbol-function 'project-current)
                (lambda (&optional _maybe-prompt _dir)
@@ -937,7 +937,7 @@ everything is cleaned up afterward."
               ((symbol-function 'magit-toplevel)
                (lambda (&optional _dir) "/git/bar/")))
       (should (equal (ai-code--session-project-root)
-                     "/projects/foo/")))))
+                     "/git/bar/")))))
 
 (ert-deftest test-ai-code-session-project-root-falls-back-to-git-root ()
   "Should fall back to git root when project.el returns nil."

--- a/test/test_ai-code-git.el
+++ b/test/test_ai-code-git.el
@@ -10,6 +10,7 @@
 
 (require 'ert)
 (require 'ai-code-git)
+(require 'ai-code-codex-cli)
 (require 'ai-code-prompt-mode)
 
 (declare-function difftastic-magit-diff "difftastic" ())
@@ -17,7 +18,7 @@
 
 (ert-deftest ai-code-test-ai-code-git-does-not-eagerly-load-github-module ()
   "Loading `ai-code-git' should not eagerly load `ai-code-github'."
-  (let ((git-library (locate-library "ai-code-git"))
+  (let ((git-library (locate-library "ai-code-git.el"))
         (github-library (locate-library "ai-code-github")))
     (unwind-protect
         (progn
@@ -324,7 +325,8 @@ other-file"))
          (worktree-path (expand-file-name branch repo-dir))
          (files-dir (expand-file-name ai-code-files-dir-name temp-git-root))
          (dired-called nil)
-         (find-file-called-with nil))
+         (find-file-called-with nil)
+         (opened-buffer (generate-new-buffer " *ai-code-worktree-task*")))
     (make-directory files-dir t)
     (unwind-protect
         (cl-letf (((symbol-function 'ai-code--validate-git-repository)
@@ -353,7 +355,9 @@ other-file"))
                   ((symbol-function 'ai-code-current-backend-label)
                    (lambda () "Codex"))
                   ((symbol-function 'find-file-other-window)
-                   (lambda (file) (setq find-file-called-with file)))
+                   (lambda (file)
+                     (setq find-file-called-with file)
+                     opened-buffer))
                   ((symbol-function 'ai-code--generate-task-filename)
                    (lambda (_name) "task-link-test"))
                   ((symbol-function 'save-buffer)
@@ -367,11 +371,75 @@ other-file"))
             (let ((symlink-path (expand-file-name "task-link-test.org" worktree-path)))
               (should (file-symlink-p symlink-path))
               (should (string= (file-truename symlink-path)
-                               (file-truename task-file))))
-            ;; Task file should be opened
-            (should find-file-called-with)))
+                               (file-truename task-file)))
+              ;; The worktree-specific link should be opened.
+              (should (equal find-file-called-with symlink-path)))))
+      (when (buffer-live-p opened-buffer)
+        (kill-buffer opened-buffer))
       (delete-directory temp-worktree-root t)
       (delete-directory temp-git-root t))))
+
+(ert-deftest ai-code-test-git-worktree-task-starts-session-in-worktree ()
+  "Start the public backend in the worktree that owns a shared task link."
+  (let* ((git-root (make-temp-file "ai-code-real-git-root-" t))
+         (temp-worktree-root (make-temp-file "ai-code-real-worktree-root-" t))
+         (ai-code-git-worktree-root temp-worktree-root)
+         (branch "feature/session-context")
+         (repo-dir (ai-code--git-worktree-repo-dir git-root))
+         (worktree-path (expand-file-name branch repo-dir))
+         (task-link (expand-file-name "worktree-task.org" worktree-path))
+         task-buffer
+         captured-working-dir)
+    (unwind-protect
+        (progn
+          (should (zerop (process-file "git" nil nil nil "-C" git-root
+                                       "init" "--quiet")))
+          (should (zerop (process-file "git" nil nil nil "-C" git-root
+                                       "config" "user.email" "test@example.com")))
+          (should (zerop (process-file "git" nil nil nil "-C" git-root
+                                       "config" "user.name" "AI Code Test")))
+          (with-temp-file (expand-file-name "README.md" git-root)
+            (insert "# Test repository\n"))
+          (should (zerop (process-file "git" nil nil nil "-C" git-root
+                                       "add" "README.md")))
+          (should (zerop (process-file "git" nil nil nil "-C" git-root
+                                       "commit" "--quiet" "-m" "Initial commit")))
+          (let ((default-directory git-root)
+                (answers '("Worktree task" "worktree-task.org")))
+            (cl-letf (((symbol-function 'dired) (lambda (_directory) nil))
+                      ((symbol-function 'y-or-n-p) (lambda (_prompt) t))
+                      ((symbol-function 'ai-code--validate-git-repository)
+                       (lambda () git-root))
+                      ((symbol-function 'magit-branch-p) (lambda (_branch) nil))
+                      ((symbol-function 'magit-call-git)
+                       (lambda (&rest args)
+                         (apply #'process-file
+                                "git" nil nil nil
+                                (append (list "-C" git-root) args))))
+                      ((symbol-function 'ai-code-read-string)
+                       (lambda (&rest _args) (pop answers))))
+              (ai-code-git-worktree-branch branch "HEAD")
+              (setq task-buffer (find-buffer-visiting task-link))))
+          (should (file-symlink-p task-link))
+          (should (buffer-live-p task-buffer))
+          (cl-letf (((symbol-function 'ai-code-mcp-agent-prepare-launch)
+                     (lambda (_backend _working-dir argv) (list :argv argv)))
+                    ((symbol-function 'ai-code-backends-infra--toggle-or-create-session)
+                     (lambda (working-dir &rest _args)
+                       (setq captured-working-dir working-dir))))
+            (with-current-buffer task-buffer
+              (ai-code-codex-cli)))
+          (should (equal (file-name-as-directory (file-truename worktree-path))
+                         (file-name-as-directory
+                          (file-truename captured-working-dir)))))
+      (when (buffer-live-p task-buffer)
+        (kill-buffer task-buffer))
+      (when (file-directory-p worktree-path)
+        (ignore-errors
+          (process-file "git" nil nil nil "-C" git-root
+                        "worktree" "remove" "--force" worktree-path)))
+      (ignore-errors (delete-directory temp-worktree-root t))
+      (ignore-errors (delete-directory git-root t)))))
 
 (ert-deftest ai-code-test-git-worktree-branch-skips-task-when-declined ()
   "After worktree creation, when user declines, no task file is created."

--- a/test/test_ai-code-session.el
+++ b/test/test_ai-code-session.el
@@ -40,6 +40,28 @@
        (when (buffer-live-p buffer)
          (kill-buffer buffer))))))
 
+(ert-deftest ai-code-test-session-register-canonicalizes-repo-root-alias ()
+  "Store one canonical repository identity for a symlinked root."
+  (ai-code-test-session--with-clean-registry
+   (let* ((root (make-temp-file "ai-code-registry-root-" t))
+          (alias-parent (make-temp-file "ai-code-registry-alias-" t))
+          (alias-root (expand-file-name "repo" alias-parent))
+          (buffer (generate-new-buffer " *ai-code-registry-session*")))
+     (unwind-protect
+         (progn
+           (make-symbolic-link root alias-root)
+           (let ((session (ai-code-session-register
+                           :buffer buffer
+                           :backend "codex"
+                           :repo-root alias-root)))
+             (should (equal (ai-code-session-repo-root session)
+                            (file-name-as-directory
+                             (file-truename root))))))
+       (when (buffer-live-p buffer)
+         (kill-buffer buffer))
+       (ignore-errors (delete-directory alias-parent t))
+       (ignore-errors (delete-directory root t))))))
+
 (ert-deftest ai-code-test-session-refresh-populates-branch-status-and-dirty-count ()
   "Refreshing should populate simple git/process metadata."
   (ai-code-test-session--with-clean-registry

--- a/test/test_ai-code-utils.el
+++ b/test/test_ai-code-utils.el
@@ -55,7 +55,7 @@
                    (file-truename "/git/root/")))))
 
 (ert-deftest test-ai-code-utils-session-project-root-cascade ()
-  "session-project-root should cascade: project.el -> git -> default-directory."
+  "session-project-root should cascade: override, Git, project, then default."
   (let ((default-directory "/tmp/fallback/"))
     (cl-letf (((symbol-function 'project-current)
                (lambda (&optional _maybe-prompt _dir) nil))


### PR DESCRIPTION
## Summary

Fix AI coding session association so symlink aliases of the same repository resolve consistently while separate Git worktrees keep independent sessions.

- Prefer the canonical Git worktree root over nested project roots, and normalize process and session-registry keys.
- Bind task-file symlink buffers to the active worktree, scope file attachments by workspace, and reject sessions recorded for a different root.
- Add real Git, symlink, and worktree regression coverage, and correct the batch test bootstrap adapter exposed by the full suite.

## Verification

The full ERT suite completed 1,333 tests with 1,320 passes, 13 environment-dependent skips, and zero unexpected results. Byte compilation, checkdoc, diagnostics, and fault-injection checks also passed.