### PR TITLE
Update Grill harness to frontier-based rounds

### DIFF
--- a/prompt/grilling.v1.md
+++ b/prompt/grilling.v1.md
@@ -1,13 +1,15 @@
-Interview the user to clarify or stress-test the request before acting.
+Interview the user to clarify or stress-test the request before acting. Map unresolved decisions as a design tree: decisions may depend on other decisions, and those dependencies determine what can be asked next.
 
-Ask exactly one question at a time and wait for the user's response. For every question, provide your recommended answer and briefly explain why.
+Work through the tree in rounds. The frontier is the set of decisions whose prerequisites are already settled. In each round, ask the whole frontier: number the questions, provide your recommended answer for each, and briefly explain why. Then wait for the user's answers before continuing.
 
-Before asking the user for factual information, inspect the available repository, files, tests, documentation, tools, and environment. Ask the user only about decisions, preferences, priorities, trade-offs, scope, constraints, and acceptance criteria that cannot be determined from the environment.
+After each round, recompute the frontier from the user's answers. Questions that depend on an unresolved decision belong to a later round, not the current one.
 
-The decisions belong to the user. Provide a recommendation, but do not silently adopt it or move past the decision until the user answers.
+Before asking the user for factual information, inspect the available repository, files, tests, documentation, tools, and environment. Finding facts is your responsibility; use available tools or parallel exploration when useful. Ask the user only about decisions, preferences, priorities, trade-offs, scope, constraints, and acceptance criteria that cannot be determined from the environment.
 
-Follow important branches of the decision tree and resolve dependent decisions in a sensible order. Avoid questions that would not materially change the result.
+The decisions belong to the user. Provide recommendations, but do not silently adopt them or move past an unresolved decision until the user answers.
+
+Follow the important branches of the design tree that could materially change the result. Avoid questions whose answers would not affect the implementation, scope, or acceptance criteria.
 
 Do not modify code, files, configuration, or external state until the user explicitly confirms that shared understanding has been reached.
 
-When shared understanding appears complete, summarize the goal, agreed decisions, scope and non-goals, constraints, acceptance criteria, and remaining assumptions, then ask the user whether to proceed.
+When the frontier is empty, summarize the goal, agreed decisions, scope and non-goals, constraints, acceptance criteria, and remaining assumptions. Then ask the user whether to proceed.


### PR DESCRIPTION
## Summary

Update the bundled Grill prompt to follow the current upstream `mattpocock/skills` grilling model.

## What changed

- replace the old one-question-at-a-time interview with a design-tree / frontier model
- ask all currently independent decisions in one numbered round, then recompute the frontier from the user's answers
- keep dependent questions for later rounds
- preserve the existing ai-code behavior that facts should be discovered from the repository/tools rather than asked of the user
- preserve explicit user ownership of decisions and the final confirmation before any code or external state is changed
- keep the wording backend-neutral rather than requiring a specific sub-agent implementation
- keep the existing materiality filter so routine coding requests do not get over-grilled

## Upstream context

This follows the upstream change that reworked `grilling` from one-question-at-a-time to round-by-round frontier interviews:

https://github.com/mattpocock/skills/commit/b8fd9afa42a6eebcfdcfc5007c42ef2367911000

Current upstream prompt:

https://github.com/mattpocock/skills/blob/main/skills/productivity/grilling/SKILL.md

The local prompt intentionally keeps ai-code's coding-oriented safeguards and avoids hard-coding upstream's `dispatch a sub-agent` wording so it remains portable across supported AI backends.

## Validation

Prompt-only change. Verified the final branch diff is limited to `prompt/grilling.v1.md`; no runtime Elisp behavior changed.