### PR TITLE
Reuse recent shell commands in run prompts

### DIFF
--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -275,10 +275,13 @@ and runs it in a compilation buffer."
 
 (defun ai-code--generate-shell-command (&optional initial-input)
   "Generate shell command from user input or AI assistance.
-Read initial command from user with INITIAL-INPUT as default.
+Read initial command with INITIAL-INPUT as the default, falling back to
+the latest entry in `ai-code-shell-command-history'.
 If command starts with ':', treat as prompt for AI to generate command.
-Return the final command string."
-  (let* ((initial-command (read-string "Shell command: " initial-input
+Record the confirmed AI command in the dedicated history and return it."
+  (let* ((default-command (or initial-input
+                              (car ai-code-shell-command-history)))
+         (initial-command (read-string "Shell command: " default-command
                                        'ai-code-shell-command-history))
          ;; if current buffer is Dired buffer, replace the * character
          ;; inside initial-command with file base name under cursor,
@@ -318,7 +321,14 @@ Return the final command string."
                                          (car (split-string ai-generated "\n" t)))))
                       (when first-line
                         ;; Ask user to confirm/edit the AI-generated command
-                        (read-string "Shell command (AI generated): " (string-trim first-line))))
+                        (let ((confirmed-command
+                               (read-string "Shell command (AI generated): "
+                                            (string-trim first-line))))
+                          (when (and confirmed-command
+                                     (not (string-empty-p confirmed-command)))
+                            (add-to-history 'ai-code-shell-command-history
+                                            confirmed-command))
+                          confirmed-command)))
                   (error
                    (message "Failed to generate command with AI: %s" err)
                    "")))

--- a/test/run_ai_code_file_history_gauntlet.sh
+++ b/test/run_ai_code_file_history_gauntlet.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+task_tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/ai-code-file-history-gauntlet.XXXXXX")
+
+cleanup() {
+  case "$task_tmp_dir" in
+    "${TMPDIR:-/tmp}"/ai-code-file-history-gauntlet.*)
+      rm -rf -- "$task_tmp_dir"
+      ;;
+  esac
+}
+
+trap cleanup EXIT
+
+cd "$repo_root"
+
+emacs --version | sed -n '1p'
+git --version
+perl -e 'printf "perl %vd\n", $^V'
+
+run_focused_tests() {
+  local source_dir=$1
+
+  emacs -Q --batch \
+    --eval "(setq user-emacs-directory \"$task_tmp_dir/emacs.d/\" load-prefer-newer t)" \
+    -L "$source_dir" -L "$repo_root" \
+    -l ert -l "$source_dir/test_ai-code-file.el" \
+    --eval '(ert-run-tests-batch-and-exit "^ai-code-test-run-current-file-or-shell-cmd-")'
+}
+
+run_mutant() {
+  local description=$1
+  local expression=$2
+  local mutant_dir="$task_tmp_dir/mutant"
+
+  rm -rf -- "$mutant_dir"
+  mkdir -p "$mutant_dir"
+  cp ai-code-file.el "$mutant_dir/ai-code-file.el"
+  cp test/test_ai-code-file.el "$mutant_dir/test_ai-code-file.el"
+  perl -0pi -e "$expression" "$mutant_dir/ai-code-file.el"
+
+  if run_focused_tests "$mutant_dir" >/dev/null 2>&1; then
+    echo "Mutation survived: $description" >&2
+    exit 1
+  fi
+  echo "Mutation killed: $description"
+}
+
+cp ai-code-file.el "$task_tmp_dir/ai-code-file.el"
+cp test/test_ai-code-file.el "$task_tmp_dir/test_ai-code-file.el"
+
+run_focused_tests "$task_tmp_dir"
+
+emacs -Q --batch --eval '(setq load-prefer-newer t)' -L . -l ert \
+  --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" \
+  -f ert-run-tests-batch-and-exit
+
+emacs -Q --batch \
+  --eval "(setq user-emacs-directory \"$task_tmp_dir/emacs.d/\" load-prefer-newer t)" \
+  -L test/stubs -L . -L "$task_tmp_dir" \
+  -f batch-byte-compile "$task_tmp_dir/ai-code-file.el"
+
+emacs -Q --batch -L . -l checkdoc \
+  --eval '(progn (checkdoc-file "ai-code-file.el")
+                 (checkdoc-file "test/test_ai-code-file.el"))'
+
+git diff --check
+
+run_mutant "remove dedicated history fallback" \
+  's/\(or initial-input\s+\(car ai-code-shell-command-history\)\)/initial-input/'
+run_mutant "prefer history over explicit region input" \
+  's/\(or initial-input\s+\(car ai-code-shell-command-history\)\)/(or (car ai-code-shell-command-history) initial-input)/'
+run_mutant "skip confirmed AI command history" \
+  "s/\\(add-to-history 'ai-code-shell-command-history/(ignore 'ai-code-shell-command-history/"
+
+echo "AI Code file history gauntlet passed"

--- a/test/test_ai-code-file.el
+++ b/test/test_ai-code-file.el
@@ -44,6 +44,129 @@ everything is cleaned up afterward."
        (when (file-directory-p test-dir)
          (delete-directory test-dir t)))))
 
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-dired-defaults-to-latest-command ()
+  "Test Dired command prompts with the latest dedicated history entry."
+  (let ((major-mode 'dired-mode)
+        (default-directory "/tmp/")
+        (ai-code-shell-command-history '("echo newest"))
+        captured-initial-input
+        captured-history)
+    (cl-letf (((symbol-function 'dired-current-directory)
+               (lambda () default-directory))
+              ((symbol-function 'read-string)
+               (lambda (_prompt &optional initial-input history &rest _args)
+                 (setq captured-initial-input initial-input
+                       captured-history history)
+                 "echo fallback"))
+              ((symbol-function 'compilation-start)
+               (lambda (&rest _args) nil)))
+      (ai-code-run-current-file-or-shell-cmd)
+      (should (eq captured-history 'ai-code-shell-command-history))
+      (should (equal captured-initial-input "echo newest")))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-region-overrides-history ()
+  "Test an active region takes precedence over shell command history."
+  (let ((ai-code-shell-command-history '("echo history"))
+        (transient-mark-mode t)
+        captured-initial-input)
+    (with-temp-buffer
+      (insert "echo selected")
+      (set-mark (point-min))
+      (goto-char (point-max))
+      (activate-mark)
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional initial-input &rest _args)
+                   (setq captured-initial-input initial-input)
+                   initial-input))
+                ((symbol-function 'compilation-start)
+                 (lambda (&rest _args) nil)))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (equal captured-initial-input "echo selected"))))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-shell-defaults-to-latest-command ()
+  "Test shell buffers prompt with the latest dedicated history entry."
+  (let ((ai-code-shell-command-history '("echo newest"))
+        captured-initial-input)
+    (with-temp-buffer
+      (setq major-mode 'shell-mode)
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional initial-input &rest _args)
+                   (setq captured-initial-input initial-input)
+                   initial-input)))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (equal captured-initial-input "echo newest"))
+        (should (equal (buffer-string) "echo newest"))))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-file-reuses-matching-command ()
+  "Test a file reuses its latest matching run command."
+  (let ((ai-code-run-file-history '("pytest current.py -q"))
+        captured-initial-input)
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/current.py")
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional initial-input &rest _args)
+                   (setq captured-initial-input initial-input)
+                   initial-input))
+                ((symbol-function 'ai-code--run-command-in-comint)
+                 (lambda (&rest _args) nil)))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (equal captured-initial-input "pytest current.py -q"))))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-file-ignores-other-file-command ()
+  "Test a file does not default to another file's run command."
+  (let ((ai-code-run-file-history '("pytest other.py -q"))
+        captured-initial-input)
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/current.py")
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional initial-input &rest _args)
+                   (setq captured-initial-input initial-input)
+                   initial-input))
+                ((symbol-function 'ai-code--run-command-in-comint)
+                 (lambda (&rest _args) nil)))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (equal captured-initial-input "python current.py"))))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-remembers-ai-confirmed-command ()
+  "Test the confirmed AI command becomes the latest dedicated history entry."
+  (let ((ai-code-shell-command-history nil)
+        (read-count 0))
+    (with-temp-buffer
+      (setq major-mode 'shell-mode)
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional _initial-input history &rest _args)
+                   (setq read-count (1+ read-count))
+                   (if (= read-count 1)
+                       (progn
+                         (add-to-history history ":list files")
+                         ":list files")
+                     "ls -la")))
+                ((symbol-function 'ai-code-call-gptel-sync)
+                 (lambda (_prompt) "ls -la")))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (equal (buffer-string) "ls -la"))
+        (should (equal (car ai-code-shell-command-history) "ls -la"))))))
+
+(ert-deftest ai-code-test-run-current-file-or-shell-cmd-skips-empty-ai-command-history ()
+  "Test an empty AI confirmation is not added to dedicated history."
+  (let ((ai-code-shell-command-history nil)
+        (read-count 0))
+    (with-temp-buffer
+      (setq major-mode 'shell-mode)
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (_prompt &optional _initial-input history &rest _args)
+                   (setq read-count (1+ read-count))
+                   (if (= read-count 1)
+                       (progn
+                         (add-to-history history ":list files")
+                         ":list files")
+                     "")))
+                ((symbol-function 'ai-code-call-gptel-sync)
+                 (lambda (_prompt) "ls -la")))
+        (ai-code-run-current-file-or-shell-cmd)
+        (should (string-empty-p (buffer-string)))
+        (should (equal ai-code-shell-command-history '(":list files")))))))
+
 ;;; Tests for ai-code--sanitize-generated-path-name
 
 (ert-deftest ai-code-test-sanitize-basic-name ()


### PR DESCRIPTION
Fixes #472.

`ai-code-run-current-file-or-shell-cmd` now uses the most recent dedicated shell-command history entry as the prompt default, while explicit region input still takes precedence and per-file history remains file-aware.

- Record confirmed non-empty AI-generated commands so they become the next default.
- Cover Dired, shell, region, per-file, and AI-generated command behavior with focused ERT tests.
- Add a reproducible history gauntlet for the focused/full suites, byte compilation, checkdoc, diff checks, and mutation checks.

Verification completed before publication: the focused tests passed 7/7, the full ERT suite completed with 1,336 passed and 13 skipped, byte compilation reported no warnings, and all 3 mutation checks were killed.