### PR TITLE
Skip test harnesses for non-code prompts

### DIFF
--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -47,6 +47,26 @@ or nil (prompt the user)."
 
 (defvar ai-code--grill-me-workflow)
 
+(defconst ai-code-github--analysis-only-note
+  "No need to make code change. Provide analysis only."
+  "Prompt note marking a GitHub workflow as analysis without code changes.")
+
+(defconst ai-code-github--resolution-analysis-only-note
+  "Do not make code changes. Provide analysis and resolution suggestions only."
+  "Prompt note marking a resolution workflow as analysis without code changes.")
+
+(defconst ai-code-github--pr-creation-no-code-change-note
+  "No need to make code change. Only create the pull request and report its details."
+  "Prompt note marking PR creation as a workflow without code changes.")
+
+(defconst ai-code-github--analysis-only-notes
+  (list ai-code-github--analysis-only-note
+        ai-code-github--resolution-analysis-only-note
+        ai-code-github--pr-creation-no-code-change-note)
+  "Generated prompt notes that mark a GitHub workflow as analysis only.
+Send-time prompt classification treats these as non-code-change markers, so
+editing the note out of a prompt restores normal code-change routing.")
+
 (defun ai-code--extract-url-from-region ()
   "Return the first URL found in the active region, or nil."
   (when (use-region-p)
@@ -121,9 +141,11 @@ Review Steps:
 1. Requirement Fit: Verify the PR implementation against requirements.
 2. Code Quality: Check code quality, security, and performance concerns.
 3. Findings: For each issue include location, issue, fix suggestion, and priority.
+4. %s
 
 Provide an overall assessment at the end."
-            pr-url source-instruction)))
+            pr-url source-instruction
+            ai-code-github--analysis-only-note)))
 
 (defun ai-code--build-send-current-branch-pr-init-prompt
     (review-source current-branch target-branch &optional pr-title)
@@ -153,13 +175,15 @@ PR Creation Steps:
 %s3. Write a concise PR description that sounds like it was written by the author, but do not make it too short.
 4. Keep the description focused on the problem, the approach, and the most important verification, with enough detail for reviewers to understand the change quickly.
 5. Aim for a compact but complete description, roughly a short summary plus 2 to 3 brief supporting paragraphs or bullet points.
-6. Return the final PR URL, the exact PR title, and the exact description that were used."
+6. Return the final PR URL, the exact PR title, and the exact description that were used.
+7. %s"
             current-branch
             target-branch
             source-instruction
             target-branch
             pr-type-instruction
-            title-instruction)))
+            title-instruction
+            ai-code-github--pr-creation-no-code-change-note)))
 
 (defun ai-code--build-pr-feedback-check-init-prompt (review-source pr-url)
   "Build unresolved feedback check prompt for REVIEW-SOURCE with PR-URL."
@@ -173,8 +197,9 @@ Feedback Check Steps:
 1. Find unresolved feedback or unresolved review comments in this PR.
 2. For each unresolved feedback, explain whether it makes sense and why.
 3. If a feedback does not make sense, explain why it may not be necessary.
-4. No need to make code change. Provide analysis only."
-            pr-url source-instruction)))
+4. %s"
+            pr-url source-instruction
+            ai-code-github--analysis-only-note)))
 
 (defun ai-code--build-issue-investigation-init-prompt (review-source issue-url &optional include-context)
   "Build issue investigation prompt for REVIEW-SOURCE with ISSUE-URL.
@@ -190,8 +215,9 @@ Issue Investigation Steps:
 1. Understand the issue description, reproduction details, and expected behavior.
 2. Analyze relevant code in this repository as context and identify likely root causes.
 3. Provide concrete insights on how to fix it, including likely files or areas to change.
-4. No need to make code change. Provide analysis only."
-                  issue-url source-instruction)))
+4. %s"
+                  issue-url source-instruction
+                  ai-code-github--analysis-only-note)))
     (if (and include-context (or buffer-file-name (use-region-p)))
         (let* ((region-text (when (use-region-p)
                               (buffer-substring-no-properties (region-beginning) (region-end))))
@@ -236,8 +262,10 @@ PR Description Steps:
 2. Highlight the most important code changes and user-visible impact.
 3. Add a testing section with relevant verification details.
 4. Format the result as a concise PR description ready to share with reviewers,
-   written in the voice of the author or maintainer."
-            pr-url source-instruction)))
+   written in the voice of the author or maintainer.
+5. %s"
+            pr-url source-instruction
+            ai-code-github--analysis-only-note)))
 
 (defun ai-code--build-pr-ci-check-init-prompt (review-source pr-url)
   "Build a CI check review prompt for REVIEW-SOURCE with PR-URL."
@@ -251,8 +279,9 @@ CI Checks Review Steps:
 1. Review the GitHub CI checks for this pull request.
 2. If there is a failing or error state, inspect the failing checks and relevant details.
 3. Analyze the likely root cause of each failure.
-4. No need to make code change. Provide analysis only."
-            pr-url source-instruction)))
+4. %s"
+            pr-url source-instruction
+            ai-code-github--analysis-only-note)))
 
 (defun ai-code--build-resolve-merge-conflict-init-prompt (review-source pr-url)
   "Build merge conflict resolution prompt for REVIEW-SOURCE with PR-URL."
@@ -268,9 +297,10 @@ Merge Conflict Resolution Steps:
 3. Update the local target branch to the latest remote version.
 4. Attempt to merge the target branch into the current working branch.
 5. If there are merge conflicts, analyze each conflict and provide detailed instructions on how to resolve them, including which files to change and how.
-6. Do not make code changes. Provide analysis and resolution suggestions only.
+6. %s
 7. If there are no merge conflicts, report that the merge would succeed and return a success message."
-            pr-url source-instruction)))
+            pr-url source-instruction
+            ai-code-github--resolution-analysis-only-note)))
 
 (defun ai-code--pull-or-review-url-prompt (review-mode)
   "Return the URL prompt string for REVIEW-MODE."
@@ -278,19 +308,25 @@ Merge Conflict Resolution Steps:
       "GitHub issue URL: "
     "Pull request URL: "))
 
+(defconst ai-code-github--pull-or-review-pr-mode-alist
+  '(("Review the PR" . review-pr)
+    ("Check unresolved feedback" . check-feedback)
+    ("Prepare PR description" . prepare-pr-description)
+    ("Send out PR for current branch" . send-current-branch-pr)
+    ("Review current branch with difftastic"
+     . review-current-branch-with-difftastic)
+    ("Investigate issue" . investigate-issue)
+    ("Review GitHub CI checks" . review-ci-checks)
+    ("Explain code change" . explain-code-change)
+    ("Resolve merge conflict" . resolve-merge-conflict)
+    ("Generate diff file" . generate-diff-file))
+  "Analysis modes offered for a pull request or issue.
+Every mode that builds a send prompt must mark the prompt with one of
+`ai-code-github--analysis-only-notes' unless it really requests code changes.")
+
 (defun ai-code--pull-or-review-pr-mode-choice ()
   "Prompt user to choose analysis mode for a pull request or issue."
-  (let* ((review-mode-alist '(("Review the PR" . review-pr)
-                              ("Check unresolved feedback" . check-feedback)
-                              ("Prepare PR description" . prepare-pr-description)
-                              ("Send out PR for current branch" . send-current-branch-pr)
-                              ("Review current branch with difftastic"
-                               . review-current-branch-with-difftastic)
-                              ("Investigate issue" . investigate-issue)
-                              ("Review GitHub CI checks" . review-ci-checks)
-                              ("Explain code change" . explain-code-change)
-                              ("Resolve merge conflict" . resolve-merge-conflict)
-                              ("Generate diff file" . generate-diff-file)))
+  (let* ((review-mode-alist ai-code-github--pull-or-review-pr-mode-alist)
          (review-mode (completing-read "Select analysis mode (PR or issue): "
                                        review-mode-alist
                                        nil t nil nil "Review the PR")))
@@ -447,10 +483,12 @@ ARG is the optional prefix argument to force including context."
 1. **Requirement Fit** (Top Priority): Verify if the code change fulfills the requirement below. Identify gaps or missing implementations.
 2. **Code Quality**: Check for quality, security, performance, and coding patterns.
 3. **Issues Found**: For each issue: Location, Issue, Solution, Priority (High/Medium/Low)
+4. %s
 
 Provide overall assessment.
 
-**Requirement**: " file-name)))
+**Requirement**: " file-name
+                                  ai-code-github--analysis-only-note)))
         (ai-code--confirm-and-send "Enter review prompt (type requirement at end): " init-prompt))
     ;; For non-diff files, let user choose PR review via MCP/gh CLI.
     (unless ai-code-default-review-source

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -40,7 +40,9 @@
 (defvar ai-code--tdd-run-test-after-each-stage-instruction)
 (defvar ai-code--tdd-test-pattern-instruction)
 (defvar ai-code--tdd-with-refactoring-extension-instruction)
+(defvar ai-code-change--ask-question-note)
 (defvar ai-code-change--generic-note)
+(defvar ai-code-change--question-brief-default-boundaries)
 (defvar ai-code-change--selected-files-note)
 (defvar ai-code-change--selected-region-note)
 (defvar ai-code-discussion--exception-investigation-boundaries)
@@ -406,12 +408,24 @@ test suffixes."
 (defconst ai-code--non-code-change-prompt-markers
   (append
    (ai-code--downcase-strings
-    (list ai-code-discussion--question-only-note
+    (list ai-code-change--ask-question-note
+          ai-code-change--question-brief-default-boundaries
+          ai-code-discussion--question-only-note
           ai-code-discussion--selected-region-note
           ai-code-discussion--exception-investigation-boundaries))
    (ai-code--downcase-strings
     ai-code-discussion--explain-prompt-prefixes))
   "Prompt markers that clearly indicate a non-code-change request.")
+
+(defconst ai-code--non-code-change-workflows
+  '(review-pr
+    check-feedback
+    prepare-pr-description
+    send-current-branch-pr
+    investigate-issue
+    review-ci-checks
+    resolve-merge-conflict)
+  "Known workflows that do not request program code changes.")
 
 (defun ai-code--prompt-contains-any-marker-p (text markers)
   "Return non-nil when any string in MARKERS appears in TEXT."
@@ -427,17 +441,20 @@ Return one of: `code-change`, `non-code-change`, or `unknown`."
      ((ai-code--prompt-contains-any-marker-p text
                                              ai-code--code-change-prompt-markers)
       'code-change)
-     ((ai-code--prompt-contains-any-marker-p text
-                                             ai-code--non-code-change-prompt-markers)
+     ((or (memq ai-code--grill-me-workflow
+                ai-code--non-code-change-workflows)
+          (ai-code--prompt-contains-any-marker-p
+           text ai-code--non-code-change-prompt-markers))
       'non-code-change)
      (t 'unknown))))
 
 (defun ai-code--classify-prompt-code-change (prompt-text)
   "Classify whether PROMPT-TEXT requests a code change.
-Use simple string matching first, then fall back to GPTel."
+Use simple string matching first, then optionally fall back to GPTel."
   (let ((classification
          (ai-code--simple-classify-prompt-code-change prompt-text)))
-    (if (eq classification 'unknown)
+    (if (and (eq classification 'unknown)
+             ai-code-use-gptel-classify-prompt)
         (ai-code--gptel-classify-prompt-code-change prompt-text)
       classification)))
 
@@ -483,13 +500,11 @@ CLASSIFICATION is the optional prompt classification result."
 (defun ai-code--resolve-ask-auto-test-type-for-send (&optional prompt-text classification)
   "Resolve the send-time auto test type for ask-me mode with PROMPT-TEXT.
 CLASSIFICATION is the optional prompt classification result."
-  (if ai-code-use-gptel-classify-prompt
-      (pcase (or classification
-                 (ai-code--classify-prompt-code-change prompt-text))
-        ('code-change (ai-code--read-auto-test-type-choice))
-        ('non-code-change nil)
-        (_ (ai-code--read-auto-test-type-choice)))
-    (ai-code--read-auto-test-type-choice)))
+  (pcase (or classification
+             (ai-code--classify-prompt-code-change prompt-text))
+    ('code-change (ai-code--read-auto-test-type-choice))
+    ('non-code-change nil)
+    (_ (ai-code--read-auto-test-type-choice))))
 
 (defun ai-code--ensure-discussion-follow-up-harness-file ()
   "Write and return the package prompt file path for discussion follow-up."
@@ -522,8 +537,8 @@ CLASSIFICATION is the optional prompt classification result."
   (when (and ai-code-discussion-auto-follow-up-enabled
              ai-code-next-step-suggestion-suffix)
     (let ((classification (or classification
-                              (and ai-code-use-gptel-classify-prompt
-                                   (ai-code--classify-prompt-code-change prompt-text)))))
+                              (ai-code--classify-prompt-code-change
+                               prompt-text))))
       (unless (and (eq classification 'code-change)
                    (not ai-code-discussion-auto-follow-up-on-code-change))
         (and (pcase ai-code-discussion-auto-follow-up-enabled
@@ -541,9 +556,8 @@ CLASSIFICATION is the optional prompt classification result."
 (defun ai-code--classify-prompt-for-send (&optional prompt-text)
   "Return prompt classification for PROMPT-TEXT when needed.
 Send-time routing uses this result for test and discussion follow-up suffixes."
-  (when (and ai-code-use-gptel-classify-prompt
-             (or ai-code-auto-test-type
-                 ai-code-discussion-auto-follow-up-enabled))
+  (when (or ai-code-auto-test-type
+            ai-code-discussion-auto-follow-up-enabled)
     (ai-code--classify-prompt-code-change prompt-text)))
 
 ;;;; Send-Time Routing: Providers and Setters

--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -20,6 +20,7 @@
   (require 'ai-code-backends)
   (require 'ai-code-change)
   (require 'ai-code-discussion)
+  (require 'ai-code-github)
   (require 'ai-code-prompt-mode))
 
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
@@ -49,6 +50,7 @@
 (defvar ai-code-discussion--explain-prompt-prefixes)
 (defvar ai-code-discussion--question-only-note)
 (defvar ai-code-discussion--selected-region-note)
+(defvar ai-code-github--analysis-only-notes)
 (defvar ai-code-mcp-agent-enabled-backends)
 (defvar ai-code-prompt-suffix-functions)
 (defvar ai-code-selected-backend)
@@ -414,18 +416,10 @@ test suffixes."
           ai-code-discussion--selected-region-note
           ai-code-discussion--exception-investigation-boundaries))
    (ai-code--downcase-strings
-    ai-code-discussion--explain-prompt-prefixes))
+    ai-code-discussion--explain-prompt-prefixes)
+   (ai-code--downcase-strings
+    ai-code-github--analysis-only-notes))
   "Prompt markers that clearly indicate a non-code-change request.")
-
-(defconst ai-code--non-code-change-workflows
-  '(review-pr
-    check-feedback
-    prepare-pr-description
-    send-current-branch-pr
-    investigate-issue
-    review-ci-checks
-    resolve-merge-conflict)
-  "Known workflows that do not request program code changes.")
 
 (defun ai-code--prompt-contains-any-marker-p (text markers)
   "Return non-nil when any string in MARKERS appears in TEXT."
@@ -435,16 +429,16 @@ test suffixes."
 
 (defun ai-code--simple-classify-prompt-code-change (prompt-text)
   "Classify PROMPT-TEXT with cheap string matching before GPTel.
+Classification is driven only by PROMPT-TEXT, so editing a generated
+analysis-only prompt into a code-change request reclassifies it.
 Return one of: `code-change`, `non-code-change`, or `unknown`."
   (let ((text (downcase (or prompt-text ""))))
     (cond
      ((ai-code--prompt-contains-any-marker-p text
                                              ai-code--code-change-prompt-markers)
       'code-change)
-     ((or (memq ai-code--grill-me-workflow
-                ai-code--non-code-change-workflows)
-          (ai-code--prompt-contains-any-marker-p
-           text ai-code--non-code-change-prompt-markers))
+     ((ai-code--prompt-contains-any-marker-p
+       text ai-code--non-code-change-prompt-markers)
       'non-code-change)
      (t 'unknown))))
 

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -37,6 +37,8 @@ the terminal backend infrastructure.")
 (declare-function ai-code-cli-switch-to-buffer "ai-code-backends" ())
 (declare-function gptel-request "gptel" (prompt &rest args))
 (declare-function gptel-abort "gptel" (buffer))
+(defvar gptel-use-tools)
+(defvar gptel-tools)
 (declare-function ai-code--git-repo-recent-modified-files "ai-code-git" (base-dir limit))
 (declare-function ai-code--git-ignored-repo-file-p "ai-code-git" (file root))
 (declare-function ai-code--hash-completion-target-file "ai-code-input" (&optional end-pos))
@@ -257,9 +259,36 @@ writable."
     (org-insert-time-stamp (current-time) t t))
   (insert "\n"))
 
+(defun ai-code--gptel-sync-intermediate-response-p (response info)
+  "Return non-nil when RESPONSE with INFO is an intermediate GPTel event.
+Reasoning blocks arrive before the final response, so they must not end
+the wait.  A reported error always ends it, even mid-reasoning."
+  (and (null (plist-get info :error))
+       (consp response)
+       (eq (car response) 'reasoning)))
+
+(defun ai-code--gptel-sync-failure-description (response info)
+  "Return a failure description for RESPONSE and INFO.
+RESPONSE and INFO follow the `gptel-request' callback contract."
+  (let ((gptel-error (plist-get info :error))
+        (status (plist-get info :status)))
+    (cond
+     (gptel-error
+      (if status
+          (format "%s (status: %s)" gptel-error status)
+        (format "%s" gptel-error)))
+     ((eq response 'abort) "Request aborted")
+     ;; A nil response means no response or an unreported error.
+     ((null response)
+      (format "Empty response from GPTel (status: %s)"
+              (or status "unknown")))
+     (t (format "Unexpected GPTel response: %S" response)))))
+
 (defun ai-code-call-gptel-sync (question)
   "Get an answer from gptel synchronously for a given QUESTION.
 This function blocks until a response is received or a timeout occurs.
+GPTel tools are disabled for the request, because this is a background
+query whose answer is consumed by ai-code rather than by the user.
 Only works when gptel package is installed, otherwise shows error message."
   (unless (featurep 'gptel)
     (user-error "GPTel package is required for AI command generation; please install gptel package"))
@@ -277,27 +306,26 @@ Only works when gptel package is installed, otherwise shows error message."
             (temp-buffer (generate-new-buffer " *gptel-sync*")))
         (unwind-protect
             (progn
-              (gptel-request truncated-question
-                             :buffer temp-buffer
-                             :stream nil
-                             :callback (lambda (response info)
-                                         (let ((gptel-error
-                                                (plist-get info :error)))
+              ;; `gptel-request' copies these out of its `:buffer'.  That is a
+              ;; fresh buffer with no local values, so it inherits these
+              ;; bindings and the user's own tools stay out of this query.
+              (let ((gptel-use-tools nil)
+                    (gptel-tools nil))
+                (gptel-request truncated-question
+                               :buffer temp-buffer
+                               :stream nil
+                               :callback (lambda (response info)
                                            (cond
-                                            (gptel-error
-                                             (setq error-info
-                                                   (format "%s" gptel-error)
-                                                   done t))
-                                            ((stringp response)
+                                            ((ai-code--gptel-sync-intermediate-response-p
+                                              response info))
+                                            ((and (stringp response)
+                                                  (null (plist-get info :error)))
                                              (setq answer response
                                                    done t))
-                                            ((eq response 'abort)
-                                             (setq error-info "Request aborted."
-                                                   done t))
-                                            ((and (consp response)
-                                                  (eq (car response) 'reasoning)))
                                             (t
-                                             (setq error-info "Unknown error"
+                                             (setq error-info
+                                                   (ai-code--gptel-sync-failure-description
+                                                    response info)
                                                    done t))))))
               ;; Block until 'done' is true or timeout is reached
               (while (not done)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -281,14 +281,24 @@ Only works when gptel package is installed, otherwise shows error message."
                              :buffer temp-buffer
                              :stream nil
                              :callback (lambda (response info)
-                                         (cond
-                                          ((stringp response)
-                                           (setq answer response))
-                                          ((eq response 'abort)
-                                           (setq error-info "Request aborted."))
-                                          (t
-                                           (setq error-info (or (plist-get info :status) "Unknown error"))))
-                                         (setq done t)))
+                                         (let ((gptel-error
+                                                (plist-get info :error)))
+                                           (cond
+                                            (gptel-error
+                                             (setq error-info
+                                                   (format "%s" gptel-error)
+                                                   done t))
+                                            ((stringp response)
+                                             (setq answer response
+                                                   done t))
+                                            ((eq response 'abort)
+                                             (setq error-info "Request aborted."
+                                                   done t))
+                                            ((and (consp response)
+                                                  (eq (car response) 'reasoning)))
+                                            (t
+                                             (setq error-info "Unknown error"
+                                                   done t))))))
               ;; Block until 'done' is true or timeout is reached
               (while (not done)
                 (when quit-flag

--- a/test/run_ai_code_issue_478_gauntlet.sh
+++ b/test/run_ai_code_issue_478_gauntlet.sh
@@ -52,8 +52,7 @@ run_focused_tests() {
     -l ert \
     -l "$source_dir/ai-code-prompt-mode.el" \
     -l "$source_dir/test_ai-code-prompt-mode.el" \
-    --eval '(ert-run-tests-batch-and-exit
-             "ai-code-test-call-gptel-sync-\\(ignores-reasoning-before-final-response\\|reports-gptel-error-field\\)")' \
+    --eval '(ert-run-tests-batch-and-exit "ai-code-test-call-gptel-sync-")' \
     || return 1
 }
 
@@ -124,5 +123,17 @@ run_mutant "treat reasoning as an unknown response" \
 run_mutant "ignore GPTel callback errors" \
   "ai-code-prompt-mode.el" \
   's/\Q(plist-get info :error)\E/nil/'
+run_mutant "let caller GPTel tools run during a sync request" \
+  "ai-code-prompt-mode.el" \
+  's/\Q(let ((gptel-use-tools nil)\E\s+\Q(gptel-tools nil))\E/(progn/'
+run_mutant "drop the GPTel status from failure descriptions" \
+  "ai-code-prompt-mode.el" \
+  's/\Q(plist-get info :status)\E/nil/'
+run_mutant "let a reasoning block mask a reported error" \
+  "ai-code-prompt-mode.el" \
+  's/\Q(and (null (plist-get info :error))\E\s+\Q(consp response)\E/(and (consp response)/'
+run_mutant "accept a partial string response reported with an error" \
+  "ai-code-prompt-mode.el" \
+  's/\Q((and (stringp response)\E\s+\Q(null (plist-get info :error)))\E/((stringp response)/'
 
 echo "Issue 478 gauntlet passed"

--- a/test/run_ai_code_issue_478_gauntlet.sh
+++ b/test/run_ai_code_issue_478_gauntlet.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+task_tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/ai-code-issue-478-gauntlet.XXXXXX")
+
+cleanup() {
+  case "$task_tmp_dir" in
+    "${TMPDIR:-/tmp}"/ai-code-issue-478-gauntlet.*)
+      rm -rf -- "$task_tmp_dir"
+      ;;
+  esac
+}
+
+trap cleanup EXIT
+
+cd "$repo_root"
+
+emacs --version | sed -n '1p'
+git --version
+perl -e 'printf "perl %vd\n", $^V'
+
+copy_issue_files() {
+  local destination=$1
+
+  cp ai-code-harness.el "$destination/ai-code-harness.el"
+  cp ai-code-prompt-mode.el "$destination/ai-code-prompt-mode.el"
+  cp test/test_ai-code-harness.el "$destination/test_ai-code-harness.el"
+  cp test/test_ai-code-prompt-mode.el "$destination/test_ai-code-prompt-mode.el"
+}
+
+run_focused_tests() {
+  local source_dir=$1
+  local emacs_home="$task_tmp_dir/emacs.d/"
+
+  emacs -Q --batch \
+    --eval "(setq user-emacs-directory \"$emacs_home\" load-prefer-newer t)" \
+    -L test/stubs -L "$source_dir" -L "$repo_root" \
+    -l ert \
+    -l "$source_dir/ai-code-harness.el" \
+    -l "$source_dir/test_ai-code-harness.el" \
+    --eval '(ert-run-tests-batch-and-exit
+             "ai-code-test-\\(github-analysis-workflows-bypass-auto-test-routing\\|resolve-auto-test-type-for-send-\\(question-skips-when-gptel-disabled\\|unknown-asks-without-gptel\\)\\|simple-classifier-treats-todo-question-brief-as-non-code-change\\)")' \
+    || return 1
+
+  emacs -Q --batch \
+    --eval "(setq user-emacs-directory \"$emacs_home\" load-prefer-newer t)" \
+    -L test/stubs -L "$source_dir" -L "$repo_root" \
+    -l ert \
+    -l "$source_dir/ai-code-prompt-mode.el" \
+    -l "$source_dir/test_ai-code-prompt-mode.el" \
+    --eval '(ert-run-tests-batch-and-exit
+             "ai-code-test-call-gptel-sync-\\(ignores-reasoning-before-final-response\\|reports-gptel-error-field\\)")' \
+    || return 1
+}
+
+run_mutant() {
+  local description=$1
+  local target_file=$2
+  local expression=$3
+  local mutant_dir="$task_tmp_dir/mutant"
+
+  rm -rf -- "$mutant_dir"
+  mkdir -p "$mutant_dir"
+  copy_issue_files "$mutant_dir"
+  perl -0pi -e "$expression" "$mutant_dir/$target_file"
+
+  if cmp -s "$target_file" "$mutant_dir/$target_file"; then
+    echo "Mutation did not change source: $description" >&2
+    exit 1
+  fi
+
+  if run_focused_tests "$mutant_dir" >/dev/null 2>&1; then
+    echo "Mutation survived: $description" >&2
+    exit 1
+  fi
+  echo "Mutation killed: $description"
+}
+
+copy_issue_files "$task_tmp_dir"
+
+run_focused_tests "$task_tmp_dir"
+
+emacs -Q --batch --eval '(setq load-prefer-newer t)' -L . -l ert \
+  --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" \
+  -f ert-run-tests-batch-and-exit
+
+emacs -Q --batch \
+  --eval "(setq user-emacs-directory \"$task_tmp_dir/emacs.d/\" load-prefer-newer t)" \
+  -L test/stubs -L "$task_tmp_dir" -L . \
+  -f batch-byte-compile \
+  "$task_tmp_dir/ai-code-prompt-mode.el" \
+  "$task_tmp_dir/ai-code-harness.el"
+
+emacs -Q --batch -L test/stubs -L . -l checkdoc \
+  --eval '(progn (checkdoc-file "ai-code-harness.el")
+                 (checkdoc-file "ai-code-prompt-mode.el")
+                 (checkdoc-file "test/test_ai-code-harness.el")
+                 (checkdoc-file "test/test_ai-code-prompt-mode.el"))'
+
+git diff --check
+
+run_mutant "call GPTel when local fallback is disabled" \
+  "ai-code-harness.el" \
+  's/\Qai-code-use-gptel-classify-prompt)\E/t)/'
+run_mutant "drop TODO question markers" \
+  "ai-code-harness.el" \
+  's/ai-code-change--ask-question-note\s+ai-code-change--question-brief-default-boundaries\s+//'
+run_mutant "ignore GitHub workflow metadata" \
+  "ai-code-harness.el" \
+  's/\Qai-code--non-code-change-workflows)\E/nil)/'
+run_mutant "treat reasoning as an unknown response" \
+  "ai-code-prompt-mode.el" \
+  "s/'reasoning/'never-reasoning/"
+run_mutant "ignore GPTel callback errors" \
+  "ai-code-prompt-mode.el" \
+  's/\Q(plist-get info :error)\E/nil/'
+
+echo "Issue 478 gauntlet passed"

--- a/test/run_ai_code_issue_478_gauntlet.sh
+++ b/test/run_ai_code_issue_478_gauntlet.sh
@@ -26,6 +26,7 @@ copy_issue_files() {
   local destination=$1
 
   cp ai-code-harness.el "$destination/ai-code-harness.el"
+  cp ai-code-github.el "$destination/ai-code-github.el"
   cp ai-code-prompt-mode.el "$destination/ai-code-prompt-mode.el"
   cp test/test_ai-code-harness.el "$destination/test_ai-code-harness.el"
   cp test/test_ai-code-prompt-mode.el "$destination/test_ai-code-prompt-mode.el"
@@ -42,7 +43,7 @@ run_focused_tests() {
     -l "$source_dir/ai-code-harness.el" \
     -l "$source_dir/test_ai-code-harness.el" \
     --eval '(ert-run-tests-batch-and-exit
-             "ai-code-test-\\(github-analysis-workflows-bypass-auto-test-routing\\|resolve-auto-test-type-for-send-\\(question-skips-when-gptel-disabled\\|unknown-asks-without-gptel\\)\\|simple-classifier-treats-todo-question-brief-as-non-code-change\\)")' \
+             "ai-code-test-\\(github-analysis-workflows-bypass-auto-test-routing\\|github-review-modes-all-carry-analysis-only-note\\|github-workflow-classification-follows-edited-prompt-text\\|diff-file-review-prompt-bypasses-auto-test-routing\\|resolve-auto-test-type-for-send-\\(question-skips-when-gptel-disabled\\|unknown-asks-without-gptel\\)\\|simple-classifier-treats-todo-question-brief-as-non-code-change\\)")' \
     || return 1
 
   emacs -Q --batch \
@@ -108,9 +109,15 @@ run_mutant "call GPTel when local fallback is disabled" \
 run_mutant "drop TODO question markers" \
   "ai-code-harness.el" \
   's/ai-code-change--ask-question-note\s+ai-code-change--question-brief-default-boundaries\s+//'
-run_mutant "ignore GitHub workflow metadata" \
+run_mutant "ignore GitHub analysis-only prompt markers" \
   "ai-code-harness.el" \
-  's/\Qai-code--non-code-change-workflows)\E/nil)/'
+  's/\Q(ai-code--downcase-strings\E\s+\Qai-code-github--analysis-only-notes))\E/nil)/'
+run_mutant "drop the analysis-only note from the PR review prompt" \
+  "ai-code-github.el" \
+  's/^4\. %s\n\nProvide an overall assessment at the end\."/\n\nProvide an overall assessment at the end."/m'
+run_mutant "drop the analysis-only note from the diff file review prompt" \
+  "ai-code-github.el" \
+  's/^4\. %s\n\nProvide overall assessment\./\nProvide overall assessment./m'
 run_mutant "treat reasoning as an unknown response" \
   "ai-code-prompt-mode.el" \
   "s/'reasoning/'never-reasoning/"

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -652,6 +652,71 @@
        (ai-code--resolve-auto-test-type-for-send
         "Explain this function\nNote: This is a question only - please do not modify the code.")))))
 
+(ert-deftest ai-code-test-resolve-auto-test-type-for-send-question-skips-when-gptel-disabled ()
+  "Test that local question markers bypass ask-me without GPTel."
+  (let ((ai-code-auto-test-type 'ask-me)
+        (ai-code-use-gptel-classify-prompt nil))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text)
+                 (ert-fail "Should not call GPTel for a local question marker.")))
+              ((symbol-function 'ai-code--read-auto-test-type-choice)
+               (lambda ()
+                 (ert-fail "Should not ask test type for a question."))))
+      (should-not
+       (ai-code--resolve-auto-test-type-for-send
+        "Explain this function\nNote: This is a question only - please do not modify the code.")))))
+
+(ert-deftest ai-code-test-resolve-auto-test-type-for-send-unknown-asks-without-gptel ()
+  "Test that an unknown prompt preserves ask-me when GPTel is disabled."
+  (let ((ai-code-auto-test-type 'ask-me)
+        (ai-code-use-gptel-classify-prompt nil)
+        (choice-count 0))
+    (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+               (lambda (_prompt-text)
+                 (ert-fail "Should not call GPTel when classification is disabled.")))
+              ((symbol-function 'ai-code--read-auto-test-type-choice)
+               (lambda ()
+                 (cl-incf choice-count)
+                 'test-after-change)))
+      (should (eq 'test-after-change
+                  (ai-code--resolve-auto-test-type-for-send
+                   "Take a look at this repository.")))
+      (should (= 1 choice-count)))))
+
+(ert-deftest ai-code-test-simple-classifier-treats-todo-question-brief-as-non-code-change ()
+  "Test that the TODO Ask question brief bypasses code-change routing."
+  (let ((prompt (ai-code--compose-question-brief
+                 :goal "Why does this TODO exist?"
+                 :scope "Current file: ai-code-change.el"
+                 :instruction ai-code-change--ask-question-note)))
+    (should (eq 'non-code-change
+                (ai-code--simple-classify-prompt-code-change prompt)))))
+
+(ert-deftest ai-code-test-github-analysis-workflows-bypass-auto-test-routing ()
+  "Test that GitHub analysis workflows never offer a test harness."
+  (dolist (workflow '(review-pr
+                      check-feedback
+                      prepare-pr-description
+                      send-current-branch-pr
+                      investigate-issue
+                      review-ci-checks
+                      resolve-merge-conflict))
+    (let ((ai-code--grill-me-workflow workflow)
+          (ai-code-auto-test-type 'ask-me)
+          (ai-code-use-gptel-classify-prompt nil))
+      (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
+                 (lambda (_prompt-text)
+                   (ert-fail "Should not call GPTel for a known GitHub workflow.")))
+                ((symbol-function 'ai-code--read-auto-test-type-choice)
+                 (lambda ()
+                   (ert-fail "Should not ask test type for a GitHub analysis workflow."))))
+        (should (eq 'non-code-change
+                    (ai-code--classify-prompt-for-send
+                     "Investigate the linked GitHub item and provide analysis only.")))
+        (should-not
+         (ai-code--resolve-auto-test-type-for-send
+          "Investigate the linked GitHub item and provide analysis only."))))))
+
 (ert-deftest ai-code-test-read-auto-test-type-choice-allow-no-test ()
   "Test that ask choices support selecting no test run."
   (let ((ai-code--auto-test-type-ask-choices
@@ -1072,6 +1137,8 @@
   (should (boundp 'ai-code-change--selected-region-note))
   (should (boundp 'ai-code-change--generic-note))
   (should (boundp 'ai-code-change--selected-files-note))
+  (should (boundp 'ai-code-change--ask-question-note))
+  (should (boundp 'ai-code-change--question-brief-default-boundaries))
   (should (boundp 'ai-code-discussion--question-only-note))
   (should (boundp 'ai-code-discussion--selected-region-note))
   (should (boundp 'ai-code-discussion--exception-investigation-boundaries))
@@ -1084,7 +1151,9 @@
   (should (equal ai-code--non-code-change-prompt-markers
                  (append
                   (mapcar #'downcase
-                          (list ai-code-discussion--question-only-note
+                          (list ai-code-change--ask-question-note
+                                ai-code-change--question-brief-default-boundaries
+                                ai-code-discussion--question-only-note
                                 ai-code-discussion--selected-region-note
                                 ai-code-discussion--exception-investigation-boundaries))
                   (mapcar #'downcase

--- a/test/test_ai-code-harness.el
+++ b/test/test_ai-code-harness.el
@@ -692,30 +692,105 @@
     (should (eq 'non-code-change
                 (ai-code--simple-classify-prompt-code-change prompt)))))
 
+(defconst ai-code-test--github-non-prompt-review-modes
+  '(review-current-branch-with-difftastic
+    generate-diff-file
+    explain-code-change)
+  "Review modes that do not build a GitHub analysis prompt themselves.")
+
+(defun ai-code-test--github-prompt-for-review-mode (review-mode)
+  "Return the generated init prompt for REVIEW-MODE."
+  (cl-letf (((symbol-function 'y-or-n-p) (lambda (&rest _args) nil)))
+    (if (eq review-mode 'send-current-branch-pr)
+        (ai-code--build-send-current-branch-pr-init-prompt
+         'gh-cli "feature" "main")
+      (ai-code--build-pr-init-prompt
+       'gh-cli "https://example.test/pull/1" review-mode))))
+
+(defun ai-code-test--github-analysis-prompts ()
+  "Return one generated prompt per analysis-only GitHub review mode."
+  (mapcar #'ai-code-test--github-prompt-for-review-mode
+          (seq-remove
+           (lambda (review-mode)
+             (memq review-mode ai-code-test--github-non-prompt-review-modes))
+           (mapcar #'cdr ai-code-github--pull-or-review-pr-mode-alist))))
+
+(ert-deftest ai-code-test-github-review-modes-all-carry-analysis-only-note ()
+  "Test that every prompt-building GitHub review mode marks its prompt.
+This guards against drift when a new review mode is added."
+  (dolist (review-mode (mapcar #'cdr ai-code-github--pull-or-review-pr-mode-alist))
+    (unless (memq review-mode ai-code-test--github-non-prompt-review-modes)
+      (let ((prompt (ai-code-test--github-prompt-for-review-mode review-mode)))
+        (should (seq-some (lambda (note) (string-match-p (regexp-quote note) prompt))
+                          ai-code-github--analysis-only-notes))
+        (should (eq 'non-code-change
+                    (ai-code--simple-classify-prompt-code-change prompt)))))))
+
 (ert-deftest ai-code-test-github-analysis-workflows-bypass-auto-test-routing ()
-  "Test that GitHub analysis workflows never offer a test harness."
-  (dolist (workflow '(review-pr
-                      check-feedback
-                      prepare-pr-description
-                      send-current-branch-pr
-                      investigate-issue
-                      review-ci-checks
-                      resolve-merge-conflict))
-    (let ((ai-code--grill-me-workflow workflow)
+  "Test that generated GitHub analysis prompts never offer a test harness."
+  (dolist (prompt (ai-code-test--github-analysis-prompts))
+    (let ((ai-code--grill-me-workflow nil)
           (ai-code-auto-test-type 'ask-me)
           (ai-code-use-gptel-classify-prompt nil))
       (cl-letf (((symbol-function 'ai-code--gptel-classify-prompt-code-change)
                  (lambda (_prompt-text)
-                   (ert-fail "Should not call GPTel for a known GitHub workflow.")))
+                   (ert-fail "Should not call GPTel for a GitHub analysis prompt.")))
                 ((symbol-function 'ai-code--read-auto-test-type-choice)
                  (lambda ()
-                   (ert-fail "Should not ask test type for a GitHub analysis workflow."))))
+                   (ert-fail "Should not ask test type for a GitHub analysis prompt."))))
         (should (eq 'non-code-change
-                    (ai-code--classify-prompt-for-send
-                     "Investigate the linked GitHub item and provide analysis only.")))
-        (should-not
-         (ai-code--resolve-auto-test-type-for-send
-          "Investigate the linked GitHub item and provide analysis only."))))))
+                    (ai-code--classify-prompt-for-send prompt)))
+        (should-not (ai-code--resolve-auto-test-type-for-send prompt))))))
+
+(ert-deftest ai-code-test-github-workflow-classification-follows-edited-prompt-text ()
+  "Test that editing out the analysis-only note restores code-change routing."
+  (let* ((generated
+          (ai-code--build-pr-review-init-prompt 'gh-cli "https://example.test/pull/1"))
+         (edited
+          (replace-regexp-in-string
+           (concat "^4\\. " (regexp-quote ai-code-github--analysis-only-note) "\n")
+           "4. Fix every issue you find and add unit tests for it.\n"
+           generated)))
+    (should-not (string-equal generated edited))
+    ;; The workflow variable stays bound, as it does during `ai-code--confirm-and-send'.
+    (let ((ai-code--grill-me-workflow 'review-pr)
+          (ai-code-auto-test-type 'ask-me)
+          (ai-code-use-gptel-classify-prompt nil))
+      (should (eq 'unknown
+                  (ai-code--simple-classify-prompt-code-change edited)))
+      (cl-letf (((symbol-function 'ai-code--read-auto-test-type-choice)
+                 (lambda () 'test-after-change)))
+        (should (eq 'test-after-change
+                    (ai-code--resolve-auto-test-type-for-send edited)))))))
+
+(ert-deftest ai-code-test-diff-file-review-prompt-bypasses-auto-test-routing ()
+  "Test that the .diff review prompt is classified as analysis only."
+  (let ((ai-code-default-review-source 'github-mcp)
+        (ai-code-auto-test-type 'ask-me)
+        (ai-code-use-gptel-classify-prompt nil)
+        (ai-code-grill-me-enabled nil)
+        (ai-code-prompt-preprocess-filepaths nil)
+        (captured-prompt nil))
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/ai-code-test-review.diff")
+      (unwind-protect
+          (cl-letf (((symbol-function 'ai-code-read-string)
+                     (lambda (_prompt &optional initial-input &rest _args)
+                       initial-input))
+                    ((symbol-function 'read-string)
+                     (lambda (_prompt &optional initial-input &rest _args)
+                       initial-input))
+                    ((symbol-function 'ai-code--insert-prompt)
+                     (lambda (prompt) (setq captured-prompt prompt))))
+            (ai-code-pull-or-review-diff-file))
+        (setq buffer-file-name nil)))
+    (should captured-prompt)
+    (cl-letf (((symbol-function 'ai-code--read-auto-test-type-choice)
+               (lambda ()
+                 (ert-fail "Should not ask test type for a diff review prompt."))))
+      (should (eq 'non-code-change
+                  (ai-code--simple-classify-prompt-code-change captured-prompt)))
+      (should-not (ai-code--resolve-auto-test-type-for-send captured-prompt)))))
 
 (ert-deftest ai-code-test-read-auto-test-type-choice-allow-no-test ()
   "Test that ask choices support selecting no test run."
@@ -1143,6 +1218,7 @@
   (should (boundp 'ai-code-discussion--selected-region-note))
   (should (boundp 'ai-code-discussion--exception-investigation-boundaries))
   (should (boundp 'ai-code-discussion--explain-prompt-prefixes))
+  (should (boundp 'ai-code-github--analysis-only-notes))
   (should (equal ai-code--code-change-prompt-markers
                  (mapcar #'downcase
                          (list ai-code-change--selected-region-note
@@ -1157,7 +1233,9 @@
                                 ai-code-discussion--selected-region-note
                                 ai-code-discussion--exception-investigation-boundaries))
                   (mapcar #'downcase
-                          ai-code-discussion--explain-prompt-prefixes)))))
+                          ai-code-discussion--explain-prompt-prefixes)
+                  (mapcar #'downcase
+                          ai-code-github--analysis-only-notes)))))
 
 (ert-deftest ai-code-test-simple-classifier-treats-exception-investigation-as-non-code-change ()
   "Test that exception investigation prompts skip code-change routing."

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -23,6 +23,10 @@
 (defvar ai-code-discussion-auto-follow-up-suffix)
 (defvar ai-code-use-prompt-suffix)
 (defvar org-roam-directory)
+;; Declared special so `let' binds them dynamically here, the way gptel's own
+;; defcustoms do when gptel is loaded.
+(defvar gptel-use-tools)
+(defvar gptel-tools)
 
 (ert-deftest ai-code-test-send-prompt-refreshes-mcp-source-before-terminal-io ()
   "Sending a prompt should snapshot its source before terminal output."
@@ -109,50 +113,127 @@
           nil))))
     (should (= calls 1))))
 
+(defmacro ai-code-test-with-stub-gptel (request-fn &rest body)
+  "Evaluate BODY with `gptel-request' stubbed by REQUEST-FN.
+GPTel is reported as available and blocking helpers are neutralized."
+  (declare (indent 1))
+  `(let ((ai-code-gptel-sync-timeout 1)
+         (original-featurep (symbol-function 'featurep)))
+     (cl-letf (((symbol-function 'featurep)
+                (lambda (feature)
+                  (or (eq feature 'gptel)
+                      (funcall original-featurep feature))))
+               ((symbol-function 'gptel-request) ,request-fn)
+               ((symbol-function 'gptel-abort) #'ignore)
+               ((symbol-function 'sit-for) #'ignore))
+       ,@body)))
+
+(defun ai-code-test--gptel-sync-error-message (question)
+  "Return the error message raised by `ai-code-call-gptel-sync' for QUESTION."
+  (condition-case err
+      (progn (ai-code-call-gptel-sync question) nil)
+    (error (error-message-string err))))
+
 (ert-deftest ai-code-test-call-gptel-sync-ignores-reasoning-before-final-response ()
   "A reasoning callback should not complete a synchronous GPTel request."
-  (let ((ai-code-gptel-sync-timeout 1)
-        (original-featurep (symbol-function 'featurep)))
-    (cl-letf (((symbol-function 'featurep)
-               (lambda (feature)
-                 (or (eq feature 'gptel)
-                     (funcall original-featurep feature))))
-              ((symbol-function 'gptel-request)
-               (lambda (_question &rest args)
-                 (let ((callback (plist-get args :callback)))
-                   (funcall callback '(reasoning . "")
-                            '(:status "HTTP/2 200" :error nil))
-                   (funcall callback "NOT_CODE_CHANGE"
-                            '(:status "HTTP/2 200" :error nil)))))
-              ((symbol-function 'gptel-abort)
-               (lambda (&rest _args)
-                 (ert-fail "A completed request should not be aborted.")))
-              ((symbol-function 'sit-for) #'ignore))
-      (should (equal "NOT_CODE_CHANGE"
-                     (ai-code-call-gptel-sync "Classify this prompt"))))))
+  (let ((aborted nil))
+    (ai-code-test-with-stub-gptel
+        (lambda (_question &rest args)
+          (let ((callback (plist-get args :callback)))
+            (funcall callback '(reasoning . "")
+                     '(:status "HTTP/2 200" :error nil))
+            (funcall callback '(reasoning . "more thinking")
+                     '(:status "HTTP/2 200" :error nil))
+            (funcall callback "NOT_CODE_CHANGE"
+                     '(:status "HTTP/2 200" :error nil))))
+      (cl-letf (((symbol-function 'gptel-abort)
+                 (lambda (&rest _args) (setq aborted t))))
+        (should (equal "NOT_CODE_CHANGE"
+                       (ai-code-call-gptel-sync "Classify this prompt")))))
+    (should-not aborted)))
+
+(ert-deftest ai-code-test-call-gptel-sync-disables-tools-for-the-request ()
+  "The synchronous request must not let the caller's GPTel tools run.
+A background classification or headline request should never execute
+tools on the user's machine, so tool use is suppressed for the request."
+  (let ((gptel-use-tools t)
+        (gptel-tools '(placeholder))
+        (tools-enabled 'unset))
+    (ai-code-test-with-stub-gptel
+        (lambda (_question &rest args)
+          (setq tools-enabled (and gptel-use-tools gptel-tools t))
+          (funcall (plist-get args :callback)
+                   "NO_TOOLS" '(:status "HTTP/2 200" :error nil)))
+      (should (equal "NO_TOOLS" (ai-code-call-gptel-sync "Classify this prompt"))))
+    (should-not tools-enabled)
+    ;; The caller's configuration must be restored afterwards.
+    (should gptel-use-tools)
+    (should (equal gptel-tools '(placeholder)))))
+
+(ert-deftest ai-code-test-call-gptel-sync-reports-abort ()
+  "An aborted synchronous GPTel request should report the abort."
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 'abort '(:status "abort" :error nil)))
+    (let ((error-message
+           (ai-code-test--gptel-sync-error-message "Abort this prompt")))
+      (should (string-match-p "aborted" error-message)))))
+
+(ert-deftest ai-code-test-call-gptel-sync-reports-empty-response-with-status ()
+  "A nil response without an error field should report GPTel's status."
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 nil '(:status "HTTP/2 200" :error nil)))
+    (let ((error-message
+           (ai-code-test--gptel-sync-error-message "Empty this prompt")))
+      (should (string-match-p "HTTP/2 200" error-message)))))
 
 (ert-deftest ai-code-test-call-gptel-sync-reports-gptel-error-field ()
   "A failed synchronous GPTel request should report INFO's error field."
-  (let ((ai-code-gptel-sync-timeout 1)
-        (original-featurep (symbol-function 'featurep)))
-    (cl-letf (((symbol-function 'featurep)
-               (lambda (feature)
-                 (or (eq feature 'gptel)
-                     (funcall original-featurep feature))))
-              ((symbol-function 'gptel-request)
-               (lambda (_question &rest args)
-                 (funcall (plist-get args :callback)
-                          nil
-                          '(:status "HTTP/2 500" :error "Backend failed"))))
-              ((symbol-function 'gptel-abort) #'ignore)
-              ((symbol-function 'sit-for) #'ignore))
-      (let ((error-message
-             (condition-case err
-                 (progn
-                   (ai-code-call-gptel-sync "Fail this prompt")
-                   nil)
-               (error (error-message-string err)))))
-        (should (string-match-p "Backend failed" error-message))))))
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 nil
+                 '(:status "HTTP/2 500" :error "Backend failed")))
+    (should (string-match-p
+             "Backend failed"
+             (ai-code-test--gptel-sync-error-message "Fail this prompt")))))
+
+(ert-deftest ai-code-test-call-gptel-sync-error-includes-gptel-status ()
+  "A failed request should surface INFO's status alongside the error."
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 nil
+                 '(:status "HTTP/2 429" :error "Rate limited")))
+    (let ((error-message
+           (ai-code-test--gptel-sync-error-message "Throttle this prompt")))
+      (should (string-match-p "Rate limited" error-message))
+      (should (string-match-p "HTTP/2 429" error-message)))))
+
+(ert-deftest ai-code-test-call-gptel-sync-reports-error-arriving-with-reasoning ()
+  "An error reported alongside a reasoning block must end the request."
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 '(reasoning . "partial thought")
+                 '(:status "HTTP/2 500" :error "Backend died mid-stream")))
+    (should (string-match-p
+             "Backend died mid-stream"
+             (ai-code-test--gptel-sync-error-message "Break this prompt")))))
+
+(ert-deftest ai-code-test-call-gptel-sync-rejects-string-response-with-error ()
+  "A string response reported with an error must not be treated as an answer."
+  (ai-code-test-with-stub-gptel
+      (lambda (_question &rest args)
+        (funcall (plist-get args :callback)
+                 "partial output"
+                 '(:status "HTTP/2 500" :error "Truncated")))
+    (should (string-match-p
+             "Truncated"
+             (ai-code-test--gptel-sync-error-message "Truncate this prompt")))))
 
 (ert-deftest ai-code-test-custom-prompt-suffix-provider-respects-switch ()
   "The custom suffix provider should honor the legacy suffix switch."

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -109,6 +109,51 @@
           nil))))
     (should (= calls 1))))
 
+(ert-deftest ai-code-test-call-gptel-sync-ignores-reasoning-before-final-response ()
+  "A reasoning callback should not complete a synchronous GPTel request."
+  (let ((ai-code-gptel-sync-timeout 1)
+        (original-featurep (symbol-function 'featurep)))
+    (cl-letf (((symbol-function 'featurep)
+               (lambda (feature)
+                 (or (eq feature 'gptel)
+                     (funcall original-featurep feature))))
+              ((symbol-function 'gptel-request)
+               (lambda (_question &rest args)
+                 (let ((callback (plist-get args :callback)))
+                   (funcall callback '(reasoning . "")
+                            '(:status "HTTP/2 200" :error nil))
+                   (funcall callback "NOT_CODE_CHANGE"
+                            '(:status "HTTP/2 200" :error nil)))))
+              ((symbol-function 'gptel-abort)
+               (lambda (&rest _args)
+                 (ert-fail "A completed request should not be aborted.")))
+              ((symbol-function 'sit-for) #'ignore))
+      (should (equal "NOT_CODE_CHANGE"
+                     (ai-code-call-gptel-sync "Classify this prompt"))))))
+
+(ert-deftest ai-code-test-call-gptel-sync-reports-gptel-error-field ()
+  "A failed synchronous GPTel request should report INFO's error field."
+  (let ((ai-code-gptel-sync-timeout 1)
+        (original-featurep (symbol-function 'featurep)))
+    (cl-letf (((symbol-function 'featurep)
+               (lambda (feature)
+                 (or (eq feature 'gptel)
+                     (funcall original-featurep feature))))
+              ((symbol-function 'gptel-request)
+               (lambda (_question &rest args)
+                 (funcall (plist-get args :callback)
+                          nil
+                          '(:status "HTTP/2 500" :error "Backend failed"))))
+              ((symbol-function 'gptel-abort) #'ignore)
+              ((symbol-function 'sit-for) #'ignore))
+      (let ((error-message
+             (condition-case err
+                 (progn
+                   (ai-code-call-gptel-sync "Fail this prompt")
+                   nil)
+               (error (error-message-string err)))))
+        (should (string-match-p "Backend failed" error-message))))))
+
 (ert-deftest ai-code-test-custom-prompt-suffix-provider-respects-switch ()
   "The custom suffix provider should honor the legacy suffix switch."
   (let ((ai-code-prompt-suffix-functions


### PR DESCRIPTION
Fixes #478.

This prevents ask-me test harnesses from being offered for prompts that clearly request analysis or an answer without code changes. Deterministic local classification now always runs, while GPTel is used only as an optional fallback for genuinely unknown prompts.

The routing recognizes TODO question briefs and GitHub review/investigation workflows. It also handles GPTel reasoning callbacks as intermediate events and reports callback errors from `info :error`, avoiding the misleading `HTTP/2 200` failure.

Verification:
- `test/run_ai_code_issue_478_gauntlet.sh`
- 1,355 ERT tests: 1,342 passed, 13 environment-dependent skips, 0 failures
- Byte compilation and checkdoc completed without warnings; all five targeted mutations were killed