### PR TITLE
Add Tree-sitter semantic scope and structural context extraction

### DIFF
--- a/README.org
+++ b/README.org
@@ -219,7 +219,23 @@ Context engineering is the deliberate practice of selecting, structuring, and de
 This package makes context engineering easy by automatically assembling precise context blocks and letting you curate additional context on demand:
 - Automatic file and window context: prompts can include the current file and other visible files (`ai-code--get-context-files-string`), so the AI sees related code without manual copying.
 - Function or region scoping: most actions capture the current function or active region, keeping requests focused (e.g., `ai-code-code-change`, `ai-code-implement-todo`, `ai-code-ask-question`).
-- Manual context curation: `C-c a @` (`ai-code-context-action`) stores file paths, function anchors, or region ranges in a repo-scoped list, which is appended to prompts via `ai-code--format-repo-context-info`. In a Dired buffer, `C-c a @` (`ai-code-context-action`) can store the marked files or directories as repo context; if nothing is explicitly marked, it falls back to the file or directory at point.
+- Tree-sitter semantic scope: when the current buffer has an active Tree-sitter parser, prompts carry structural context derived from the real syntax tree instead of just a function name. A prompt for a method now includes its enclosing type, both declaration headers, and the function's line range:
+
+  #+begin_example
+  Enclosing class: UserService
+  Class definition: class UserService(BaseService):
+  Function: find_user
+  Function definition: def find_user(self, user_id: int) -> str:
+  Function range: lines 2-4
+  #+end_example
+
+  Details worth knowing:
+  - The enclosing container is grammar-driven, so it covers classes, structs, `impl` and `trait` blocks, interfaces, objects, records, and enums across languages, not only Python-style classes.
+  - Headers are taken from the declaration node, so multi-line signatures are preserved in full while bodies, docstrings, and comments that the grammar attaches to the body are excluded.
+  - A region spanning sibling functions does not claim to be inside either one; it collapses to their common container, emitting only `Enclosing class:` and `Class definition:`.
+  - Indented definition lines resolve to the definition itself rather than to an enclosing node, so placing the cursor on a `def` line reports that method.
+  - Without an active Tree-sitter grammar, the same actions fall back to `which-function`, so behavior degrades to the previous function-name-only context rather than breaking.
+- Manual context curation: `C-c a @` (`ai-code-context-action`) stores file paths, function anchors, or region ranges in a repo-scoped list, which is appended to prompts via `ai-code--format-repo-context-info`. Function anchors are qualified with their enclosing type when Tree-sitter can resolve one, so a stored method reads `src/service.py#UserService.find_user` instead of the ambiguous `src/service.py#find_user`; with the cursor outside any function the anchor falls back to the container alone (`src/service.py#UserService`). In a Dired buffer, `C-c a @` (`ai-code-context-action`) can store the marked files or directories as repo context; if nothing is explicitly marked, it falls back to the file or directory at point.
 - Optional clipboard context: prefix with `C-u` to append clipboard content to prompts for external snippets or logs.
 - @-triggered filepath completion in comments and AI sessions. Type `@` to open a completion list of recent and visible repo files, then select a path to insert.
 - Dired-aware prompt context: Dired-based actions such as code change, question asking, and explain can use marked entries or the current entry as prompt context, so the AI receives the exact file or directory targets you selected in the directory view.

--- a/README.org
+++ b/README.org
@@ -229,18 +229,6 @@ This package makes context engineering easy by automatically assembling precise 
   Function range: lines 2-4
   #+end_example
 
-  Details worth knowing:
-  - The enclosing container is grammar-driven, so it covers classes, structs, `impl` and `trait` blocks, interfaces, objects, records, and enums across languages, not only Python-style classes.
-  - Headers are taken from the declaration node, so multi-line signatures are preserved in full while bodies, docstrings, and comments that the grammar attaches to the body are excluded.
-  - A region spanning sibling functions does not claim to be inside either one; it collapses to their common container, emitting only `Enclosing class:` and `Class definition:`.
-  - Indented definition lines resolve to the definition itself rather than to an enclosing node, so placing the cursor on a `def` line reports that method.
-  - Without an active Tree-sitter grammar, the same actions fall back to `which-function`, so behavior degrades to the previous function-name-only context rather than breaking.
-- Manual context curation: `C-c a @` (`ai-code-context-action`) stores file paths, function anchors, or region ranges in a repo-scoped list, which is appended to prompts via `ai-code--format-repo-context-info`. Function anchors are qualified with their enclosing type when Tree-sitter can resolve one, so a stored method reads `src/service.py#UserService.find_user` instead of the ambiguous `src/service.py#find_user`; with the cursor outside any function the anchor falls back to the container alone (`src/service.py#UserService`). In a Dired buffer, `C-c a @` (`ai-code-context-action`) can store the marked files or directories as repo context; if nothing is explicitly marked, it falls back to the file or directory at point.
-- Optional clipboard context: prefix with `C-u` to append clipboard content to prompts for external snippets or logs.
-- @-triggered filepath completion in comments and AI sessions. Type `@` to open a completion list of recent and visible repo files, then select a path to insert.
-- Dired-aware prompt context: Dired-based actions such as code change, question asking, and explain can use marked entries or the current entry as prompt context, so the AI receives the exact file or directory targets you selected in the directory view.
-- Prompt suffix guardrails: set `ai-code-prompt-suffix` to append persistent constraints to every prompt (when `ai-code-use-prompt-suffix` is non-nil). Example: `(setq ai-code-prompt-suffix "Only use English in code file, but Reply in Simplified Chinese language")`.
-
 Example (focused refactor with curated context):
 1) In a buffer, run `C-c a @` to add the current function or selected region to stored repo context.
 2) Open another related file in a window so it is picked up by `ai-code--get-context-files-string`.

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -24,6 +24,8 @@
                   "ai-code-change" (&rest plist))
 (declare-function ai-code--get-context-files-string "ai-code-utils")
 (declare-function ai-code--current-function-name "ai-code-utils")
+(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function dired-current-directory "dired" ())
 (declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
@@ -468,7 +470,11 @@ A single FILE-AT-POINT entry means Dired is only reporting the current line."
   (let* ((dired-targets (when (derived-mode-p 'dired-mode)
                           (ai-code--refactoring-dired-targets)))
          (region-active (and (not dired-targets) (region-active-p)))
-         (current-function (unless dired-targets (ai-code--current-function-name)))
+         (scope-context (unless dired-targets
+                          (ai-code--current-scope-context)))
+         (current-function (plist-get scope-context :function-name))
+         (semantic-scope (unless dired-targets
+                           (ai-code--format-scope-context scope-context)))
          (file-name (unless dired-targets
                       (when buffer-file-name
                         (file-name-nondirectory buffer-file-name)))))
@@ -476,6 +482,7 @@ A single FILE-AT-POINT entry means Dired is only reporting the current line."
           :region-text (when region-active
                          (buffer-substring-no-properties (region-beginning) (region-end)))
           :current-function current-function
+          :semantic-scope semantic-scope
           :file-name file-name
           :dired-targets dired-targets
           :context-description (cond
@@ -514,19 +521,23 @@ otherwise falls back to absolute paths."
   "Return scope text for current agile prompt.
 FUNCTION-NAME is the current function when available.
 FILE-INFO is additional visible-file context."
-  (concat
-   (if buffer-file-name
-       (format "Current file: %s" buffer-file-name)
-     (format "Current buffer: %s" (buffer-name)))
-   (when function-name
-     (format "\nFunction: %s" function-name))
-   file-info))
+  (let ((semantic-scope
+         (ai-code--format-scope-context (ai-code--current-scope-context))))
+    (concat
+     (if buffer-file-name
+         (format "Current file: %s" buffer-file-name)
+       (format "Current buffer: %s" (buffer-name)))
+     (cond
+      ((not (string-empty-p semantic-scope)) (concat "\n" semantic-scope))
+      (function-name (format "\nFunction: %s" function-name)))
+     file-info)))
 
 (defun ai-code--refactoring-scope-string (context file-info)
   "Return structured scope text for refactoring CONTEXT and FILE-INFO."
   (let ((region-active (plist-get context :region-active))
         (region-text (plist-get context :region-text))
         (current-function (plist-get context :current-function))
+        (semantic-scope (plist-get context :semantic-scope))
         (dired-targets (plist-get context :dired-targets))
         (context-description (plist-get context :context-description))
         (file-name (plist-get context :file-name)))
@@ -543,8 +554,10 @@ FILE-INFO is additional visible-file context."
        (format "Current buffer: %s" (buffer-name))))
      (when context-description
        (format "\nRefactoring context: %s" context-description))
-     (when current-function
-       (format "\nFunction: %s" current-function))
+     (cond
+      ((and semantic-scope (not (string-empty-p semantic-scope)))
+       (concat "\n" semantic-scope))
+      (current-function (format "\nFunction: %s" current-function)))
      (when region-active
        (format "\nSelected code:\n%s" region-text))
      file-info)))
@@ -923,7 +936,12 @@ to fix code."
 (defun ai-code--run-test-ai-assisted ()
   "Send a prompt to AI to run a test command with current context."
   (let* ((is-dired (derived-mode-p 'dired-mode))
-         (function-name (unless is-dired (ai-code--current-function-name)))
+         (scope-context (unless is-dired (ai-code--current-scope-context)))
+         (function-name (plist-get scope-context :function-name))
+         (semantic-scope (unless is-dired
+                           (ai-code--format-scope-context scope-context)))
+         (scope-details (unless (string-empty-p (or semantic-scope ""))
+                          (concat "\n" semantic-scope)))
          (file-info (unless is-dired (ai-code--get-context-files-string)))
          (error-handling-instruction
           (concat "\n\nIf any test fails:"
@@ -938,12 +956,14 @@ to fix code."
                     (dired-current-directory)
                     error-handling-instruction))
            (function-name
-            (format "Run the tests for the current function '%s' using appropriate test runner.%s%s"
+            (format "Run the tests for the current function '%s' using appropriate test runner.%s%s%s"
                     function-name
+                    scope-details
                     file-info
                     error-handling-instruction))
            (t
-            (format "Run the tests for the current file using appropriate test runner.%s%s"
+            (format "Run the tests for the current file using appropriate test runner.%s%s%s"
+                    scope-details
                     file-info
                     error-handling-instruction))))
          (prompt (ai-code-read-string "Send to AI: " initial-input)))

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -23,6 +23,7 @@
 (declare-function ai-code--compose-code-change-brief
                   "ai-code-change" (&rest plist))
 (declare-function ai-code--get-context-files-string "ai-code-utils")
+(declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function dired-current-directory "dired" ())
 (declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
@@ -467,7 +468,7 @@ A single FILE-AT-POINT entry means Dired is only reporting the current line."
   (let* ((dired-targets (when (derived-mode-p 'dired-mode)
                           (ai-code--refactoring-dired-targets)))
          (region-active (and (not dired-targets) (region-active-p)))
-         (current-function (unless dired-targets (which-function)))
+         (current-function (unless dired-targets (ai-code--current-function-name)))
          (file-name (unless dired-targets
                       (when buffer-file-name
                         (file-name-nondirectory buffer-file-name)))))
@@ -922,7 +923,7 @@ to fix code."
 (defun ai-code--run-test-ai-assisted ()
   "Send a prompt to AI to run a test command with current context."
   (let* ((is-dired (derived-mode-p 'dired-mode))
-         (function-name (unless is-dired (which-function)))
+         (function-name (unless is-dired (ai-code--current-function-name)))
          (file-info (unless is-dired (ai-code--get-context-files-string)))
          (error-handling-instruction
           (concat "\n\nIf any test fails:"
@@ -963,7 +964,7 @@ Helps users follow Kent Beck's TDD methodology with AI assistance.
 Works with both source code and test files that have been added to ai-code."
   (interactive)
   ;; DONE: use-write-test-stage should also support selected region. If there is selected region, we can use it as the context for writing a test. If there is no selected region, we can use the current function name as the context for writing a test.
-  (let* ((function-name (which-function))
+  (let* ((function-name (ai-code--current-function-name))
          ;; Capture region text early, before completing-read may deactivate the mark.
          ;; Only capture when in a non-test source buffer so it mirrors the same guard
          ;; used by ai-code--tdd-source-function-context-p.

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -23,8 +23,8 @@
 (declare-function ai-code--compose-code-change-brief
                   "ai-code-change" (&rest plist))
 (declare-function ai-code--get-context-files-string "ai-code-utils")
-(declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function dired-current-directory "dired" ())
@@ -471,7 +471,10 @@ A single FILE-AT-POINT entry means Dired is only reporting the current line."
                           (ai-code--refactoring-dired-targets)))
          (region-active (and (not dired-targets) (region-active-p)))
          (scope-context (unless dired-targets
-                          (ai-code--current-scope-context)))
+                          (if region-active
+                              (ai-code--scope-context-for-region
+                               (region-beginning) (region-end))
+                            (ai-code--current-scope-context))))
          (current-function (plist-get scope-context :function-name))
          (semantic-scope (unless dired-targets
                            (ai-code--format-scope-context scope-context)))
@@ -521,8 +524,12 @@ otherwise falls back to absolute paths."
   "Return scope text for current agile prompt.
 FUNCTION-NAME is the current function when available.
 FILE-INFO is additional visible-file context."
-  (let ((semantic-scope
-         (ai-code--format-scope-context (ai-code--current-scope-context))))
+  (let* ((scope-context
+          (if (region-active-p)
+              (ai-code--scope-context-for-region
+               (region-beginning) (region-end))
+            (ai-code--current-scope-context)))
+         (semantic-scope (ai-code--format-scope-context scope-context)))
     (concat
      (if buffer-file-name
          (format "Current file: %s" buffer-file-name)
@@ -936,7 +943,12 @@ to fix code."
 (defun ai-code--run-test-ai-assisted ()
   "Send a prompt to AI to run a test command with current context."
   (let* ((is-dired (derived-mode-p 'dired-mode))
-         (scope-context (unless is-dired (ai-code--current-scope-context)))
+         (scope-context
+          (unless is-dired
+            (if (region-active-p)
+                (ai-code--scope-context-for-region
+                 (region-beginning) (region-end))
+              (ai-code--current-scope-context))))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (unless is-dired
                            (ai-code--format-scope-context scope-context)))
@@ -984,11 +996,17 @@ Helps users follow Kent Beck's TDD methodology with AI assistance.
 Works with both source code and test files that have been added to ai-code."
   (interactive)
   ;; DONE: use-write-test-stage should also support selected region. If there is selected region, we can use it as the context for writing a test. If there is no selected region, we can use the current function name as the context for writing a test.
-  (let* ((function-name (ai-code--current-function-name))
+  (let* ((region-active (region-active-p))
+         (scope-context
+          (if region-active
+              (ai-code--scope-context-for-region
+               (region-beginning) (region-end))
+            (ai-code--current-scope-context)))
+         (function-name (plist-get scope-context :function-name))
          ;; Capture region text early, before completing-read may deactivate the mark.
          ;; Only capture when in a non-test source buffer so it mirrors the same guard
          ;; used by ai-code--tdd-source-function-context-p.
-         (region-text (when (and (region-active-p)
+         (region-text (when (and region-active
                                  buffer-file-name
                                  (derived-mode-p 'prog-mode)
                                  (let ((case-fold-search t))

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -952,7 +952,8 @@ to fix code."
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (unless is-dired
                            (ai-code--format-scope-context scope-context)))
-         (scope-details (unless (string-empty-p (or semantic-scope ""))
+         (scope-details (if (string-empty-p (or semantic-scope ""))
+                            ""
                           (concat "\n" semantic-scope)))
          (file-info (unless is-dired (ai-code--get-context-files-string)))
          (error-handling-instruction

--- a/ai-code-agile.el
+++ b/ai-code-agile.el
@@ -23,7 +23,7 @@
 (declare-function ai-code--compose-code-change-brief
                   "ai-code-change" (&rest plist))
 (declare-function ai-code--get-context-files-string "ai-code-utils")
-(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--current-line-scope-context "ai-code-utils" ())
 (declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
@@ -474,7 +474,7 @@ A single FILE-AT-POINT entry means Dired is only reporting the current line."
                           (if region-active
                               (ai-code--scope-context-for-region
                                (region-beginning) (region-end))
-                            (ai-code--current-scope-context))))
+                            (ai-code--current-line-scope-context))))
          (current-function (plist-get scope-context :function-name))
          (semantic-scope (unless dired-targets
                            (ai-code--format-scope-context scope-context)))
@@ -528,7 +528,7 @@ FILE-INFO is additional visible-file context."
           (if (region-active-p)
               (ai-code--scope-context-for-region
                (region-beginning) (region-end))
-            (ai-code--current-scope-context)))
+            (ai-code--current-line-scope-context)))
          (semantic-scope (ai-code--format-scope-context scope-context)))
     (concat
      (if buffer-file-name
@@ -948,7 +948,7 @@ to fix code."
             (if (region-active-p)
                 (ai-code--scope-context-for-region
                  (region-beginning) (region-end))
-              (ai-code--current-scope-context))))
+              (ai-code--current-line-scope-context))))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (unless is-dired
                            (ai-code--format-scope-context scope-context)))
@@ -1001,7 +1001,7 @@ Works with both source code and test files that have been added to ai-code."
           (if region-active
               (ai-code--scope-context-for-region
                (region-beginning) (region-end))
-            (ai-code--current-scope-context)))
+            (ai-code--current-line-scope-context)))
          (function-name (plist-get scope-context :function-name))
          ;; Capture region text early, before completing-read may deactivate the mark.
          ;; Only capture when in a non-test source buffer so it mirrors the same guard

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -23,6 +23,7 @@
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
 (declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function ai-code--get-git-relative-paths "ai-code-discussion")
 (declare-function ai-code--get-region-location-info "ai-code-discussion")
@@ -284,8 +285,7 @@ REGION-ACTIVE indicates whether a region is selected."
   (let* ((clipboard-context (when arg (ai-code--get-clipboard-text)))
          (scope-ctx (ai-code--current-scope-context))
          (function-name (plist-get scope-ctx :function-name))
-         (class-name (plist-get scope-ctx :class-name))
-         (class-header (plist-get scope-ctx :class-header))
+         (semantic-scope (ai-code--format-scope-context scope-ctx))
          (region-text (when region-active
                         (buffer-substring-no-properties (region-beginning) (region-end))))
          (region-start-line (when region-active
@@ -307,9 +307,8 @@ REGION-ACTIVE indicates whether a region is selected."
                       (region-start-line
                        (format "Start line: %d\n" region-start-line)))
                      region-text))
-           (when class-name (format "\nEnclosing class: %s" class-name))
-           (when class-header (format "\nClass definition: %s" class-header))
-           (when function-name (format "\nFunction: %s" function-name))
+           (unless (string-empty-p semantic-scope)
+             (concat "\n" semantic-scope))
            files-context-string))
          (final-prompt
           (ai-code--compose-code-change-brief
@@ -519,16 +518,23 @@ ARG controls whether clipboard context is included."
          (current-line (string-trim (thing-at-point 'line t)))
          (current-line-number (line-number-at-pos (point)))
          (is-comment (ai-code--is-comment-line current-line))
+         (scope-context (unless is-comment
+                          (ai-code--current-scope-context)))
          (function-name (if is-comment
                             (ai-code--get-function-name-for-comment)
-                          (ai-code--current-function-name)))
+                          (plist-get scope-context :function-name)))
          (org-todo-section-info (ai-code--implement-todo--get-org-todo-section-info))
          (org-section-block
           (ai-code--implement-todo--format-org-section-block
            org-todo-section-info))
-         (function-context (if function-name
-                               (format "\nFunction: %s" function-name)
-                             ""))
+         (semantic-scope (unless is-comment
+                           (ai-code--format-scope-context scope-context)))
+         (function-context
+          (cond
+           ((and semantic-scope (not (string-empty-p semantic-scope)))
+            (concat "\n" semantic-scope))
+           (function-name (format "\nFunction: %s" function-name))
+           (t "")))
          (region-active (region-active-p))
          (region-text (when region-active
                         (buffer-substring-no-properties

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -23,6 +23,7 @@
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
 (declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function ai-code--get-git-relative-paths "ai-code-discussion")
@@ -283,7 +284,10 @@ FUNCTION-NAME is the name of the function at point if any."
 ARG is the prefix argument.
 REGION-ACTIVE indicates whether a region is selected."
   (let* ((clipboard-context (when arg (ai-code--get-clipboard-text)))
-         (scope-ctx (ai-code--current-scope-context))
+         (scope-ctx (if region-active
+                        (ai-code--scope-context-for-region
+                         (region-beginning) (region-end))
+                      (ai-code--current-scope-context)))
          (function-name (plist-get scope-ctx :function-name))
          (semantic-scope (ai-code--format-scope-context scope-ctx))
          (region-text (when region-active
@@ -518,8 +522,12 @@ ARG controls whether clipboard context is included."
          (current-line (string-trim (thing-at-point 'line t)))
          (current-line-number (line-number-at-pos (point)))
          (is-comment (ai-code--is-comment-line current-line))
+         (region-active (region-active-p))
          (scope-context (unless is-comment
-                          (ai-code--current-scope-context)))
+                          (if region-active
+                              (ai-code--scope-context-for-region
+                               (region-beginning) (region-end))
+                            (ai-code--current-scope-context))))
          (function-name (if is-comment
                             (ai-code--get-function-name-for-comment)
                           (plist-get scope-context :function-name)))
@@ -535,7 +543,6 @@ ARG controls whether clipboard context is included."
             (concat "\n" semantic-scope))
            (function-name (format "\nFunction: %s" function-name))
            (t "")))
-         (region-active (region-active-p))
          (region-text (when region-active
                         (buffer-substring-no-properties
                          (region-beginning)

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -25,6 +25,7 @@
 (declare-function ai-code--current-line-scope-context "ai-code-utils" ())
 (declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
+(declare-function ai-code--class-only-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function ai-code--get-git-relative-paths "ai-code-discussion")
 (declare-function ai-code--get-region-location-info "ai-code-discussion")
@@ -515,6 +516,17 @@ The plist contains `:heading-line', `:content', and `:line-number'."
     (and clipboard-context
          (string-match-p "\\S-" clipboard-context))))
 
+(defun ai-code--implement-todo--format-function-context (semantic-scope
+                                                         fallback-function-name)
+  "Return the scope block for a TODO prompt.
+SEMANTIC-SCOPE is preformatted scope text.  FALLBACK-FUNCTION-NAME names
+the function when SEMANTIC-SCOPE carries no function of its own."
+  (concat
+   (unless (string-empty-p (or semantic-scope ""))
+     (concat "\n" semantic-scope))
+   (when fallback-function-name
+     (format "\nFunction: %s" fallback-function-name))))
+
 (defun ai-code--implement-todo--collect-prompt-context (arg)
   "Collect prompt context for `ai-code-implement-todo'.
 ARG controls whether clipboard context is included."
@@ -523,26 +535,33 @@ ARG controls whether clipboard context is included."
          (current-line-number (line-number-at-pos (point)))
          (is-comment (ai-code--is-comment-line current-line))
          (region-active (region-active-p))
-         (scope-context (unless is-comment
-                          (if region-active
+         (scope-context (if region-active
                               (ai-code--scope-context-for-region
                                (region-beginning) (region-end))
-                            (ai-code--current-line-scope-context))))
-         (function-name (if is-comment
-                            (ai-code--get-function-name-for-comment)
-                          (plist-get scope-context :function-name)))
+                          (ai-code--current-line-scope-context)))
+         (scope-function-name (plist-get scope-context :function-name))
+         (comment-function-name (when is-comment
+                                  (ai-code--get-function-name-for-comment)))
+         (function-name (or comment-function-name scope-function-name))
+         ;; A comment may document the function that follows it, so the scope
+         ;; at point then describes a different function.  Keep only its
+         ;; class-like container in that case.
+         (semantic-context
+          (if (and comment-function-name
+                   scope-function-name
+                   (not (equal comment-function-name scope-function-name)))
+              (ai-code--class-only-scope-context scope-context)
+            scope-context))
+         (semantic-scope (ai-code--format-scope-context semantic-context))
          (org-todo-section-info (ai-code--implement-todo--get-org-todo-section-info))
          (org-section-block
           (ai-code--implement-todo--format-org-section-block
            org-todo-section-info))
-         (semantic-scope (unless is-comment
-                           (ai-code--format-scope-context scope-context)))
          (function-context
-          (cond
-           ((and semantic-scope (not (string-empty-p semantic-scope)))
-            (concat "\n" semantic-scope))
-           (function-name (format "\nFunction: %s" function-name))
-           (t "")))
+          (ai-code--implement-todo--format-function-context
+           semantic-scope
+           (unless (plist-get semantic-context :function-name)
+             function-name)))
          (region-text (when region-active
                         (buffer-substring-no-properties
                          (region-beginning)

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -22,7 +22,7 @@
 (declare-function ai-code--insert-prompt "ai-code-prompt-mode")
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
 (declare-function ai-code--current-function-name "ai-code-utils")
-(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--current-line-scope-context "ai-code-utils" ())
 (declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
@@ -287,7 +287,7 @@ REGION-ACTIVE indicates whether a region is selected."
          (scope-ctx (if region-active
                         (ai-code--scope-context-for-region
                          (region-beginning) (region-end))
-                      (ai-code--current-scope-context)))
+                      (ai-code--current-line-scope-context)))
          (function-name (plist-get scope-ctx :function-name))
          (semantic-scope (ai-code--format-scope-context scope-ctx))
          (region-text (when region-active
@@ -527,7 +527,7 @@ ARG controls whether clipboard context is included."
                           (if region-active
                               (ai-code--scope-context-for-region
                                (region-beginning) (region-end))
-                            (ai-code--current-scope-context))))
+                            (ai-code--current-line-scope-context))))
          (function-name (if is-comment
                             (ai-code--get-function-name-for-comment)
                           (plist-get scope-context :function-name)))
@@ -768,13 +768,17 @@ to include in each error report."
 
 (defun ai-code--choose-flycheck-scope ()
   "Return a list (START END DESCRIPTION) for Flycheck fixing scope."
-  (let* ((scope (if (region-active-p) 'region
+  (let* ((region-active (region-active-p))
+         (scope-context (unless region-active
+                          (ai-code--current-line-scope-context)))
+         (function-name (plist-get scope-context :function-name))
+         (scope (if region-active 'region
                   (intern
                    (completing-read
                     "Select Flycheck fixing scope: "
                     (delq nil
                           `("current-line"
-                            ,(when (ai-code--current-function-name) "current-function")
+                            ,(when function-name "current-function")
                             "whole-file"))
                     nil t))))
          start end description)
@@ -792,13 +796,14 @@ to include in each error report."
              description       (format "current line (%d)"
                                        (line-number-at-pos (point)))))
       ('current-function
-       (let ((bounds (bounds-of-thing-at-point 'defun)))
+       (let ((bounds (or (plist-get scope-context :range)
+                         (bounds-of-thing-at-point 'defun))))
          (unless bounds
            (user-error "Not inside a function; cannot select current function"))
          (setq start            (car bounds)
                end              (cdr bounds)
                description       (format "function '%s' (lines %d–%d)"
-                                         (ai-code--current-function-name)
+                                         function-name
                                          (line-number-at-pos (car bounds))
                                          (line-number-at-pos (cdr bounds))))))
       ('whole-file

--- a/ai-code-change.el
+++ b/ai-code-change.el
@@ -21,6 +21,8 @@
 (declare-function ai-code-read-string "ai-code-input")
 (declare-function ai-code--insert-prompt "ai-code-prompt-mode")
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
+(declare-function ai-code--current-function-name "ai-code-utils")
+(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
 (declare-function ai-code--get-git-relative-paths "ai-code-discussion")
 (declare-function ai-code--get-region-location-info "ai-code-discussion")
@@ -176,9 +178,10 @@ begins with a DONE: prefix."
 (defun ai-code--get-function-name-for-comment ()
   "Get the appropriate function name when cursor is on a comment line.
 If the comment precedes a function definition or is inside a function body,
-returns that function's name.  Otherwise returns the result of `which-function`."
+returns that function's name.  Otherwise returns the result of
+`ai-code--current-function-name`."
   (interactive)
-  (let* ((current-func (which-function))
+  (let* ((current-func (ai-code--current-function-name))
          (resolved-func
           (save-excursion
             (cl-labels ((line-text ()
@@ -198,7 +201,7 @@ returns that function's name.  Otherwise returns the result of `which-function`.
                     (when (or (eobp) (string-blank-p text))
                       (cl-return-from resolve nil)))
                   ;; Resolve with a short lookahead; stop on blank lines.
-                  (let ((next-func (which-function)))
+                  (let ((next-func (ai-code--current-function-name)))
                     (cl-loop with lookahead = 5
                              while (and (> lookahead 0)
                                         (or (null next-func)
@@ -209,14 +212,12 @@ returns that function's name.  Otherwise returns the result of `which-function`.
                                 (when (string-blank-p text)
                                   (cl-return-from resolve nil))
                                 (unless (ai-code--is-comment-line text)
-                                  (setq next-func (which-function)))
+                                  (setq next-func (ai-code--current-function-name)))
                              finally return (cond
                                              ((not current-func) next-func)
                                              ((not next-func) current-func)
                                              ((not (string= next-func current-func)) next-func)
                                              (t current-func))))))))))
-    ;; (when resolved-func
-    ;;   (message "Identified function: %s" resolved-func))
     resolved-func))
 
 (defun ai-code--detect-todo-info (region-active)
@@ -281,7 +282,10 @@ FUNCTION-NAME is the name of the function at point if any."
 ARG is the prefix argument.
 REGION-ACTIVE indicates whether a region is selected."
   (let* ((clipboard-context (when arg (ai-code--get-clipboard-text)))
-         (function-name (which-function))
+         (scope-ctx (ai-code--current-scope-context))
+         (function-name (plist-get scope-ctx :function-name))
+         (class-name (plist-get scope-ctx :class-name))
+         (class-header (plist-get scope-ctx :class-header))
          (region-text (when region-active
                         (buffer-substring-no-properties (region-beginning) (region-end))))
          (region-start-line (when region-active
@@ -303,6 +307,8 @@ REGION-ACTIVE indicates whether a region is selected."
                       (region-start-line
                        (format "Start line: %d\n" region-start-line)))
                      region-text))
+           (when class-name (format "\nEnclosing class: %s" class-name))
+           (when class-header (format "\nClass definition: %s" class-header))
            (when function-name (format "\nFunction: %s" function-name))
            files-context-string))
          (final-prompt
@@ -515,7 +521,7 @@ ARG controls whether clipboard context is included."
          (is-comment (ai-code--is-comment-line current-line))
          (function-name (if is-comment
                             (ai-code--get-function-name-for-comment)
-                          (which-function)))
+                          (ai-code--current-function-name)))
          (org-todo-section-info (ai-code--implement-todo--get-org-todo-section-info))
          (org-section-block
           (ai-code--implement-todo--format-org-section-block
@@ -755,7 +761,7 @@ to include in each error report."
                     "Select Flycheck fixing scope: "
                     (delq nil
                           `("current-line"
-                            ,(when (which-function) "current-function")
+                            ,(when (ai-code--current-function-name) "current-function")
                             "whole-file"))
                     nil t))))
          start end description)
@@ -779,9 +785,9 @@ to include in each error report."
          (setq start            (car bounds)
                end              (cdr bounds)
                description       (format "function '%s' (lines %d–%d)"
-                                        (which-function)
-                                        (line-number-at-pos (car bounds))
-                                        (line-number-at-pos (cdr bounds))))))
+                                         (ai-code--current-function-name)
+                                         (line-number-at-pos (car bounds))
+                                         (line-number-at-pos (cdr bounds))))))
       ('whole-file
        (setq start            (point-min)
              end              (point-max)

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -26,7 +26,7 @@
 (declare-function ai-code--detect-todo-info
                   "ai-code-change" (region-active))
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
-(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--current-line-scope-context "ai-code-utils" ())
 (declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode")
@@ -236,7 +236,7 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                       (if region-active
                           (ai-code--scope-context-for-region
                            (region-beginning) (region-end))
-                        (ai-code--current-scope-context))))
+                        (ai-code--current-line-scope-context))))
          (function-name (plist-get scope-ctx :function-name))
          (semantic-scope (ai-code--format-scope-context scope-ctx))
          (region-text (when region-active
@@ -349,7 +349,7 @@ Argument ARG is the prefix argument."
           (if region-text
               (ai-code--scope-context-for-region
                (region-beginning) (region-end))
-            (ai-code--current-scope-context)))
+            (ai-code--current-line-scope-context)))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
@@ -644,7 +644,8 @@ In the current repository, inspect `git show %s` and explain:
   "Explain the symbol at point."
   (let* ((symbol (thing-at-point 'symbol t))
          (semantic-scope
-          (ai-code--format-scope-context (ai-code--current-scope-context))))
+          (ai-code--format-scope-context
+           (ai-code--current-line-scope-context))))
     (unless symbol
       (user-error "No symbol at point"))
     (let* ((initial-prompt (format "%s%s' in the context of:%s\nFile: %s\n\nExplain what this symbol represents, its type, purpose, and how it's used in this context."
@@ -656,22 +657,13 @@ In the current repository, inspect `git show %s` and explain:
                                   (or buffer-file-name "current buffer"))))
       (ai-code--confirm-and-send "Prompt: " initial-prompt))))
 
-(defun ai-code--line-semantic-position ()
-  "Return the first non-whitespace position on the current line.
-Return nil when the current line contains only whitespace."
-  (save-excursion
-    (back-to-indentation)
-    (unless (eolp)
-      (point))))
-
 (defun ai-code--explain-line ()
   "Explain the current line."
   (let* ((line-text (string-trim (thing-at-point 'line t)))
          (line-number (line-number-at-pos))
-         (semantic-position (ai-code--line-semantic-position))
          (semantic-scope
           (ai-code--format-scope-context
-           (ai-code--current-scope-context semantic-position))))
+           (ai-code--current-line-scope-context))))
     (let* ((initial-prompt (format "%s\n\nLine %d: %s\n\n%sFile: %s\n\nExplain what this line does, its purpose, and how it fits into the surrounding code."
                                    ai-code-discussion--explain-line-prefix
                                    line-number
@@ -684,8 +676,7 @@ Return nil when the current line contains only whitespace."
 
 (defun ai-code--explain-function ()
   "Explain the current function."
-  (let* ((semantic-position (ai-code--line-semantic-position))
-         (scope-context (ai-code--current-scope-context semantic-position))
+  (let* ((scope-context (ai-code--current-line-scope-context))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context)))
     (unless function-name

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -656,12 +656,22 @@ In the current repository, inspect `git show %s` and explain:
                                   (or buffer-file-name "current buffer"))))
       (ai-code--confirm-and-send "Prompt: " initial-prompt))))
 
+(defun ai-code--line-semantic-position ()
+  "Return the first non-whitespace position on the current line.
+Return nil when the current line contains only whitespace."
+  (save-excursion
+    (back-to-indentation)
+    (unless (eolp)
+      (point))))
+
 (defun ai-code--explain-line ()
   "Explain the current line."
   (let* ((line-text (string-trim (thing-at-point 'line t)))
          (line-number (line-number-at-pos))
+         (semantic-position (ai-code--line-semantic-position))
          (semantic-scope
-          (ai-code--format-scope-context (ai-code--current-scope-context))))
+          (ai-code--format-scope-context
+           (ai-code--current-scope-context semantic-position))))
     (let* ((initial-prompt (format "%s\n\nLine %d: %s\n\n%sFile: %s\n\nExplain what this line does, its purpose, and how it fits into the surrounding code."
                                    ai-code-discussion--explain-line-prefix
                                    line-number

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -26,8 +26,8 @@
 (declare-function ai-code--detect-todo-info
                   "ai-code-change" (region-active))
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
-(declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode")
 (declare-function ai-code--ensure-files-directory "ai-code-utils")
@@ -231,11 +231,14 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                           (file-name-extension buffer-file-name)))
          (is-diff-or-patch (and file-extension
                                (member file-extension '("diff" "patch"))))
+         (region-active (region-active-p))
          (scope-ctx (unless is-diff-or-patch
-                      (ai-code--current-scope-context)))
+                      (if region-active
+                          (ai-code--scope-context-for-region
+                           (region-beginning) (region-end))
+                        (ai-code--current-scope-context))))
          (function-name (plist-get scope-ctx :function-name))
          (semantic-scope (ai-code--format-scope-context scope-ctx))
-         (region-active (region-active-p))
          (region-text (when region-active
                         (buffer-substring-no-properties (region-beginning) (region-end))))
          (region-location-info (when region-active
@@ -342,7 +345,11 @@ Argument ARG is the prefix argument."
          (buffer-file buffer-file-name)
          (full-buffer-context (when (and (not buffer-file) (not region-text))
                                 (buffer-substring-no-properties (point-min) (point-max))))
-         (scope-context (ai-code--current-scope-context))
+         (scope-context
+          (if region-text
+              (ai-code--scope-context-for-region
+               (region-beginning) (region-end))
+            (ai-code--current-scope-context)))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
@@ -468,7 +475,9 @@ sends to AI."
 (defun ai-code--explain-region ()
   "Explain the selected region with function/file context."
   (let* ((region-text (buffer-substring-no-properties (region-beginning) (region-end)))
-         (scope-context (ai-code--current-scope-context))
+         (scope-context
+          (ai-code--scope-context-for-region
+           (region-beginning) (region-end)))
          (context-info (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
          (initial-prompt (format "%s\n\n%s\n\n%s%s%s\n\nProvide a clear explanation of what this code does, how it works, and its purpose within the context."

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -26,6 +26,8 @@
 (declare-function ai-code--detect-todo-info
                   "ai-code-change" (region-active))
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
+(declare-function ai-code--current-function-name "ai-code-utils")
+(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode")
 (declare-function ai-code--ensure-files-directory "ai-code-utils")
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
@@ -228,8 +230,11 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                           (file-name-extension buffer-file-name)))
          (is-diff-or-patch (and file-extension
                                (member file-extension '("diff" "patch"))))
-         (function-name (unless is-diff-or-patch
-                         (which-function)))
+         (scope-ctx (unless is-diff-or-patch
+                      (ai-code--current-scope-context)))
+         (function-name (plist-get scope-ctx :function-name))
+         (class-name (plist-get scope-ctx :class-name))
+         (class-header (plist-get scope-ctx :class-header))
          (region-active (region-active-p))
          (region-text (when region-active
                         (buffer-substring-no-properties (region-beginning) (region-end))))
@@ -271,6 +276,10 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                      (when region-location-info
                        (concat region-location-info "\n"))
                      region-text))
+           (when class-name
+             (format "\nEnclosing class: %s" class-name))
+           (when class-header
+             (format "\nClass definition: %s" class-header))
            (when function-name
              (format "\nFunction: %s" function-name))
            files-context-string))
@@ -337,7 +346,7 @@ Argument ARG is the prefix argument."
          (buffer-file buffer-file-name)
          (full-buffer-context (when (and (not buffer-file) (not region-text))
                                 (buffer-substring-no-properties (point-min) (point-max))))
-         (function-name (which-function))
+         (function-name (ai-code--current-function-name))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
          (diagnostic-context
@@ -461,7 +470,7 @@ sends to AI."
 (defun ai-code--explain-region ()
   "Explain the selected region with function/file context."
   (let* ((region-text (buffer-substring-no-properties (region-beginning) (region-end)))
-         (function-name (which-function))
+         (function-name (ai-code--current-function-name))
          (context-info (if function-name
                           (format "Function: %s" function-name)
                         ""))
@@ -629,7 +638,7 @@ In the current repository, inspect `git show %s` and explain:
 (defun ai-code--explain-symbol ()
   "Explain the symbol at point."
   (let* ((symbol (thing-at-point 'symbol t))
-         (function-name (which-function)))
+         (function-name (ai-code--current-function-name)))
     (unless symbol
       (user-error "No symbol at point"))
     (let* ((initial-prompt (format "%s%s' in the context of:%s\nFile: %s\n\nExplain what this symbol represents, its type, purpose, and how it's used in this context."
@@ -645,7 +654,7 @@ In the current repository, inspect `git show %s` and explain:
   "Explain the current line."
   (let* ((line-text (string-trim (thing-at-point 'line t)))
          (line-number (line-number-at-pos))
-         (function-name (which-function)))
+         (function-name (ai-code--current-function-name)))
     (let* ((initial-prompt (format "%s\n\nLine %d: %s\n\n%sFile: %s\n\nExplain what this line does, its purpose, and how it fits into the surrounding code."
                                    ai-code-discussion--explain-line-prefix
                                    line-number
@@ -658,7 +667,7 @@ In the current repository, inspect `git show %s` and explain:
 
 (defun ai-code--explain-function ()
   "Explain the current function."
-  (let ((function-name (which-function)))
+  (let ((function-name (ai-code--current-function-name)))
     (unless function-name
       (user-error "Not inside a function"))
     (let* ((initial-prompt (format "%s%s':

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -28,6 +28,7 @@
 (declare-function ai-code--get-clipboard-text "ai-code-utils")
 (declare-function ai-code--current-function-name "ai-code-utils")
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code-call-gptel-sync "ai-code-prompt-mode")
 (declare-function ai-code--ensure-files-directory "ai-code-utils")
 (declare-function ai-code--git-root "ai-code-utils" (&optional dir))
@@ -233,8 +234,7 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
          (scope-ctx (unless is-diff-or-patch
                       (ai-code--current-scope-context)))
          (function-name (plist-get scope-ctx :function-name))
-         (class-name (plist-get scope-ctx :class-name))
-         (class-header (plist-get scope-ctx :class-header))
+         (semantic-scope (ai-code--format-scope-context scope-ctx))
          (region-active (region-active-p))
          (region-text (when region-active
                         (buffer-substring-no-properties (region-beginning) (region-end))))
@@ -276,12 +276,8 @@ CLIPBOARD-CONTEXT is optional clipboard text to append as context."
                      (when region-location-info
                        (concat region-location-info "\n"))
                      region-text))
-           (when class-name
-             (format "\nEnclosing class: %s" class-name))
-           (when class-header
-             (format "\nClass definition: %s" class-header))
-           (when function-name
-             (format "\nFunction: %s" function-name))
+           (unless (string-empty-p semantic-scope)
+             (concat "\n" semantic-scope))
            files-context-string))
          (final-prompt
           (ai-code--compose-question-brief
@@ -346,7 +342,9 @@ Argument ARG is the prefix argument."
          (buffer-file buffer-file-name)
          (full-buffer-context (when (and (not buffer-file) (not region-text))
                                 (buffer-substring-no-properties (point-min) (point-max))))
-         (function-name (ai-code--current-function-name))
+         (scope-context (ai-code--current-scope-context))
+         (function-name (plist-get scope-context :function-name))
+         (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
          (diagnostic-context
@@ -389,8 +387,8 @@ Argument ARG is the prefix argument."
            (if buffer-file
                (format "Current file: %s" buffer-file)
              (format "Current buffer: %s" (buffer-name)))
-           (when function-name
-             (format "\nFunction: %s" function-name))
+           (unless (string-empty-p semantic-scope)
+             (concat "\n" semantic-scope))
            files-context-string))
          (context-string
           (string-trim
@@ -470,17 +468,15 @@ sends to AI."
 (defun ai-code--explain-region ()
   "Explain the selected region with function/file context."
   (let* ((region-text (buffer-substring-no-properties (region-beginning) (region-end)))
-         (function-name (ai-code--current-function-name))
-         (context-info (if function-name
-                          (format "Function: %s" function-name)
-                        ""))
+         (scope-context (ai-code--current-scope-context))
+         (context-info (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
          (initial-prompt (format "%s\n\n%s\n\n%s%s%s\n\nProvide a clear explanation of what this code does, how it works, and its purpose within the context."
                          ai-code-discussion--explain-code-prefix
                          region-text
                          context-info
-                         (if function-name "\n" "")
-                        files-context-string)))
+                         (if (string-empty-p context-info) "" "\n")
+                         files-context-string)))
     (ai-code--confirm-and-send "Prompt: " initial-prompt)))
 
 (defun ai-code--explain-with-scope-selection ()
@@ -638,15 +634,16 @@ In the current repository, inspect `git show %s` and explain:
 (defun ai-code--explain-symbol ()
   "Explain the symbol at point."
   (let* ((symbol (thing-at-point 'symbol t))
-         (function-name (ai-code--current-function-name)))
+         (semantic-scope
+          (ai-code--format-scope-context (ai-code--current-scope-context))))
     (unless symbol
       (user-error "No symbol at point"))
     (let* ((initial-prompt (format "%s%s' in the context of:%s\nFile: %s\n\nExplain what this symbol represents, its type, purpose, and how it's used in this context."
                                    ai-code-discussion--explain-symbol-prefix
                                    symbol
-                                   (if function-name
-                                       (format "\nFunction: %s" function-name)
-                                     "")
+                                   (if (string-empty-p semantic-scope)
+                                       ""
+                                     (concat "\n" semantic-scope))
                                   (or buffer-file-name "current buffer"))))
       (ai-code--confirm-and-send "Prompt: " initial-prompt))))
 
@@ -654,27 +651,32 @@ In the current repository, inspect `git show %s` and explain:
   "Explain the current line."
   (let* ((line-text (string-trim (thing-at-point 'line t)))
          (line-number (line-number-at-pos))
-         (function-name (ai-code--current-function-name)))
+         (semantic-scope
+          (ai-code--format-scope-context (ai-code--current-scope-context))))
     (let* ((initial-prompt (format "%s\n\nLine %d: %s\n\n%sFile: %s\n\nExplain what this line does, its purpose, and how it fits into the surrounding code."
                                    ai-code-discussion--explain-line-prefix
                                    line-number
                                    line-text
-                                   (if function-name
-                                       (format "Function: %s\n" function-name)
-                                    "")
+                                   (if (string-empty-p semantic-scope)
+                                       ""
+                                     (concat semantic-scope "\n"))
                                   (or buffer-file-name "current buffer"))))
       (ai-code--confirm-and-send "Prompt: " initial-prompt))))
 
 (defun ai-code--explain-function ()
   "Explain the current function."
-  (let ((function-name (ai-code--current-function-name)))
+  (let* ((scope-context (ai-code--current-scope-context))
+         (function-name (plist-get scope-context :function-name))
+         (semantic-scope (ai-code--format-scope-context scope-context)))
     (unless function-name
       (user-error "Not inside a function"))
     (let* ((initial-prompt (format "%s%s':
+%s
 File: %s
 Explain what this function does, its parameters, return value, algorithm, and its role in the overall codebase."
                                    ai-code-discussion--explain-function-prefix
                                    function-name
+                                   semantic-scope
                                    (or buffer-file-name "current buffer"))))
       (ai-code--confirm-and-send "Prompt: " initial-prompt))))
 

--- a/ai-code-discussion.el
+++ b/ai-code-discussion.el
@@ -684,7 +684,8 @@ Return nil when the current line contains only whitespace."
 
 (defun ai-code--explain-function ()
   "Explain the current function."
-  (let* ((scope-context (ai-code--current-scope-context))
+  (let* ((semantic-position (ai-code--line-semantic-position))
+         (scope-context (ai-code--current-scope-context semantic-position))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context)))
     (unless function-name

--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -73,7 +73,7 @@ active region line range, then the current function, then the file path."
                   (line-number-at-pos start t)
                   (line-number-at-pos (max start (1- end)) t))))
        (t
-        (let ((function-name (ai-code--current-function-name)))
+        (let ((function-name (ai-code--current-qualified-scope-name)))
           (if (and (stringp function-name)
                    (not (string-empty-p function-name)))
               (format "%s#%s" file-reference function-name)

--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -73,8 +73,7 @@ active region line range, then the current function, then the file path."
                   (line-number-at-pos start t)
                   (line-number-at-pos (max start (1- end)) t))))
        (t
-        (let ((function-name (when (fboundp 'which-function)
-                               (which-function))))
+        (let ((function-name (ai-code--current-function-name)))
           (if (and (stringp function-name)
                    (not (string-empty-p function-name)))
               (format "%s#%s" file-reference function-name)

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -29,6 +29,8 @@
 (declare-function ai-code--get-context-files-string "ai-code-utils" ())
 (declare-function ai-code--format-repo-context-info "ai-code-utils" ())
 (declare-function ai-code--current-function-name "ai-code-utils" ())
+(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--get-region-location-info "ai-code-discussion" (region-beginning region-end))
 
 
@@ -199,7 +201,9 @@ Issue Investigation Steps:
                                        (ai-code--get-region-location-info
                                         (region-beginning)
                                         (region-end))))
-               (function-name (ai-code--current-function-name))
+               (semantic-scope
+                (ai-code--format-scope-context
+                 (ai-code--current-scope-context)))
                (files-context-string (ai-code--get-context-files-string))
                (repo-context-string (ai-code--format-repo-context-info))
                (context-blocks nil))
@@ -207,8 +211,8 @@ Issue Investigation Steps:
                     (format "Current file: %s" buffer-file-name)
                   (format "Current buffer: %s" (buffer-name)))
                 context-blocks)
-          (when function-name
-            (push (format "Function: %s" function-name) context-blocks))
+          (unless (string-empty-p semantic-scope)
+            (push semantic-scope context-blocks))
           (when region-text
             (push (concat "Selected region:\n"
                           (when region-location-info

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -28,8 +28,8 @@
 (declare-function ai-code--explain-code-change "ai-code-discussion" (&optional review-source))
 (declare-function ai-code--get-context-files-string "ai-code-utils" ())
 (declare-function ai-code--format-repo-context-info "ai-code-utils" ())
-(declare-function ai-code--current-function-name "ai-code-utils" ())
 (declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--get-region-location-info "ai-code-discussion" (region-beginning region-end))
 
@@ -203,7 +203,10 @@ Issue Investigation Steps:
                                         (region-end))))
                (semantic-scope
                 (ai-code--format-scope-context
-                 (ai-code--current-scope-context)))
+                 (if region-text
+                     (ai-code--scope-context-for-region
+                      (region-beginning) (region-end))
+                   (ai-code--current-scope-context))))
                (files-context-string (ai-code--get-context-files-string))
                (repo-context-string (ai-code--format-repo-context-info))
                (context-blocks nil))

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -28,7 +28,7 @@
 (declare-function ai-code--explain-code-change "ai-code-discussion" (&optional review-source))
 (declare-function ai-code--get-context-files-string "ai-code-utils" ())
 (declare-function ai-code--format-repo-context-info "ai-code-utils" ())
-(declare-function ai-code--current-scope-context "ai-code-utils" (&optional pos))
+(declare-function ai-code--current-line-scope-context "ai-code-utils" ())
 (declare-function ai-code--scope-context-for-region "ai-code-utils" (beg end))
 (declare-function ai-code--format-scope-context "ai-code-utils" (context))
 (declare-function ai-code--get-region-location-info "ai-code-discussion" (region-beginning region-end))
@@ -206,7 +206,7 @@ Issue Investigation Steps:
                  (if region-text
                      (ai-code--scope-context-for-region
                       (region-beginning) (region-end))
-                   (ai-code--current-scope-context))))
+                   (ai-code--current-line-scope-context))))
                (files-context-string (ai-code--get-context-files-string))
                (repo-context-string (ai-code--format-repo-context-info))
                (context-blocks nil))

--- a/ai-code-github.el
+++ b/ai-code-github.el
@@ -28,8 +28,8 @@
 (declare-function ai-code--explain-code-change "ai-code-discussion" (&optional review-source))
 (declare-function ai-code--get-context-files-string "ai-code-utils" ())
 (declare-function ai-code--format-repo-context-info "ai-code-utils" ())
+(declare-function ai-code--current-function-name "ai-code-utils" ())
 (declare-function ai-code--get-region-location-info "ai-code-discussion" (region-beginning region-end))
-(declare-function which-function "which-func" ())
 
 
 (defcustom ai-code-default-review-source nil
@@ -199,7 +199,7 @@ Issue Investigation Steps:
                                        (ai-code--get-region-location-info
                                         (region-beginning)
                                         (region-end))))
-               (function-name (which-function))
+               (function-name (ai-code--current-function-name))
                (files-context-string (ai-code--get-context-files-string))
                (repo-context-string (ai-code--format-repo-context-info))
                (context-blocks nil))

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -204,6 +204,13 @@ POS defaults to `point'."
   (and (stringp node-type)
        (member node-type ai-code--treesit-enclosing-type-node-types)))
 
+(defun ai-code--treesit-class-like-node-p (node)
+  "Return non-nil when Tree-sitter NODE is a class-like container."
+  (and node
+       (fboundp 'treesit-node-type)
+       (when-let ((node-type (ignore-errors (treesit-node-type node))))
+         (ai-code--treesit-enclosing-type-node-p node-type))))
+
 (defun ai-code--treesit-enclosing-class-node (&optional node)
   "Find the enclosing class, struct, trait, or interface node for NODE.
 If NODE is omitted, searches upward from the defun at point."
@@ -243,11 +250,14 @@ Otherwise, return the first source line of NODE."
   "Return the name of the function/method at point.
 Prefers Tree-sitter AST detection when available, and falls back to
 `which-function'."
-  (or (when (ai-code--treesit-available-p)
-        (when-let ((node (ai-code--treesit-defun-at-point)))
-          (ai-code--treesit-node-name node)))
-      (when (fboundp 'which-function)
-        (ignore-errors (which-function)))))
+  (if (ai-code--treesit-available-p)
+      (let ((node (ai-code--treesit-defun-at-point)))
+        (unless (ai-code--treesit-class-like-node-p node)
+          (or (and node (ai-code--treesit-node-name node))
+              (when (fboundp 'which-function)
+                (ignore-errors (which-function))))))
+    (when (fboundp 'which-function)
+      (ignore-errors (which-function)))))
 
 (defun ai-code--current-scope-context (&optional pos)
   "Return a plist describing the semantic scope at POS (defaults to point).
@@ -256,15 +266,30 @@ plus the function's buffer range under `:range'."
   (save-excursion
     (when pos (goto-char pos))
     (if (ai-code--treesit-available-p)
-        (let* ((defun-node (ai-code--treesit-defun-at-point))
-               (class-node (ai-code--treesit-enclosing-class-node defun-node))
-               (func-name (or (and defun-node (ai-code--treesit-node-name defun-node))
-                              (when (fboundp 'which-function)
-                                (ignore-errors (which-function)))))
+        (let* ((raw-defun-node (ai-code--treesit-defun-at-point))
+               (raw-node-is-class
+                (ai-code--treesit-class-like-node-p raw-defun-node))
+               (defun-node (unless raw-node-is-class raw-defun-node))
+               (class-node (if raw-node-is-class
+                               raw-defun-node
+                             (ai-code--treesit-enclosing-class-node
+                              defun-node)))
+               (func-name
+                (or (and defun-node (ai-code--treesit-node-name defun-node))
+                    (when (and (null raw-defun-node)
+                               (fboundp 'which-function))
+                      (ignore-errors (which-function)))))
                (class-name (and class-node (ai-code--treesit-node-name class-node)))
                (class-header (and class-node (ai-code--treesit-node-header class-node)))
                (function-header (and defun-node
                                      (ai-code--treesit-node-header defun-node)))
+               (class-range
+                (when (and class-node
+                           (fboundp 'treesit-node-start)
+                           (fboundp 'treesit-node-end))
+                  (ignore-errors
+                    (cons (treesit-node-start class-node)
+                          (treesit-node-end class-node)))))
                (range (when (and defun-node
                                  (fboundp 'treesit-node-start)
                                  (fboundp 'treesit-node-end))
@@ -274,14 +299,81 @@ plus the function's buffer range under `:range'."
           (list :function-name func-name
                 :class-name class-name
                 :class-header class-header
+                :class-range class-range
                 :function-header function-header
                 :range range))
       (list :function-name (when (fboundp 'which-function)
                              (ignore-errors (which-function)))
             :class-name nil
             :class-header nil
+            :class-range nil
             :function-header nil
             :range nil))))
+
+(defun ai-code--empty-scope-context ()
+  "Return an empty semantic scope context plist."
+  (list :function-name nil
+        :class-name nil
+        :class-header nil
+        :class-range nil
+        :function-header nil
+        :range nil))
+
+(defun ai-code--region-semantic-bounds (beg end)
+  "Return first and last non-whitespace positions between BEG and END.
+END is treated as an exclusive buffer position.  Return nil when the
+region is empty or contains only whitespace."
+  (when (< beg end)
+    (let ((start (save-excursion
+                   (goto-char beg)
+                   (when (re-search-forward "\\S-" end t)
+                     (match-beginning 0))))
+          (finish (save-excursion
+                    (goto-char end)
+                    (when (re-search-backward "\\S-" beg t)
+                      (match-beginning 0)))))
+      (when (and start finish)
+        (cons start finish)))))
+
+(defun ai-code--scope-context-same-range-p (first second range-key name-key)
+  "Return non-nil when FIRST and SECOND identify the same semantic scope.
+RANGE-KEY selects the preferred identity range.  NAME-KEY supplies the
+fallback identity when neither context has a range."
+  (let ((first-range (plist-get first range-key))
+        (second-range (plist-get second range-key))
+        (first-name (plist-get first name-key))
+        (second-name (plist-get second name-key)))
+    (cond
+     ((and first-range second-range) (equal first-range second-range))
+     ((or first-range second-range) nil)
+     (t (and first-name second-name (equal first-name second-name))))))
+
+(defun ai-code--class-only-scope-context (context)
+  "Return only the class-like container fields from CONTEXT."
+  (list :function-name nil
+        :class-name (plist-get context :class-name)
+        :class-header (plist-get context :class-header)
+        :class-range (plist-get context :class-range)
+        :function-header nil
+        :range nil))
+
+(defun ai-code--scope-context-for-region (beg end)
+  "Return semantic context shared by the selected region from BEG to END.
+Use full function context only when both non-whitespace endpoints belong
+to the same function.  For a region spanning sibling functions, retain
+only their common class-like container context."
+  (if-let ((bounds (ai-code--region-semantic-bounds beg end)))
+      (let* ((first-context (ai-code--current-scope-context (car bounds)))
+             (last-context (ai-code--current-scope-context (cdr bounds))))
+        (cond
+         ((ai-code--scope-context-same-range-p
+           first-context last-context :range :function-name)
+          first-context)
+         ((ai-code--scope-context-same-range-p
+           first-context last-context :class-range :class-name)
+          (ai-code--class-only-scope-context first-context))
+         (t (ai-code--empty-scope-context))))
+    (ai-code--empty-scope-context)))
 
 (defun ai-code--format-scope-context (context)
   "Return human-readable semantic scope lines for CONTEXT.

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -20,6 +20,17 @@
 (declare-function project-current "project" (&optional maybe-prompt dir))
 (declare-function project-root "project" (project))
 (declare-function magit-git-string "magit-git" (&rest args))
+(declare-function which-function "which-func" ())
+(declare-function treesit-available-p "treesit")
+(declare-function treesit-parser-list "treesit" (&optional buffer))
+(declare-function treesit-defun-at-point "treesit" ())
+(declare-function treesit-defun-name "treesit" (node))
+(declare-function treesit-node-type "treesit" (node))
+(declare-function treesit-node-start "treesit" (node))
+(declare-function treesit-node-end "treesit" (node))
+(declare-function treesit-node-text "treesit" (node &optional no-property))
+(declare-function treesit-node-parent "treesit" (node))
+(declare-function treesit-node-child-by-field-name "treesit" (node field-name))
 
 (defvar ai-code--repo-context-info (make-hash-table :test #'equal)
   "Hash table storing context info lists per Git repository root.")
@@ -147,6 +158,104 @@ Includes stored context entries for the current Git repository if available."
                                  (concat "  - " ctx))
                                (reverse entries)
                                "\n"))))))))
+
+;;; Semantic Scope & Tree-sitter Utilities
+
+(defun ai-code--treesit-available-p (&optional buffer)
+  "Return non-nil if Tree-sitter is available and active for BUFFER.
+BUFFER defaults to `current-buffer'."
+  (and (fboundp 'treesit-available-p)
+       (treesit-available-p)
+       (fboundp 'treesit-parser-list)
+       (condition-case nil
+           (consp (treesit-parser-list (or buffer (current-buffer))))
+         (error nil))))
+
+(defun ai-code--treesit-defun-at-point (&optional pos)
+  "Return the Tree-sitter defun/method AST node at POS, or nil.
+POS defaults to `point'."
+  (when (ai-code--treesit-available-p)
+    (save-excursion
+      (when pos (goto-char pos))
+      (and (fboundp 'treesit-defun-at-point)
+           (ignore-errors (treesit-defun-at-point))))))
+
+(defun ai-code--treesit-node-name (node)
+  "Return the symbol/identifier name string for Tree-sitter NODE, or nil."
+  (when node
+    (or (and (fboundp 'treesit-defun-name)
+             (ignore-errors (treesit-defun-name node)))
+        (and (fboundp 'treesit-node-child-by-field-name)
+             (when-let ((name-child (or (treesit-node-child-by-field-name node "name")
+                                        (treesit-node-child-by-field-name node "identifier"))))
+               (and (fboundp 'treesit-node-text)
+                    (treesit-node-text name-child t)))))))
+
+(defun ai-code--treesit-enclosing-class-node (&optional node)
+  "Find the enclosing class, struct, trait, or interface node for NODE.
+If NODE is omitted, searches upward from the defun at point."
+  (when (ai-code--treesit-available-p)
+    (let ((current (or node (ai-code--treesit-defun-at-point))))
+      (while (and current
+                  (fboundp 'treesit-node-parent)
+                  (let ((parent (treesit-node-parent current)))
+                    (setq current parent)
+                    (and current
+                         (fboundp 'treesit-node-type)
+                         (not (string-match-p
+                               "\\`\\(?:class\\|struct\\|impl\\|interface\\|trait\\|module\\|object\\)\\_>"
+                               (or (treesit-node-type current) "")))))))
+      current)))
+
+(defun ai-code--treesit-node-header (node &optional max-lines)
+  "Extract the signature / header line(s) of Tree-sitter NODE.
+MAX-LINES defaults to 3."
+  (when (and node (fboundp 'treesit-node-start) (fboundp 'treesit-node-end))
+    (let* ((start (treesit-node-start node))
+           (end (min (treesit-node-end node)
+                     (save-excursion
+                       (goto-char start)
+                       (forward-line (or max-lines 3))
+                       (point))))
+           (text (buffer-substring-no-properties start end)))
+      (string-trim text))))
+
+(defun ai-code--current-function-name ()
+  "Return the name of the function/method at point.
+Prefers Tree-sitter AST detection when available, and falls back to
+`which-function'."
+  (or (when (ai-code--treesit-available-p)
+        (when-let ((node (ai-code--treesit-defun-at-point)))
+          (ai-code--treesit-node-name node)))
+      (when (fboundp 'which-function)
+        (ignore-errors (which-function)))))
+
+(defun ai-code--current-scope-context (&optional pos)
+  "Return a plist describing the semantic scope at POS (defaults to point).
+Includes `:function-name', `:class-name', `:class-header', and `:range'."
+  (save-excursion
+    (when pos (goto-char pos))
+    (if (ai-code--treesit-available-p)
+        (let* ((defun-node (ai-code--treesit-defun-at-point))
+               (class-node (ai-code--treesit-enclosing-class-node defun-node))
+               (func-name (or (and defun-node (ai-code--treesit-node-name defun-node))
+                              (when (fboundp 'which-function) (which-function))))
+               (class-name (and class-node (ai-code--treesit-node-name class-node)))
+               (class-header (and class-node (ai-code--treesit-node-header class-node)))
+               (range (when (and defun-node
+                                 (fboundp 'treesit-node-start)
+                                 (fboundp 'treesit-node-end))
+                        (ignore-errors
+                          (cons (treesit-node-start defun-node)
+                                (treesit-node-end defun-node))))))
+          (list :function-name func-name
+                :class-name class-name
+                :class-header class-header
+                :range range))
+      (list :function-name (when (fboundp 'which-function) (which-function))
+            :class-name nil
+            :class-header nil
+            :range nil))))
 
 (provide 'ai-code-utils)
 

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -161,6 +161,14 @@ Includes stored context entries for the current Git repository if available."
 
 ;;; Semantic Scope & Tree-sitter Utilities
 
+(defconst ai-code--treesit-enclosing-type-node-types
+  '("class" "class_definition" "class_declaration" "class_specifier"
+    "struct" "struct_definition" "struct_declaration" "struct_specifier"
+    "struct_item" "impl_item" "interface_declaration" "trait_item"
+    "object_declaration" "object_definition" "record_declaration"
+    "enum_declaration")
+  "Tree-sitter node types that can contain a method or function.")
+
 (defun ai-code--treesit-available-p (&optional buffer)
   "Return non-nil if Tree-sitter is available and active for BUFFER.
 BUFFER defaults to `current-buffer'."
@@ -191,32 +199,43 @@ POS defaults to `point'."
                (and (fboundp 'treesit-node-text)
                     (treesit-node-text name-child t)))))))
 
+(defun ai-code--treesit-enclosing-type-node-p (node-type)
+  "Return non-nil when NODE-TYPE represents a class-like container."
+  (and (stringp node-type)
+       (member node-type ai-code--treesit-enclosing-type-node-types)))
+
 (defun ai-code--treesit-enclosing-class-node (&optional node)
   "Find the enclosing class, struct, trait, or interface node for NODE.
 If NODE is omitted, searches upward from the defun at point."
   (when (ai-code--treesit-available-p)
-    (let ((current (or node (ai-code--treesit-defun-at-point))))
-      (while (and current
-                  (fboundp 'treesit-node-parent)
-                  (let ((parent (treesit-node-parent current)))
-                    (setq current parent)
-                    (and current
-                         (fboundp 'treesit-node-type)
-                         (not (string-match-p
-                               "\\`\\(?:class\\|struct\\|impl\\|interface\\|trait\\|module\\|object\\)\\_>"
-                               (or (treesit-node-type current) "")))))))
-      current)))
+    (let ((current (or node (ai-code--treesit-defun-at-point)))
+          enclosing-node)
+      (while (and current (not enclosing-node)
+                  (fboundp 'treesit-node-parent))
+        (setq current (treesit-node-parent current))
+        (when (and current
+                   (fboundp 'treesit-node-type)
+                   (ai-code--treesit-enclosing-type-node-p
+                    (treesit-node-type current)))
+          (setq enclosing-node current)))
+      enclosing-node)))
 
-(defun ai-code--treesit-node-header (node &optional max-lines)
-  "Extract the signature / header line(s) of Tree-sitter NODE.
-MAX-LINES defaults to 3."
+(defun ai-code--treesit-node-header (node)
+  "Extract the signature or declaration header of Tree-sitter NODE.
+When the grammar exposes a body field, stop immediately before it.
+Otherwise, return the first source line of NODE."
   (when (and node (fboundp 'treesit-node-start) (fboundp 'treesit-node-end))
     (let* ((start (treesit-node-start node))
-           (end (min (treesit-node-end node)
-                     (save-excursion
-                       (goto-char start)
-                       (forward-line (or max-lines 3))
-                       (point))))
+           (body-node
+            (and (fboundp 'treesit-node-child-by-field-name)
+                 (ignore-errors
+                   (treesit-node-child-by-field-name node "body"))))
+           (end (if (and body-node (fboundp 'treesit-node-start))
+                    (treesit-node-start body-node)
+                  (min (treesit-node-end node)
+                       (save-excursion
+                         (goto-char start)
+                         (line-end-position)))))
            (text (buffer-substring-no-properties start end)))
       (string-trim text))))
 
@@ -232,16 +251,20 @@ Prefers Tree-sitter AST detection when available, and falls back to
 
 (defun ai-code--current-scope-context (&optional pos)
   "Return a plist describing the semantic scope at POS (defaults to point).
-Includes `:function-name', `:class-name', `:class-header', and `:range'."
+Includes names and headers for the function and its class-like container,
+plus the function's buffer range under `:range'."
   (save-excursion
     (when pos (goto-char pos))
     (if (ai-code--treesit-available-p)
         (let* ((defun-node (ai-code--treesit-defun-at-point))
                (class-node (ai-code--treesit-enclosing-class-node defun-node))
                (func-name (or (and defun-node (ai-code--treesit-node-name defun-node))
-                              (when (fboundp 'which-function) (which-function))))
+                              (when (fboundp 'which-function)
+                                (ignore-errors (which-function)))))
                (class-name (and class-node (ai-code--treesit-node-name class-node)))
                (class-header (and class-node (ai-code--treesit-node-header class-node)))
+               (function-header (and defun-node
+                                     (ai-code--treesit-node-header defun-node)))
                (range (when (and defun-node
                                  (fboundp 'treesit-node-start)
                                  (fboundp 'treesit-node-end))
@@ -251,11 +274,41 @@ Includes `:function-name', `:class-name', `:class-header', and `:range'."
           (list :function-name func-name
                 :class-name class-name
                 :class-header class-header
+                :function-header function-header
                 :range range))
-      (list :function-name (when (fboundp 'which-function) (which-function))
+      (list :function-name (when (fboundp 'which-function)
+                             (ignore-errors (which-function)))
             :class-name nil
             :class-header nil
+            :function-header nil
             :range nil))))
+
+(defun ai-code--format-scope-context (context)
+  "Return human-readable semantic scope lines for CONTEXT.
+CONTEXT is a plist returned by `ai-code--current-scope-context'."
+  (let* ((function-name (plist-get context :function-name))
+         (class-name (plist-get context :class-name))
+         (class-header (plist-get context :class-header))
+         (function-header (plist-get context :function-header))
+         (range (plist-get context :range))
+         (start-line (and (consp range)
+                          (integer-or-marker-p (car range))
+                          (ignore-errors (line-number-at-pos (car range)))))
+         (end-line (and (consp range)
+                        (integer-or-marker-p (cdr range))
+                        (ignore-errors (line-number-at-pos (cdr range))))))
+    (mapconcat
+     #'identity
+     (delq nil
+           (list
+            (when class-name (format "Enclosing class: %s" class-name))
+            (when class-header (format "Class definition: %s" class-header))
+            (when function-name (format "Function: %s" function-name))
+            (when function-header
+              (format "Function definition: %s" function-header))
+            (when (and start-line end-line)
+              (format "Function range: lines %d-%d" start-line end-line))))
+     "\n")))
 
 (provide 'ai-code-utils)
 

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -329,6 +329,29 @@ Preserve the raw point behavior for whitespace-only lines."
       (ai-code--current-scope-context semantic-position)
     (ai-code--current-scope-context)))
 
+(defun ai-code--current-qualified-scope-name ()
+  "Return a qualified name for the semantic scope on the current line.
+Join the enclosing class-like container and the function with a dot, as in
+\"Service.run\".  Fall back to the container name alone when point is not
+inside a function, and to the bare function name when there is no
+container.  Return nil when no scope can be resolved."
+  (let* ((context (ai-code--current-line-scope-context))
+         (function-name (plist-get context :function-name))
+         (class-name (plist-get context :class-name))
+         (parts (delq nil
+                      (list (and (stringp class-name)
+                                 (not (string-empty-p class-name))
+                                 class-name)
+                            (and (stringp function-name)
+                                 (not (string-empty-p function-name))
+                                 function-name)))))
+    (when parts
+      ;; The `which-function' fallback may already return a qualified name.
+      (if (and (cdr parts)
+               (string-prefix-p (concat (car parts) ".") (cadr parts)))
+          (cadr parts)
+        (mapconcat #'identity parts ".")))))
+
 (defun ai-code--empty-scope-context ()
   "Return an empty semantic scope context plist."
   (list :function-name nil

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -246,18 +246,28 @@ Otherwise, return the first source line of NODE."
            (text (buffer-substring-no-properties start end)))
       (string-trim text))))
 
+(defun ai-code--current-line-semantic-position ()
+  "Return the first non-whitespace position on the current line.
+Return nil when the current line contains only whitespace."
+  (save-excursion
+    (back-to-indentation)
+    (unless (eolp)
+      (point))))
+
 (defun ai-code--current-function-name ()
-  "Return the name of the function/method at point.
-Prefers Tree-sitter AST detection when available, and falls back to
-`which-function'."
-  (if (ai-code--treesit-available-p)
-      (let ((node (ai-code--treesit-defun-at-point)))
-        (unless (ai-code--treesit-class-like-node-p node)
-          (or (and node (ai-code--treesit-node-name node))
-              (when (fboundp 'which-function)
-                (ignore-errors (which-function))))))
-    (when (fboundp 'which-function)
-      (ignore-errors (which-function)))))
+  "Return the function or method name for the current semantic line."
+  (save-excursion
+    (when-let ((semantic-position
+                (ai-code--current-line-semantic-position)))
+      (goto-char semantic-position))
+    (if (ai-code--treesit-available-p)
+        (let ((node (ai-code--treesit-defun-at-point)))
+          (unless (ai-code--treesit-class-like-node-p node)
+            (or (and node (ai-code--treesit-node-name node))
+                (when (fboundp 'which-function)
+                  (ignore-errors (which-function))))))
+      (when (fboundp 'which-function)
+        (ignore-errors (which-function))))))
 
 (defun ai-code--current-scope-context (&optional pos)
   "Return a plist describing the semantic scope at POS (defaults to point).
@@ -309,6 +319,15 @@ plus the function's buffer range under `:range'."
             :class-range nil
             :function-header nil
             :range nil))))
+
+(defun ai-code--current-line-scope-context ()
+  "Return semantic context for the code on the current line.
+Resolve nonblank lines from their first non-whitespace character so
+leading indentation does not select an enclosing Tree-sitter node.
+Preserve the raw point behavior for whitespace-only lines."
+  (if-let ((semantic-position (ai-code--current-line-semantic-position)))
+      (ai-code--current-scope-context semantic-position)
+    (ai-code--current-scope-context)))
 
 (defun ai-code--empty-scope-context ()
   "Return an empty semantic scope context plist."

--- a/ai-code-utils.el
+++ b/ai-code-utils.el
@@ -15,6 +15,8 @@
 (require 'subr-x)
 (require 'magit)
 (require 'project)
+;; Optional: provides the non-Tree-sitter fallback for scope detection.
+(require 'which-func nil t)
 
 (declare-function projectile-project-root "projectile")
 (declare-function project-current "project" (&optional maybe-prompt dir))
@@ -30,6 +32,7 @@
 (declare-function treesit-node-end "treesit" (node))
 (declare-function treesit-node-text "treesit" (node &optional no-property))
 (declare-function treesit-node-parent "treesit" (node))
+(declare-function treesit-node-children "treesit" (node &optional named))
 (declare-function treesit-node-child-by-field-name "treesit" (node field-name))
 
 (defvar ai-code--repo-context-info (make-hash-table :test #'equal)
@@ -227,9 +230,35 @@ If NODE is omitted, searches upward from the defun at point."
           (setq enclosing-node current)))
       enclosing-node)))
 
+(defconst ai-code--treesit-comment-node-types
+  '("comment" "line_comment" "block_comment" "documentation_comment")
+  "Tree-sitter node types treated as comments when extracting headers.")
+
+(defun ai-code--treesit-signature-end (node body-node)
+  "Return the position where NODE's declaration ends before BODY-NODE.
+Ignore comment children that the grammar places between the declaration
+and BODY-NODE.  Return nil when NODE exposes no such child."
+  (when (and (fboundp 'treesit-node-children)
+             (fboundp 'treesit-node-type)
+             (fboundp 'treesit-node-start)
+             (fboundp 'treesit-node-end))
+    (let ((body-start (treesit-node-start body-node))
+          (signature-end nil))
+      (dolist (child (ignore-errors (treesit-node-children node)))
+        (let ((child-end (treesit-node-end child)))
+          (when (and child-end
+                     (<= child-end body-start)
+                     (not (member (treesit-node-type child)
+                                  ai-code--treesit-comment-node-types))
+                     (or (null signature-end)
+                         (> child-end signature-end)))
+            (setq signature-end child-end))))
+      signature-end)))
+
 (defun ai-code--treesit-node-header (node)
   "Extract the signature or declaration header of Tree-sitter NODE.
-When the grammar exposes a body field, stop immediately before it.
+When the grammar exposes a body field, stop at the end of the last
+declaration child before it so comments preceding the body are excluded.
 Otherwise, return the first source line of NODE."
   (when (and node (fboundp 'treesit-node-start) (fboundp 'treesit-node-end))
     (let* ((start (treesit-node-start node))
@@ -237,12 +266,14 @@ Otherwise, return the first source line of NODE."
             (and (fboundp 'treesit-node-child-by-field-name)
                  (ignore-errors
                    (treesit-node-child-by-field-name node "body"))))
-           (end (if (and body-node (fboundp 'treesit-node-start))
-                    (treesit-node-start body-node)
-                  (min (treesit-node-end node)
+           (end (cond
+                 ((and body-node
+                       (ai-code--treesit-signature-end node body-node)))
+                 (body-node (treesit-node-start body-node))
+                 (t (min (treesit-node-end node)
                        (save-excursion
                          (goto-char start)
-                         (line-end-position)))))
+                         (line-end-position))))))
            (text (buffer-substring-no-properties start end)))
       (string-trim text))))
 

--- a/ai-code.el
+++ b/ai-code.el
@@ -380,7 +380,11 @@ optional runtime/debugging text from the clipboard."
          (buffer-scope (if buffer-file-name
                            (format "Current file: %s" buffer-file-name)
                          (format "Current buffer: %s" (buffer-name))))
-         (scope-context (ai-code--current-scope-context))
+         (scope-context
+          (if region-text
+              (ai-code--scope-context-for-region
+               (region-beginning) (region-end))
+            (ai-code--current-scope-context)))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))

--- a/ai-code.el
+++ b/ai-code.el
@@ -291,15 +291,16 @@ normally omit it, which skips the prompt."
                                                        function-name
                                                        files-context-string
                                                        repo-context-string
-                                                       clipboard-context)
+                                                       clipboard-context
+                                                       semantic-scope)
   "Return an Emacs runtime debugging prompt from DESCRIPTION.
 EVAL-AVAILABLE-P reports whether `eval_elisp' is globally enabled.
 Optional REGION-TEXT and REGION-LOCATION-INFO add selected-region context.
 BUFFER-SCOPE, FUNCTION-NAME, FILES-CONTEXT-STRING, REPO-CONTEXT-STRING,
-and CLIPBOARD-CONTEXT add broader debugging context."
+CLIPBOARD-CONTEXT, and SEMANTIC-SCOPE add broader debugging context."
   (let ((scope-string
          (ai-code--emacs-runtime-debug-scope-string
-          buffer-scope function-name files-context-string))
+          buffer-scope function-name files-context-string semantic-scope))
         (context-string
          (ai-code--emacs-runtime-debug-context-string
           repo-context-string clipboard-context)))
@@ -331,15 +332,18 @@ Runtime issue description:\n\
        (concat "\n\nContext:\n" context-string)))))
 
 (defun ai-code--emacs-runtime-debug-scope-string (buffer-scope function-name
-                                                              files-context-string)
+                                                              files-context-string
+                                                              &optional semantic-scope)
   "Return scope text for one Emacs runtime debug prompt.
-BUFFER-SCOPE describes the current file or buffer.  FUNCTION-NAME and
-FILES-CONTEXT-STRING are optional additional scope levels."
+BUFFER-SCOPE describes the current file or buffer.  FUNCTION-NAME,
+FILES-CONTEXT-STRING, and SEMANTIC-SCOPE are optional additional levels."
   (string-trim
    (concat
     (or buffer-scope "")
-    (when function-name
-      (format "\nFunction: %s" function-name))
+    (cond
+     ((and semantic-scope (not (string-empty-p semantic-scope)))
+      (concat "\n" semantic-scope))
+     (function-name (format "\nFunction: %s" function-name)))
     (or files-context-string ""))))
 
 (defun ai-code--emacs-runtime-debug-context-string (repo-context-string
@@ -376,7 +380,9 @@ optional runtime/debugging text from the clipboard."
          (buffer-scope (if buffer-file-name
                            (format "Current file: %s" buffer-file-name)
                          (format "Current buffer: %s" (buffer-name))))
-         (function-name (ai-code--current-function-name))
+         (scope-context (ai-code--current-scope-context))
+         (function-name (plist-get scope-context :function-name))
+         (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
          (clipboard-context (when current-prefix-arg
@@ -403,7 +409,8 @@ optional runtime/debugging text from the clipboard."
         function-name
         files-context-string
         repo-context-string
-        clipboard-context)))))
+        clipboard-context
+        semantic-scope)))))
 
 ;;;###autoload
 (defun ai-code-cli-switch-to-buffer-or-hide ()

--- a/ai-code.el
+++ b/ai-code.el
@@ -134,6 +134,7 @@
 (require 'ai-code-kilo)
 (require 'ai-code-grok-cli)
 (require 'ai-code-codebuddy-cli)
+(require 'ai-code-utils)
 (require 'ai-code-file)
 (require 'ai-code-doc)
 (require 'ai-code-harness)
@@ -375,7 +376,7 @@ optional runtime/debugging text from the clipboard."
          (buffer-scope (if buffer-file-name
                            (format "Current file: %s" buffer-file-name)
                          (format "Current buffer: %s" (buffer-name))))
-         (function-name (which-function))
+         (function-name (ai-code--current-function-name))
          (files-context-string (ai-code--get-context-files-string))
          (repo-context-string (ai-code--format-repo-context-info))
          (clipboard-context (when current-prefix-arg

--- a/ai-code.el
+++ b/ai-code.el
@@ -384,7 +384,7 @@ optional runtime/debugging text from the clipboard."
           (if region-text
               (ai-code--scope-context-for-region
                (region-beginning) (region-end))
-            (ai-code--current-scope-context)))
+            (ai-code--current-line-scope-context)))
          (function-name (plist-get scope-context :function-name))
          (semantic-scope (ai-code--format-scope-context scope-context))
          (files-context-string (ai-code--get-context-files-string))

--- a/test/test_ai-code-agile.el
+++ b/test/test_ai-code-agile.el
@@ -180,6 +180,48 @@
             (ai-code-run-test)
             (should (= ai-assisted-call-count 1))))))))
 
+(ert-deftest ai-code-test-run-test-prompt-omits-empty-scope-details ()
+  "Never render a nil semantic scope as the literal string \"nil\"."
+  (dolist (case '((nil . "current file") ("run" . "current function")))
+    (ert-info ((format "Function name: %S" (car case)))
+      (with-temp-buffer
+        (insert "x = 1\n")
+        (goto-char (point-min))
+        (let (captured-prompt)
+          (cl-letf (((symbol-function 'ai-code--current-line-scope-context)
+                     (lambda () (list :function-name (car case))))
+                    ((symbol-function 'ai-code--format-scope-context)
+                     (lambda (_context) ""))
+                    ((symbol-function 'ai-code--get-context-files-string)
+                     (lambda () ""))
+                    ((symbol-function 'ai-code-read-string)
+                     (lambda (_prompt &optional initial &rest _) initial))
+                    ((symbol-function 'ai-code--insert-prompt)
+                     (lambda (prompt) (setq captured-prompt prompt))))
+            (ai-code--run-test-ai-assisted))
+          (should (string-match-p (cdr case) captured-prompt))
+          (should-not (string-match-p "nil" captured-prompt)))))))
+
+(ert-deftest ai-code-test-run-test-prompt-includes-scope-details ()
+  "Include semantic scope details in the run-test prompt when present."
+  (with-temp-buffer
+    (insert "x = 1\n")
+    (goto-char (point-min))
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code--current-line-scope-context)
+                 (lambda () (list :function-name "run")))
+                ((symbol-function 'ai-code--format-scope-context)
+                 (lambda (_context) "Enclosing class: Service"))
+                ((symbol-function 'ai-code--get-context-files-string)
+                 (lambda () ""))
+                ((symbol-function 'ai-code-read-string)
+                 (lambda (_prompt &optional initial &rest _) initial))
+                ((symbol-function 'ai-code--insert-prompt)
+                 (lambda (prompt) (setq captured-prompt prompt))))
+        (ai-code--run-test-ai-assisted))
+      (should (string-match-p "Enclosing class: Service" captured-prompt))
+      (should-not (string-match-p "nil" captured-prompt)))))
+
 (ert-deftest ai-code-test-agile-current-scope-includes-semantic-context ()
   "Include class, signature, and range context in agile prompts."
   (with-temp-buffer

--- a/test/test_ai-code-agile.el
+++ b/test/test_ai-code-agile.el
@@ -185,8 +185,8 @@
   (with-temp-buffer
     (setq-local buffer-file-name "/project/src/service.py")
     (insert "first line\nsecond line\n")
-    (cl-letf (((symbol-function 'ai-code--current-scope-context)
-               (lambda (&optional _)
+    (cl-letf (((symbol-function 'ai-code--current-line-scope-context)
+               (lambda ()
                  (list :function-name "find_user"
                        :class-name "UserService"
                        :class-header "class UserService:"

--- a/test/test_ai-code-agile.el
+++ b/test/test_ai-code-agile.el
@@ -180,6 +180,24 @@
             (ai-code-run-test)
             (should (= ai-assisted-call-count 1))))))))
 
+(ert-deftest ai-code-test-agile-current-scope-includes-semantic-context ()
+  "Include class, signature, and range context in agile prompts."
+  (with-temp-buffer
+    (setq-local buffer-file-name "/project/src/service.py")
+    (insert "first line\nsecond line\n")
+    (cl-letf (((symbol-function 'ai-code--current-scope-context)
+               (lambda (&optional _)
+                 (list :function-name "find_user"
+                       :class-name "UserService"
+                       :class-header "class UserService:"
+                       :function-header "def find_user(self):"
+                       :range (cons (point-min) (1- (point-max)))))))
+      (let ((scope (ai-code--agile-current-scope-string
+                    "find_user" "\nFiles:\n/project/src/service.py")))
+        (should (string-match-p "Class definition: class UserService:" scope))
+        (should (string-match-p "Function definition: def find_user(self):" scope))
+        (should (string-match-p "Function range: lines 1-2" scope))))))
+
 (ert-deftest ai-code-test-tdd-red-green-blue-stage-prompt-includes-xp-rules ()
   "Verify Red + Green + Blue prompt includes TDD flow and XP simplicity rules."
   (with-temp-buffer

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -806,6 +806,56 @@ is between the function definition and its body."
         (should (string-match-p "Agent responsibilities:" captured-prompt))
         (should (string-match-p "Verification evidence:" captured-prompt))))))
 
+(ert-deftest ai-code-test-code-change-whole-function-region-is-direction-independent ()
+  "Use the selected function scope for forward and reverse Tree-sitter regions."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        value = 1\n"
+            "        return value\n\n"
+            "    def second(self):\n"
+            "        return 2\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (search-forward "return value")
+    (backward-char 1)
+    (let* ((function-node (ai-code--treesit-defun-at-point))
+           (start (treesit-node-start function-node))
+           (end (treesit-node-end function-node)))
+      (cl-labels
+          ((capture-prompt
+            (point-position mark-position)
+            (goto-char mark-position)
+            (set-mark (point))
+            (goto-char point-position)
+            (let (captured-prompt)
+              (cl-letf (((symbol-function 'region-active-p) (lambda () t))
+                        ((symbol-function 'ai-code-read-string)
+                         (lambda (&rest _) "Change selected code"))
+                        ((symbol-function 'ai-code--get-context-files-string)
+                         (lambda () ""))
+                        ((symbol-function 'ai-code--format-repo-context-info)
+                         (lambda () ""))
+                        ((symbol-function 'ai-code--get-region-location-info)
+                         (lambda (&rest _) "service.py#L2-L4"))
+                        ((symbol-function 'ai-code--insert-prompt)
+                         (lambda (prompt) (setq captured-prompt prompt))))
+                (ai-code--handle-regular-code-change nil t))
+              captured-prompt)))
+        (let ((forward-prompt (capture-prompt end start))
+              (reverse-prompt (capture-prompt start end)))
+          (dolist (prompt (list forward-prompt reverse-prompt))
+            (should (string-match-p "Selected region:" prompt))
+            (should (string-match-p "Function: first" prompt))
+            (should (string-match-p "Function definition: def first(self):"
+                                    prompt))
+            (should-not (string-match-p "Function: Service" prompt)))
+          (should (equal forward-prompt reverse-prompt)))))))
+
 (ert-deftest ai-code-test-flycheck-fix-errors-uses-structured-brief ()
   "Test `ai-code-flycheck-fix-errors-in-scope' uses structured code-change brief."
   (with-temp-buffer

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -778,8 +778,8 @@ is between the function definition and its body."
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'ai-code--current-scope-context)
-                 (lambda (&optional _)
+                ((symbol-function 'ai-code--current-line-scope-context)
+                 (lambda ()
                    (list :function-name "old-helper"
                          :class-name "HelperService"
                          :class-header "class HelperService:"
@@ -855,6 +855,50 @@ is between the function definition and its body."
                                     prompt))
             (should-not (string-match-p "Function: Service" prompt)))
           (should (equal forward-prompt reverse-prompt)))))))
+
+(ert-deftest ai-code-test-implement-todo-context-normalizes-ts-indentation ()
+  "Collect method context from indentation on a Tree-sitter definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
+              ((symbol-function 'ai-code--get-context-files-string)
+               (lambda () "")))
+      (let ((context (ai-code--implement-todo--collect-prompt-context nil)))
+        (should (equal (plist-get context :function-name) "first"))
+        (should (string-match-p "Function definition: def first(self):"
+                                (plist-get context :function-context)))))))
+
+(ert-deftest ai-code-test-flycheck-function-scope-uses-ts-function-range ()
+  "Use the Tree-sitter method range from an indented definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
+              ((symbol-function 'completing-read)
+               (lambda (_prompt choices &rest _)
+                 (should (member "current-function" choices))
+                 "current-function")))
+      (pcase-let ((`(,start ,end ,description)
+                   (ai-code--choose-flycheck-scope)))
+        (should (= (line-number-at-pos start) 2))
+        (should (= (line-number-at-pos end) 3))
+        (should (string-match-p "function 'first'" description))))))
 
 (ert-deftest ai-code-test-flycheck-fix-errors-uses-structured-brief ()
   "Test `ai-code-flycheck-fix-errors-in-scope' uses structured code-change brief."

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -1215,6 +1215,64 @@ is between the function definition and its body."
         (should command-executed)
         (should-not y-or-n-called)))))
 
+(ert-deftest ai-code-test-implement-todo-comment-keeps-enclosing-scope ()
+  "Keep Tree-sitter scope for a TODO comment inside a method."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def run(self):\n"
+            "        # TODO: implement caching\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (let* ((context (ai-code--implement-todo--collect-prompt-context nil))
+           (function-context (plist-get context :function-context)))
+      (should (plist-get context :is-comment))
+      (should (equal (plist-get context :function-name) "run"))
+      (should (string-match-p "Enclosing class: Service" function-context))
+      (should (string-match-p "Function: run" function-context))
+      (should (string-match-p "Function definition: def run(self):"
+                              function-context)))))
+
+(ert-deftest ai-code-test-implement-todo-comment-for-next-function-keeps-class-only ()
+  "Drop function metadata when a TODO comment documents the following method."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def run(self):\n"
+            "        return 1\n\n"
+            "    # TODO: add retry\n"
+            "    def retry(self):\n"
+            "        return 2\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (search-forward "# TODO")
+    (back-to-indentation)
+    (let* ((context (ai-code--implement-todo--collect-prompt-context nil))
+           (function-context (plist-get context :function-context)))
+      (should (equal (plist-get context :function-name) "retry"))
+      (should (string-match-p "Enclosing class: Service" function-context))
+      (should (string-match-p "Function: retry" function-context))
+      ;; The scope at point still describes `run', so its signature and range
+      ;; must not be attributed to `retry'.
+      (should-not (string-match-p "Function definition" function-context))
+      (should-not (string-match-p "Function range" function-context))
+      (should-not (string-match-p "run" function-context)))))
+
+(ert-deftest ai-code-test-implement-todo-format-function-context-empty ()
+  "Return an empty scope block when no scope information exists."
+  (should (equal (ai-code--implement-todo--format-function-context nil nil) ""))
+  (should (equal (ai-code--implement-todo--format-function-context "" nil) ""))
+  (should (equal (ai-code--implement-todo--format-function-context "" "run")
+                 "\nFunction: run")))
+
 (provide 'test_ai-code-change)
 
 ;;; test_ai-code-change.el ends here

--- a/test/test_ai-code-change.el
+++ b/test/test_ai-code-change.el
@@ -778,7 +778,13 @@ is between the function definition and its body."
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code--current-scope-context)
+                 (lambda (&optional _)
+                   (list :function-name "old-helper"
+                         :class-name "HelperService"
+                         :class-header "class HelperService:"
+                         :function-header "(defun old-helper ()"
+                         :range (cons (point-min) (1- (point-max))))))
                 ((symbol-function 'ai-code-read-string)
                  (lambda (_label _input) "Rename old-helper to new-helper"))
                 ((symbol-function 'ai-code--get-context-files-string)
@@ -791,7 +797,11 @@ is between the function definition and its body."
         (should (stringp captured-prompt))
         (should (string-match-p "Goal:\nRename old-helper to new-helper" captured-prompt))
         (should (string-match-p "Scope:" captured-prompt))
+        (should (string-match-p "Enclosing class: HelperService" captured-prompt))
+        (should (string-match-p "Class definition: class HelperService:" captured-prompt))
         (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Function definition: (defun old-helper ()" captured-prompt))
+        (should (string-match-p "Function range: lines 1-2" captured-prompt))
         (should (string-match-p "Boundaries:" captured-prompt))
         (should (string-match-p "Agent responsibilities:" captured-prompt))
         (should (string-match-p "Verification evidence:" captured-prompt))))))

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -24,6 +24,30 @@
       (setq count (1+ count)))
     count))
 
+(ert-deftest ai-code-test-explain-line-ts-mode-uses-indented-function-scope ()
+  "Include method context when point is in indentation on its definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code--confirm-and-send)
+                 (lambda (_prompt initial-input)
+                   (setq captured-prompt initial-input))))
+        (ai-code--explain-line))
+      (should (string-match-p "Line 2: def first(self):" captured-prompt))
+      (should (string-match-p "Enclosing class: Service" captured-prompt))
+      (should (string-match-p "Function: first" captured-prompt))
+      (should (string-match-p "Function definition: def first(self):"
+                              captured-prompt)))))
+
 (ert-deftest ai-code-test-explain-dired-uses-marked-files-as-git-relative-context ()
   "Test that marked Dired files are explained using git relative paths."
   (let (captured-initial-prompt captured-final-prompt)

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -361,8 +361,8 @@
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'ai-code--current-scope-context)
-                 (lambda (&optional _)
+                ((symbol-function 'ai-code--current-line-scope-context)
+                 (lambda ()
                    (list :function-name "old-helper"
                          :class-name "HelperService"
                          :class-header "class HelperService:"
@@ -424,8 +424,8 @@
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'ai-code--current-scope-context)
-                 (lambda (&optional _)
+                ((symbol-function 'ai-code--current-line-scope-context)
+                 (lambda ()
                    (list :function-name "old-helper"
                          :class-name "HelperService"
                          :class-header "class HelperService:"

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -313,7 +313,13 @@
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code--current-scope-context)
+                 (lambda (&optional _)
+                   (list :function-name "old-helper"
+                         :class-name "HelperService"
+                         :class-header "class HelperService:"
+                         :function-header "(defun old-helper ()"
+                         :range (cons (point-min) (1- (point-max))))))
                 ((symbol-function 'ai-code-read-string)
                  (lambda (_label _input) "Why does old-helper return nil?"))
                 ((symbol-function 'ai-code--get-context-files-string)
@@ -326,7 +332,11 @@
         (should (stringp captured-prompt))
         (should (string-match-p "Goal:\nWhy does old-helper return nil\\?" captured-prompt))
         (should (string-match-p "Scope:\nCurrent file: /tmp/project/test\\.el" captured-prompt))
+        (should (string-match-p "Enclosing class: HelperService" captured-prompt))
+        (should (string-match-p "Class definition: class HelperService:" captured-prompt))
         (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Function definition: (defun old-helper ()" captured-prompt))
+        (should (string-match-p "Function range: lines 1-2" captured-prompt))
         (should (string-match-p "Context:\nStored repository context" captured-prompt))
         (should (string-match-p "Boundaries:\nAnswer the question only\\. Do not make code changes\\."
                                 captured-prompt))
@@ -366,7 +376,13 @@
     (goto-char (point-min))
     (let (captured-prompt)
       (cl-letf (((symbol-function 'region-active-p) (lambda () nil))
-                ((symbol-function 'which-function) (lambda () "old-helper"))
+                ((symbol-function 'ai-code--current-scope-context)
+                 (lambda (&optional _)
+                   (list :function-name "old-helper"
+                         :class-name "HelperService"
+                         :class-header "class HelperService:"
+                         :function-header "(defun old-helper ()"
+                         :range (cons (point-min) (1- (point-max))))))
                 ((symbol-function 'ai-code-read-string)
                  (lambda (_label input) input))
                 ((symbol-function 'ai-code--get-context-files-string)
@@ -380,6 +396,9 @@
         (should (string-match-p "^Goal:\nInvestigate this error" captured-prompt))
         (should (string-match-p "\n\nScope:\nCurrent file: /tmp/project/test\\.el" captured-prompt))
         (should (string-match-p "Function: old-helper" captured-prompt))
+        (should (string-match-p "Class definition: class HelperService:" captured-prompt))
+        (should (string-match-p "Function definition: (defun old-helper ()" captured-prompt))
+        (should (string-match-p "Function range: lines 1-2" captured-prompt))
         (should (string-match-p "Context:\nStored repository context" captured-prompt))
         (should (string-match-p
                  "Boundaries:\nInvestigate first\\. Do not make code changes\\."

--- a/test/test_ai-code-discussion.el
+++ b/test/test_ai-code-discussion.el
@@ -48,6 +48,30 @@
       (should (string-match-p "Function definition: def first(self):"
                               captured-prompt)))))
 
+(ert-deftest ai-code-test-explain-function-ts-mode-uses-indented-definition ()
+  "Explain a method when point is in indentation on its definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (let (captured-prompt)
+      (cl-letf (((symbol-function 'ai-code--confirm-and-send)
+                 (lambda (_prompt initial-input)
+                   (setq captured-prompt initial-input))))
+        (ai-code--explain-function))
+      (should (string-match-p "Please explain the function 'first':"
+                              captured-prompt))
+      (should (string-match-p "Enclosing class: Service" captured-prompt))
+      (should (string-match-p "Function definition: def first(self):"
+                              captured-prompt)))))
+
 (ert-deftest ai-code-test-explain-dired-uses-marked-files-as-git-relative-context ()
   "Test that marked Dired files are explained using git relative paths."
   (let (captured-initial-prompt captured-final-prompt)

--- a/test/test_ai-code-file.el
+++ b/test/test_ai-code-file.el
@@ -1092,6 +1092,22 @@ everything is cleaned up afterward."
       (should (stringp (ai-code--session-project-root)))
       (should (not (string-empty-p (ai-code--session-project-root)))))))
 
+(ert-deftest ai-code-test-current-file-context-reference-normalizes-ts-indentation ()
+  "Include a method anchor from indentation on its Tree-sitter definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (equal (ai-code--current-file-context-reference t)
+                   "/tmp/project/service.py#first"))))
+
 (provide 'test_ai-code-file)
 
 ;;; test_ai-code-file.el ends here

--- a/test/test_ai-code-file.el
+++ b/test/test_ai-code-file.el
@@ -1093,7 +1093,7 @@ everything is cleaned up afterward."
       (should (not (string-empty-p (ai-code--session-project-root)))))))
 
 (ert-deftest ai-code-test-current-file-context-reference-normalizes-ts-indentation ()
-  "Include a method anchor from indentation on its Tree-sitter definition line."
+             "Include a qualified method anchor from indentation on its definition line."
   (skip-unless (and (fboundp 'treesit-language-available-p)
                     (treesit-language-available-p 'python)
                     (fboundp 'python-ts-mode)))
@@ -1106,7 +1106,50 @@ everything is cleaned up afterward."
     (goto-char (point-min))
     (forward-line 1)
     (should (equal (ai-code--current-file-context-reference t)
-                   "/tmp/project/service.py#first"))))
+                              "/tmp/project/service.py#Service.first"))))
+
+(ert-deftest ai-code-test-current-file-context-reference-keeps-class-anchor ()
+  "Anchor on the enclosing class when point is not inside a function."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/service.py")
+    (insert "class Service:\n"
+            "    enabled = True\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (equal (ai-code--current-file-context-reference t)
+                   "/tmp/project/service.py#Service"))))
+
+(ert-deftest ai-code-test-current-file-context-reference-module-function-unqualified ()
+  "Keep a module-level function anchor unqualified."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/util.py")
+    (insert "def alpha():\n"
+            "    return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (equal (ai-code--current-file-context-reference t)
+                   "/tmp/project/util.py#alpha"))))
+
+(ert-deftest ai-code-test-current-file-context-reference-no-scope-plain-path ()
+  "Return a bare path when no semantic scope can be resolved."
+  (with-temp-buffer
+    (setq buffer-file-name "/tmp/project/plain.txt")
+    (insert "just text\n")
+    (goto-char (point-min))
+    (cl-letf (((symbol-function 'ai-code--current-qualified-scope-name)
+               (lambda () nil)))
+      (should (equal (ai-code--current-file-context-reference t)
+                     "/tmp/project/plain.txt")))))
 
 (provide 'test_ai-code-file)
 

--- a/test/test_ai-code-github.el
+++ b/test/test_ai-code-github.el
@@ -481,8 +481,8 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
                  (lambda (&rest _) "Use GitHub MCP server."))
                 ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
                 ((symbol-function 'ai-code--format-repo-context-info) (lambda () nil))
-                ((symbol-function 'ai-code--current-scope-context)
-                 (lambda (&optional _)
+                ((symbol-function 'ai-code--current-line-scope-context)
+                 (lambda ()
                    (list :function-name "hello-world"
                          :class-name "GreetingService"
                          :class-header "class GreetingService:"

--- a/test/test_ai-code-github.el
+++ b/test/test_ai-code-github.el
@@ -470,34 +470,40 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
     (should (string-match-p "conflict" (downcase captured-prompt)))
     (should-not diff-called)))
 
-(ert-deftest ai-code-test-pull-or-review-diff-file-investigate-issue-with-context ()
-  "Test that investigate issue mode can include current file context when y-or-n-p is true."
-  (let* ((captured-prompt nil)
-         (completing-read-results '("Use GitHub MCP server" "Investigate issue")))
+(ert-deftest ai-code-test-build-issue-investigation-prompt-with-semantic-context ()
+  "Include the current semantic scope in an issue investigation prompt."
+  (let (captured-prompt)
     (with-temp-buffer
       (setq buffer-file-name "/path/to/my-source-file.el")
       (insert "defun hello-world ()")
-      (cl-letf (((symbol-function 'completing-read)
-                 (lambda (&rest _args)
-                   (let ((selected (car completing-read-results)))
-                     (setq completing-read-results (cdr completing-read-results))
-                     selected)))
-                ((symbol-function 'ai-code-read-string)
-                 (lambda (prompt &optional initial-input &rest _args)
-                   (if (string-match-p "URL:" prompt)
-                       "https://github.com/acme/demo/issues/42"
-                     initial-input)))
-                ((symbol-function 'ai-code--insert-prompt)
-                 (lambda (prompt) (setq captured-prompt prompt)))
-                ((symbol-function 'y-or-n-p)
-                 (lambda (prompt)
-                   (should (string-match-p "Include active buffer and editor context" prompt))
-                   t))
-                ((symbol-function 'ai-code--git-root) (lambda () "/path/to/")))
-        (ai-code-pull-or-review-diff-file)))
+      (cl-letf (((symbol-function 'use-region-p) (lambda () nil))
+                ((symbol-function 'ai-code--pull-or-review-source-instruction)
+                 (lambda (&rest _) "Use GitHub MCP server."))
+                ((symbol-function 'ai-code--get-context-files-string) (lambda () ""))
+                ((symbol-function 'ai-code--format-repo-context-info) (lambda () nil))
+                ((symbol-function 'ai-code--current-scope-context)
+                 (lambda (&optional _)
+                   (list :function-name "hello-world"
+                         :class-name "GreetingService"
+                         :class-header "class GreetingService:"
+                         :function-header "defun hello-world ()"
+                         :range (cons (point-min) (point-max)))))
+                ((symbol-function 'ai-code--format-scope-context)
+                 (lambda (context)
+                   (should (equal (plist-get context :class-name)
+                                  "GreetingService"))
+                   (concat "Enclosing class: GreetingService\n"
+                           "Class definition: class GreetingService:\n"
+                           "Function: hello-world\n"
+                           "Function definition: defun hello-world ()"))))
+        (setq captured-prompt
+              (ai-code--build-issue-investigation-init-prompt
+               'github-mcp "https://github.com/acme/demo/issues/42" t))))
     (should (string-match-p "Investigate issue: https://github.com/acme/demo/issues/42" captured-prompt))
     (should (string-match-p "Local Context:" captured-prompt))
-    (should (string-match-p "Current file: /path/to/my-source-file.el" captured-prompt))))
+    (should (string-match-p "Current file: /path/to/my-source-file.el" captured-prompt))
+    (should (string-match-p "Class definition: class GreetingService:" captured-prompt))
+    (should (string-match-p "Function definition: defun hello-world ()" captured-prompt))))
 
 (provide 'test_ai-code-github)
 

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -42,6 +42,50 @@
               ((symbol-function 'which-function) (lambda () "fallback-when-no-node")))
       (should (equal (ai-code--current-function-name) "fallback-when-no-node")))))
 
+(ert-deftest test-ai-code-treesit--current-line-scope-normalizes-indentation ()
+  "Resolve the method declared on an indented Tree-sitter line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (let ((scope (ai-code--current-line-scope-context)))
+      (should (equal (plist-get scope :function-name) "first"))
+      (should (equal (plist-get scope :class-name) "Service")))))
+
+(ert-deftest test-ai-code-treesit--current-function-name-normalizes-indentation ()
+  "Return the method name from indentation on its definition line."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (equal (ai-code--current-function-name) "first"))))
+
+(ert-deftest test-ai-code-treesit--current-line-scope-preserves-whitespace-point ()
+  "Use the raw point when the current line contains only whitespace."
+  (with-temp-buffer
+    (insert "   \n")
+    (goto-char (+ (point-min) 1))
+    (let (captured-position)
+      (cl-letf (((symbol-function 'ai-code--current-scope-context)
+                 (lambda (&optional pos)
+                   (setq captured-position (or pos (point)))
+                   (list :function-name "raw-point"))))
+        (let ((scope (ai-code--current-line-scope-context)))
+          (should (equal (plist-get scope :function-name) "raw-point"))
+          (should (= captured-position (point))))))))
+
 (ert-deftest test-ai-code-treesit--enclosing-class-skeleton ()
   "Test `ai-code--current-scope-context' extracts class context when available."
   (with-temp-buffer

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -109,6 +109,113 @@
       (should-not (string-match-p "Service docs" formatted))
       (should-not (string-match-p "return str" formatted)))))
 
+(ert-deftest test-ai-code-treesit--python-whole-function-region-uses-function-scope ()
+  "Resolve a whole-function region without treating its class as a function."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        value = 1\n"
+            "        return value\n\n"
+            "    def second(self):\n"
+            "        return 2\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (search-forward "return value")
+    (backward-char 1)
+    (let* ((function-node (ai-code--treesit-defun-at-point))
+           (start (treesit-node-start function-node))
+           (end (treesit-node-end function-node))
+           (region-scope (ai-code--scope-context-for-region start end))
+           (scope-at-exclusive-end (ai-code--current-scope-context end)))
+      (should (equal (plist-get region-scope :function-name) "first"))
+      (should (equal (plist-get region-scope :class-name) "Service"))
+      (should (equal (plist-get region-scope :function-header)
+                     "def first(self):"))
+      (should-not (plist-get scope-at-exclusive-end :function-name))
+      (should (equal (plist-get scope-at-exclusive-end :class-name)
+                     "Service")))))
+
+(ert-deftest test-ai-code-treesit--python-cross-function-region-keeps-class-only ()
+  "Omit single-function metadata when a region spans sibling methods."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def first(self):\n"
+            "        return 1\n\n"
+            "    def second(self):\n"
+            "        return 2\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (search-forward "return 1")
+    (backward-char 1)
+    (let ((start (treesit-node-start (ai-code--treesit-defun-at-point))))
+      (search-forward "return 2")
+      (backward-char 1)
+      (let* ((end (treesit-node-end (ai-code--treesit-defun-at-point)))
+             (scope (ai-code--scope-context-for-region start end)))
+        (should-not (plist-get scope :function-name))
+        (should-not (plist-get scope :function-header))
+        (should-not (plist-get scope :range))
+        (should (equal (plist-get scope :class-name) "Service"))
+        (should (equal (plist-get scope :class-header)
+                       "class Service:"))))))
+
+(ert-deftest test-ai-code-treesit--region-scope-empty-for-whitespace ()
+  "Return no semantic metadata for a whitespace-only region."
+  (with-temp-buffer
+    (insert "  \n\t")
+    (cl-letf (((symbol-function 'ai-code--current-scope-context)
+               (lambda (&optional _)
+                 (ert-fail "Whitespace must not trigger scope lookup"))))
+      (should
+       (string-empty-p
+        (ai-code--format-scope-context
+         (ai-code--scope-context-for-region
+          (point-min) (point-max))))))))
+
+(ert-deftest test-ai-code-treesit--region-scope-fallback-compares-function-names ()
+  "Use matching fallback function names when Tree-sitter ranges are absent."
+  (with-temp-buffer
+    (insert "a b")
+    (cl-letf (((symbol-function 'ai-code--current-scope-context)
+               (lambda (&optional _)
+                 (list :function-name "fallback-function"
+                       :class-name nil
+                       :class-header nil
+                       :class-range nil
+                       :function-header nil
+                       :range nil))))
+      (let ((scope (ai-code--scope-context-for-region
+                    (point-min) (point-max))))
+        (should (equal (plist-get scope :function-name)
+                       "fallback-function"))))))
+
+(ert-deftest test-ai-code-treesit--region-scope-empty-across-different-classes ()
+  "Return no semantic metadata when region endpoints belong to different classes."
+  (with-temp-buffer
+    (insert "a b")
+    (cl-letf (((symbol-function 'ai-code--current-scope-context)
+               (lambda (&optional pos)
+                 (if (= pos (point-min))
+                     (list :function-name "first"
+                           :class-name "FirstClass"
+                           :class-range '(1 . 1)
+                           :range '(1 . 1))
+                   (list :function-name "second"
+                         :class-name "SecondClass"
+                         :class-range '(3 . 3)
+                         :range '(3 . 3))))))
+      (should
+       (string-empty-p
+        (ai-code--format-scope-context
+         (ai-code--scope-context-for-region
+          (point-min) (point-max))))))))
+
 (ert-deftest test-ai-code-treesit--scope-context-fallback-without-treesit ()
   "Test `ai-code--current-scope-context' provides standard which-function fallback."
   (with-temp-buffer

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -1,0 +1,63 @@
+;;; test_ai-code-treesit.el --- Tests for Tree-sitter semantic scope and context -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'ai-code-utils)
+
+(ert-deftest test-ai-code-treesit--available-p-nil-without-parser ()
+  "Test `ai-code--treesit-available-p' returns nil when buffer has no treesit parser."
+  (with-temp-buffer
+    (should-not (ai-code--treesit-available-p))))
+
+(ert-deftest test-ai-code-treesit--current-function-name-fallback ()
+  "Test `ai-code--current-function-name' falls back to `which-function' when treesit unavailable."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ai-code--treesit-available-p) (lambda (&optional _) nil))
+              ((symbol-function 'which-function) (lambda () "fallback-func")))
+      (should (equal (ai-code--current-function-name) "fallback-func")))))
+
+(ert-deftest test-ai-code-treesit--current-function-name-treesit ()
+  "Test `ai-code--current-function-name' uses treesit defun name when parser is available."
+  (with-temp-buffer
+    (let ((mock-node (list 'mock-node)))
+      (cl-letf (((symbol-function 'ai-code--treesit-available-p) (lambda (&optional _) t))
+                ((symbol-function 'ai-code--treesit-defun-at-point) (lambda (&optional _) mock-node))
+                ((symbol-function 'ai-code--treesit-node-name) (lambda (_node) "ts-detected-method"))
+                ((symbol-function 'which-function) (lambda () "wrong-which-func")))
+        (should (equal (ai-code--current-function-name) "ts-detected-method"))))))
+
+(ert-deftest test-ai-code-treesit--current-function-name-treesit-fallback-on-nil-name ()
+  "Test `ai-code--current-function-name' falls back to which-function if treesit finds no node."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ai-code--treesit-available-p) (lambda (&optional _) t))
+              ((symbol-function 'ai-code--treesit-defun-at-point) (lambda (&optional _) nil))
+              ((symbol-function 'which-function) (lambda () "fallback-when-no-node")))
+      (should (equal (ai-code--current-function-name) "fallback-when-no-node")))))
+
+(ert-deftest test-ai-code-treesit--enclosing-class-skeleton ()
+  "Test `ai-code--treesit-enclosing-class-info' extracts class context when available."
+  (with-temp-buffer
+    (let ((mock-defun (list 'defun-node))
+          (mock-class (list 'class-node)))
+      (cl-letf (((symbol-function 'ai-code--treesit-available-p) (lambda (&optional _) t))
+                ((symbol-function 'ai-code--treesit-defun-at-point) (lambda (&optional _) mock-defun))
+                ((symbol-function 'ai-code--treesit-enclosing-class-node) (lambda (_node) mock-class))
+                ((symbol-function 'ai-code--treesit-node-name) (lambda (n) (if (eq n mock-class) "UserService" "find_user")))
+                ((symbol-function 'ai-code--treesit-node-header) (lambda (n) (if (eq n mock-class) "class UserService(BaseService):" "def find_user(self, user_id: int) -> User:"))))
+        (let ((scope (ai-code--current-scope-context)))
+          (should (equal (plist-get scope :function-name) "find_user"))
+          (should (equal (plist-get scope :class-name) "UserService"))
+          (should (equal (plist-get scope :class-header) "class UserService(BaseService):")))))))
+
+(ert-deftest test-ai-code-treesit--scope-context-fallback-without-treesit ()
+  "Test `ai-code--current-scope-context' provides standard which-function fallback."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ai-code--treesit-available-p) (lambda (&optional _) nil))
+              ((symbol-function 'which-function) (lambda () "standalone_func")))
+      (let ((scope (ai-code--current-scope-context)))
+        (should (equal (plist-get scope :function-name) "standalone_func"))
+        (should-not (plist-get scope :class-name))
+        (should-not (plist-get scope :class-header))))))
+
+(provide 'test_ai-code-treesit)
+;;; test_ai-code-treesit.el ends here

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -271,6 +271,46 @@
         (should-not (plist-get scope :class-header))
         (should-not (plist-get scope :function-header))))))
 
+(ert-deftest test-ai-code-treesit--which-func-available-for-fallback ()
+  "Ensure the non-Tree-sitter fallback function is actually loadable."
+  (should (fboundp 'which-function)))
+
+(ert-deftest test-ai-code-treesit--header-excludes-body-comments ()
+  "Stop the function header before comments that open the body."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    def run(self):\n"
+            "        # Step 1: validate the payload\n"
+            "        # Step 2: normalize identifiers\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 4)
+    (let ((scope (ai-code--current-line-scope-context)))
+      (should (equal (plist-get scope :function-header) "def run(self):"))
+      (should-not (string-match-p "Step 1" (plist-get scope :function-header))))))
+
+(ert-deftest test-ai-code-treesit--class-header-excludes-body-comments ()
+  "Stop the class header before comments that open the class body."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    # NOTE: internal registry helper\n"
+            "    # NOTE: see docs/registry.md\n"
+            "    def run(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 3)
+    (let ((scope (ai-code--current-line-scope-context)))
+      (should (equal (plist-get scope :class-header) "class Service:"))
+      (should-not (string-match-p "NOTE" (plist-get scope :class-header))))))
+
 (ert-deftest test-ai-code-treesit--qualified-scope-name-joins-class-and-function ()
   "Qualify a method name with its enclosing class."
   (skip-unless (and (fboundp 'treesit-language-available-p)

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -1,5 +1,13 @@
 ;;; test_ai-code-treesit.el --- Tests for Tree-sitter semantic scope and context -*- lexical-binding: t; -*-
 
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for semantic scope discovery backed by Tree-sitter.
+
+;;; Code:
+
 (require 'ert)
 (require 'cl-lib)
 (require 'ai-code-utils)
@@ -35,7 +43,7 @@
       (should (equal (ai-code--current-function-name) "fallback-when-no-node")))))
 
 (ert-deftest test-ai-code-treesit--enclosing-class-skeleton ()
-  "Test `ai-code--treesit-enclosing-class-info' extracts class context when available."
+  "Test `ai-code--current-scope-context' extracts class context when available."
   (with-temp-buffer
     (let ((mock-defun (list 'defun-node))
           (mock-class (list 'class-node)))
@@ -47,7 +55,59 @@
         (let ((scope (ai-code--current-scope-context)))
           (should (equal (plist-get scope :function-name) "find_user"))
           (should (equal (plist-get scope :class-name) "UserService"))
-          (should (equal (plist-get scope :class-header) "class UserService(BaseService):")))))))
+          (should (equal (plist-get scope :class-header) "class UserService(BaseService):"))
+          (should (equal (plist-get scope :function-header)
+                         "def find_user(self, user_id: int) -> User:")))))))
+
+(ert-deftest test-ai-code-treesit--enclosing-type-node-types ()
+  "Recognize concrete grammar container nodes without treating roots as classes."
+  (dolist (node-type '("class_definition" "class_declaration"
+                       "struct_item" "impl_item" "interface_declaration"
+                       "trait_item" "object_declaration"))
+    (should (ai-code--treesit-enclosing-type-node-p node-type)))
+  (should-not (ai-code--treesit-enclosing-type-node-p "module"))
+  (should-not (ai-code--treesit-enclosing-type-node-p "module_root")))
+
+(ert-deftest test-ai-code-treesit--python-scope-uses-real-ast-boundaries ()
+  "Extract Python class and function headers without including their bodies."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class UserService(\n"
+            "        BaseService,\n"
+            "        AuditMixin):\n"
+            "    \"\"\"Service docs must not be part of the header.\"\"\"\n"
+            "    enabled = True\n\n"
+            "    def find_user(\n"
+            "            self,\n"
+            "            user_id: int) -> str:\n"
+            "        return str(user_id)\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (search-forward "user_id)")
+    (backward-char 1)
+    (let* ((scope (ai-code--current-scope-context))
+           (formatted (ai-code--format-scope-context scope)))
+      (should (equal (plist-get scope :function-name) "find_user"))
+      (should (equal (plist-get scope :class-name) "UserService"))
+      (should (equal (plist-get scope :class-header)
+                     (concat "class UserService(\n"
+                             "        BaseService,\n"
+                             "        AuditMixin):")))
+      (should (equal (plist-get scope :function-header)
+                     (concat "def find_user(\n"
+                             "            self,\n"
+                             "            user_id: int) -> str:")))
+      (let ((range (plist-get scope :range)))
+        (should (equal (list (line-number-at-pos (car range))
+                             (line-number-at-pos (cdr range)))
+                       '(7 10))))
+      (should (string-match-p "Enclosing class: UserService" formatted))
+      (should (string-match-p "Function definition: def find_user" formatted))
+      (should (string-match-p "Function range: lines 7-10" formatted))
+      (should-not (string-match-p "Service docs" formatted))
+      (should-not (string-match-p "return str" formatted)))))
 
 (ert-deftest test-ai-code-treesit--scope-context-fallback-without-treesit ()
   "Test `ai-code--current-scope-context' provides standard which-function fallback."
@@ -57,7 +117,8 @@
       (let ((scope (ai-code--current-scope-context)))
         (should (equal (plist-get scope :function-name) "standalone_func"))
         (should-not (plist-get scope :class-name))
-        (should-not (plist-get scope :class-header))))))
+        (should-not (plist-get scope :class-header))
+        (should-not (plist-get scope :function-header))))))
 
 (provide 'test_ai-code-treesit)
 ;;; test_ai-code-treesit.el ends here

--- a/test/test_ai-code-treesit.el
+++ b/test/test_ai-code-treesit.el
@@ -271,5 +271,35 @@
         (should-not (plist-get scope :class-header))
         (should-not (plist-get scope :function-header))))))
 
+(ert-deftest test-ai-code-treesit--qualified-scope-name-joins-class-and-function ()
+  "Qualify a method name with its enclosing class."
+  (skip-unless (and (fboundp 'treesit-language-available-p)
+                    (treesit-language-available-p 'python)
+                    (fboundp 'python-ts-mode)))
+  (with-temp-buffer
+    (insert "class Service:\n"
+            "    enabled = True\n"
+            "    def run(self):\n"
+            "        return 1\n")
+    (python-ts-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (should (equal (ai-code--current-qualified-scope-name) "Service.run"))
+    (forward-line -1)
+    (should (equal (ai-code--current-qualified-scope-name) "Service"))))
+
+(ert-deftest test-ai-code-treesit--qualified-scope-name-avoids-double-qualifying ()
+  "Do not re-qualify a fallback name that already carries its container."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ai-code--current-line-scope-context)
+               (lambda ()
+                 (list :function-name "Service.run"
+                       :class-name "Service"))))
+      (should (equal (ai-code--current-qualified-scope-name) "Service.run"))))
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ai-code--current-line-scope-context)
+               (lambda () (ai-code--empty-scope-context))))
+      (should-not (ai-code--current-qualified-scope-name)))))
+
 (provide 'test_ai-code-treesit)
 ;;; test_ai-code-treesit.el ends here

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -185,6 +185,11 @@
                  (should (= beg 10))
                  (should (= end 42))
                  "ai-code.el#L10-L11"))
+              ((symbol-function 'ai-code--scope-context-for-region)
+               (lambda (beg end)
+                 (should (= beg 10))
+                 (should (= end 42))
+                 nil))
               ((symbol-function 'ai-code-read-string)
                (lambda (prompt &optional _initial-input _candidate-list)
                  (should (string-match-p "Describe the Emacs runtime issue" prompt))
@@ -225,8 +230,10 @@
               ((symbol-function 'ai-code--get-region-location-info)
                (lambda (_beg _end)
                  "ai-code.el#L10-L11"))
-              ((symbol-function 'ai-code--current-scope-context)
-               (lambda (&optional _)
+              ((symbol-function 'ai-code--scope-context-for-region)
+               (lambda (beg end)
+                 (should (= beg 10))
+                 (should (= end 42))
                  (list :function-name "ai-code-test-command"
                        :class-name "RuntimeDebugger"
                        :class-header "class RuntimeDebugger:"

--- a/test/test_ai-code.el
+++ b/test/test_ai-code.el
@@ -225,8 +225,13 @@
               ((symbol-function 'ai-code--get-region-location-info)
                (lambda (_beg _end)
                  "ai-code.el#L10-L11"))
-              ((symbol-function 'which-function)
-               (lambda () "ai-code-test-command"))
+              ((symbol-function 'ai-code--current-scope-context)
+               (lambda (&optional _)
+                 (list :function-name "ai-code-test-command"
+                       :class-name "RuntimeDebugger"
+                       :class-header "class RuntimeDebugger:"
+                       :function-header "(defun ai-code-test-command ()"
+                       :range (cons (point-min) (point-max)))))
               ((symbol-function 'ai-code--get-context-files-string)
                (lambda () "\nFiles:\n/tmp/project/ai-code.el\n/tmp/project/ai-code-discussion.el"))
               ((symbol-function 'ai-code--format-repo-context-info)
@@ -250,6 +255,10 @@
     (should (string-match-p "Current file: /tmp/project/ai-code\\.el"
                             (cadr confirm-read-args)))
     (should (string-match-p "Function: ai-code-test-command"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Class definition: class RuntimeDebugger:"
+                            (cadr confirm-read-args)))
+    (should (string-match-p "Function definition: (defun ai-code-test-command ()"
                             (cadr confirm-read-args)))
     (should (string-match-p "Selected region:" (cadr confirm-read-args)))
     (should (string-match-p "ai-code.el#L10-L11" (cadr confirm-read-args)))


### PR DESCRIPTION
### Summary
Integrate Tree-sitter AST-aware function detection and structural scope extraction across all AI Code actions, replacing fragile `which-function` calls while gracefully falling back in non-Tree-sitter buffers.

### Problem
Previously, contextual prompt generation (`ai-code-code-change`, `ai-code-ask-question`, `ai-code-implement-todo`, refactoring, and review tools) relied on `which-function` heuristics. In complex methods, modern language modes (`*-ts-mode`), or nested definitions, `which-function` can produce inaccurate function boundaries and misses vital enclosing class/struct declarations and type context.

### Approach
- **Unified Semantic Resolution**: Added `ai-code--treesit-available-p`, `ai-code--treesit-defun-at-point`, `ai-code--treesit-node-name`, `ai-code--treesit-enclosing-class-node`, `ai-code--current-function-name`, and `ai-code--current-scope-context` in `ai-code-utils.el`.
- **Structural Skeleton Enrichment**: When Tree-sitter is active (e.g. in `python-ts-mode`, `rust-ts-mode`, etc.), prompts automatically include enclosing class/struct names and signature headers alongside the exact function AST node.
- **Graceful Fallback**: Automatically falls back to `which-function` and standard buffer analysis when Tree-sitter is not available or inactive.
- **Systematic Adoption**: Replaced direct `which-function` calls across `ai-code-change.el`, `ai-code-discussion.el`, `ai-code-agile.el`, `ai-code-file.el`, `ai-code-github.el`, and `ai-code.el`.

### Verification
- Added comprehensive unit tests in `test/test_ai-code-treesit.el`.
- Ran full test suite (1355 tests: 1342 passed, 0 unexpected failures, 13 skipped).
- Verified batch byte-compilation (0 new warnings) and `checkdoc` compliance.