### PR TITLE
Add prompt editing support for task files

### DIFF
--- a/ai-code-prompt-editing.el
+++ b/ai-code-prompt-editing.el
@@ -41,6 +41,7 @@
 (declare-function ai-code--get-files-directory "ai-code-utils" ())
 (declare-function ai-code--git-root "ai-code-git" (&optional dir))
 (declare-function ai-code--prompt-filepath-candidates "ai-code-prompt-mode" ())
+(declare-function company-begin-backend "company" (backend &optional callback))
 (declare-function company-mode "company" (&optional arg))
 (declare-function helm-imenu "helm-imenu" ())
 (declare-function magit-get-current-branch "magit-git" ())
@@ -50,6 +51,7 @@
 
 (defvar ai-code-files-dir-name)
 (defvar company-backends)
+(defvar company-mode)
 
 
 ;;;; Reference gating
@@ -130,8 +132,9 @@ deliberately suppressed."
         ;; usable both before and after "@" has been entered.
         (let ((start (save-excursion
                        (skip-chars-backward ai-code--prompt-reference-chars)
-                       (if (eq (char-before) ?@) (1- (point)) (point)))))
-          (when (< start (point))
+                       (when (eq (char-before) ?@)
+                         (1- (point))))))
+          (when start
             (delete-region start (point))))
         (insert choice)))))
 
@@ -158,6 +161,20 @@ enabled buffer-locally so `global-company-mode' stays off."
     ;; Only capf, so company offers exactly the @reference candidates.
     (setq-local company-backends '(company-capf))
     (company-mode 1)))
+
+(defun ai-code--prompt-start-inline-reference-completion ()
+  "Start non-blocking @reference completion in the current prompt buffer.
+Prefer the buffer-local Company CAPF backend configured by
+`ai-code--prompt-setup-inline-completion'.  Fall back to the standard
+`completion-at-point' UI when Company is unavailable."
+  (if (and (bound-and-true-p company-mode)
+           (fboundp 'company-begin-backend))
+      (condition-case nil
+          (company-begin-backend 'company-capf)
+        ;; Company reports an empty CAPF result as a user error.  Typing the
+        ;; sigil in an empty repository should simply leave it unchanged.
+        (user-error nil))
+    (completion-at-point)))
 
 
 ;;;; Navigation

--- a/ai-code-prompt-editing.el
+++ b/ai-code-prompt-editing.el
@@ -1,0 +1,494 @@
+;;; ai-code-prompt-editing.el --- Editing support for prompt task files -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Editing support for AI prompt task files, for people who write their
+;; prompts in Emacs rather than in a chat box.
+;;
+;; Four concerns, in dependency order:
+;;
+;; Reference gating
+;;   Prompt files routinely embed pasted source code, where "@" is a Java
+;;   annotation rather than a file reference.  Firing a completion prompt on
+;;   every "@" makes pasting code hostile, so completion is offered only at
+;;   positions that can plausibly start a reference.
+;;
+;; Navigation
+;;   Task files grow to thousands of lines with headings seven levels deep,
+;;   so plain Org navigation is not enough: outline-path jumping, subtree
+;;   focus, and per-file startup folding that leaves the global
+;;   `org-startup-folded' setting alone.
+;;
+;; Writing
+;;   Task files mix prose with pasted code and logs.  Keep the spell checker
+;;   off the pasted parts, make wrapping pasted text in a block a single
+;;   command, and offer an opt-in prose-friendly layout.
+;;
+;; Reuse
+;;   Accumulated task files are the most useful prompt corpus available, but
+;;   nothing reads them back.  Search them, offer snippets by name rather
+;;   than by key abbreviation, and expose small context helpers for
+;;   parameterising a prompt with the current file, branch, or function.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'org)
+(require 'subr-x)
+
+(declare-function ai-code--get-files-directory "ai-code-utils" ())
+(declare-function ai-code--git-root "ai-code-git" (&optional dir))
+(declare-function ai-code--prompt-filepath-candidates "ai-code-prompt-mode" ())
+(declare-function company-mode "company" (&optional arg))
+(declare-function helm-imenu "helm-imenu" ())
+(declare-function magit-get-current-branch "magit-git" ())
+(declare-function visual-fill-column-mode "visual-fill-column" (&optional arg))
+(declare-function which-function "which-func" ())
+(declare-function yas-expand-snippet "yasnippet" (snippet &optional start end expand-env))
+
+(defvar ai-code-files-dir-name)
+(defvar company-backends)
+
+
+;;;; Reference gating
+
+(defconst ai-code--prompt-block-begin-regexp
+  "^[ \t]*#\\+begin_\\(src\\|example\\|quote\\|export\\|verse\\)\\_>"
+  "Regexp matching the start of an Org block whose body is literal text.")
+
+(defconst ai-code--prompt-block-end-regexp
+  "^[ \t]*#\\+end_\\(src\\|example\\|quote\\|export\\|verse\\)\\_>"
+  "Regexp matching the end of an Org block whose body is literal text.")
+
+(defun ai-code--prompt-inside-literal-block-p (&optional pos)
+  "Return non-nil when POS sits inside a literal Org block.
+POS defaults to point.  Detection is textual rather than based on
+`org-in-src-block-p' so that it also works in buffers that are not
+derived from `org-mode', such as the temporary buffers used by tests."
+  (save-excursion
+    (save-restriction
+      (widen)
+      (goto-char (or pos (point)))
+      (forward-line 0)
+      (let ((case-fold-search t))
+        ;; The nearest preceding delimiter decides: a begin line means the
+        ;; position is enclosed, an end line means it is not.
+        (and (re-search-backward
+              (concat ai-code--prompt-block-begin-regexp
+                      "\\|" ai-code--prompt-block-end-regexp)
+              nil t)
+             (looking-at-p ai-code--prompt-block-begin-regexp))))))
+
+(defconst ai-code--prompt-reference-word-char-regexp "[[:alnum:]_]"
+  "Regexp matching a character that glues \"@\" into a surrounding word.
+Spelled as an explicit character class rather than a syntax-table query so
+that gating behaves identically in buffers not derived from `org-mode'.")
+
+(defun ai-code--prompt-reference-position-p (&optional sigil-pos)
+  "Return non-nil when SIGIL-POS starts a file reference rather than prose.
+SIGIL-POS is the position of the \"@\" character and defaults to the
+character just before point, which is where the auto-trigger hook runs
+immediately after \"@\" is typed.
+
+A position qualifies when it is outside any literal Org block and the
+\"@\" begins a word, so pasted annotations like \"@Override\" and address
+fragments like \"user@\" are both rejected."
+  (let ((sigil-pos (or sigil-pos (1- (point)))))
+    (and (>= sigil-pos (point-min))
+         (not (ai-code--prompt-inside-literal-block-p sigil-pos))
+         (or (= sigil-pos (point-min))
+             (not (string-match-p
+                   ai-code--prompt-reference-word-char-regexp
+                   (buffer-substring-no-properties (1- sigil-pos)
+                                                   sigil-pos)))))))
+
+(defconst ai-code--prompt-reference-chars "A-Za-z0-9_./-"
+  "Character set that may follow \"@\" inside a file reference.")
+
+(defvar helm-mode-no-completion-in-region-in-modes nil
+  "Modes in which `helm-mode' leaves `completion-in-region' alone.
+Defined here as well as in helm so that the opt-out can be registered
+before helm loads; helm reuses this value when it loads later.")
+
+;;;###autoload
+(defun ai-code-prompt-complete-reference ()
+  "Select a repository file and insert it as an @reference at point.
+Unlike the automatic trigger, this command is explicit, so it works
+everywhere including inside source blocks, where auto-triggering is
+deliberately suppressed."
+  (interactive)
+  (unless (ai-code--git-root)
+    (user-error "Not inside a Git repository"))
+  (let ((candidates (ai-code--prompt-filepath-candidates)))
+    (unless candidates
+      (user-error "No candidate files found"))
+    (let ((choice (completing-read "File: " candidates nil nil)))
+      (when (and choice (not (string-empty-p choice)))
+        ;; Replace an already-typed partial reference so the command is
+        ;; usable both before and after "@" has been entered.
+        (let ((start (save-excursion
+                       (skip-chars-backward ai-code--prompt-reference-chars)
+                       (if (eq (char-before) ?@) (1- (point)) (point)))))
+          (when (< start (point))
+            (delete-region start (point))))
+        (insert choice)))))
+
+(defun ai-code--prompt-opt-out-of-helm-completion-in-region ()
+  "Register `ai-code-prompt-mode' in helm's opt-out list for that completion.
+Tolerates the option being unbound, because helm may not have loaded yet
+and aborting here would prevent the major mode from activating at all."
+  (unless (boundp 'helm-mode-no-completion-in-region-in-modes)
+    (setq helm-mode-no-completion-in-region-in-modes nil))
+  (add-to-list 'helm-mode-no-completion-in-region-in-modes 'ai-code-prompt-mode))
+
+(defun ai-code--prompt-setup-inline-completion ()
+  "Prefer inline, non-blocking completion in the current prompt buffer.
+`helm-mode' otherwise routes `completion-in-region' through a blocking
+window; helm supports opting a mode out by name, which leaves helm's
+behavior in every other buffer untouched.  Company, when available, is
+enabled buffer-locally so `global-company-mode' stays off."
+  ;; Use helm's documented opt-out rather than advising helm internals.
+  (ai-code--prompt-opt-out-of-helm-completion-in-region)
+  ;; Fuzzy matching is worth having for long repository-relative paths.
+  (unless (memq 'flex completion-styles)
+    (setq-local completion-styles (append completion-styles '(flex))))
+  (when (fboundp 'company-mode)
+    ;; Only capf, so company offers exactly the @reference candidates.
+    (setq-local company-backends '(company-capf))
+    (company-mode 1)))
+
+
+;;;; Navigation
+
+(defgroup ai-code-prompt-nav nil
+  "Navigation inside AI prompt task files."
+  :group 'ai-code
+  :prefix "ai-code-prompt-")
+
+(defcustom ai-code-prompt-startup-folded 'content
+  "How AI prompt task files are folded when first opened.
+Only task files are affected, so the global `org-startup-folded' setting
+keeps applying to every other Org buffer.
+
+`content' shows all headings and hides body text, `overview' shows only
+top-level headings, and nil disables folding entirely."
+  :type '(choice (const :tag "Show all headings" content)
+                 (const :tag "Show top-level headings only" overview)
+                 (const :tag "Do not fold" nil))
+  :group 'ai-code-prompt-nav)
+
+(defcustom ai-code-prompt-focus-style 'narrow
+  "How `ai-code-prompt-focus-subtree' isolates a subtree.
+`narrow' restricts the current buffer, while `indirect' opens the subtree
+in a separate indirect buffer and leaves the original untouched."
+  :type '(choice (const :tag "Narrow the current buffer" narrow)
+                 (const :tag "Open an indirect buffer" indirect))
+  :group 'ai-code-prompt-nav)
+
+(defun ai-code--prompt-heading-candidates ()
+  "Return an alist of (OUTLINE-PATH-LABEL . POSITION) for every heading.
+The label is the full outline path, so headings that share a short name at
+different depths stay distinguishable."
+  (let (candidates)
+    (save-excursion
+      (save-restriction
+        (widen)
+        (goto-char (point-min))
+        (org-map-entries
+         (lambda ()
+           (let* ((path (append (org-get-outline-path)
+                                (list (org-get-heading t t t t))))
+                  (label (mapconcat #'identity (delq nil path) " / ")))
+             (push (cons label (point)) candidates))))))
+    (nreverse candidates)))
+
+;;;###autoload
+(defun ai-code-prompt-goto-heading ()
+  "Jump to a heading chosen by its full outline path.
+Use `helm-imenu' when helm is available, since it offers live narrowing
+over the same Org outline; otherwise fall back to `completing-read'."
+  (interactive)
+  (if (and (fboundp 'helm-imenu) (not noninteractive))
+      (helm-imenu)
+    (let ((candidates (ai-code--prompt-heading-candidates)))
+      (unless candidates
+        (user-error "No headings in this buffer"))
+      (let* ((label (completing-read "Heading: " candidates nil t))
+             (position (cdr (assoc label candidates))))
+        (unless position
+          (user-error "No heading matches %s" label))
+        (widen)
+        (goto-char position)
+        (when (fboundp 'org-fold-show-context)
+          (ignore-errors (org-fold-show-context 'org-goto)))))))
+
+;;;###autoload
+(defun ai-code-prompt-focus-subtree ()
+  "Focus the subtree at point, or restore the full view when already focused.
+The behavior is controlled by `ai-code-prompt-focus-style'."
+  (interactive)
+  (cond
+   ;; Already focused, so this invocation restores the full buffer.
+   ((buffer-narrowed-p) (widen))
+   ((eq ai-code-prompt-focus-style 'indirect)
+    (org-tree-to-indirect-buffer))
+   (t (org-narrow-to-subtree))))
+
+(defun ai-code--prompt-task-directory-name ()
+  "Return the directory name that identifies AI prompt task files."
+  (if (boundp 'ai-code-files-dir-name)
+      ai-code-files-dir-name
+    ".ai.code.files"))
+
+(defun ai-code--prompt-task-file-p (&optional file)
+  "Return non-nil when FILE lives under the AI prompt task directory.
+FILE defaults to the current buffer's file name."
+  (let ((file (or file buffer-file-name)))
+    (and file
+         (string-match-p (concat "/" (regexp-quote
+                                      (ai-code--prompt-task-directory-name))
+                                 "/")
+                         file)
+         t)))
+
+(defun ai-code--prompt-apply-startup-folding ()
+  "Fold the current buffer when it is a task file and folding is enabled."
+  (when (and ai-code-prompt-startup-folded
+             (ai-code--prompt-task-file-p))
+    (pcase ai-code-prompt-startup-folded
+      ('overview (org-overview))
+      (_ (org-content)))))
+
+
+;;;; Writing
+
+(defgroup ai-code-prompt-writing nil
+  "Long-form writing support for AI prompt files."
+  :group 'ai-code
+  :prefix "ai-code-prompt-")
+
+(defcustom ai-code-prompt-writing-fill-column 90
+  "Text width used by `ai-code-prompt-writing-mode'.
+Applies only when `visual-fill-column-mode' is available; the underlying
+buffer text is never re-wrapped, so prompts sent to an agent are
+unaffected."
+  :type 'integer
+  :group 'ai-code-prompt-writing)
+
+(defun ai-code--prompt-flyspell-verify ()
+  "Return non-nil when the word at point should be spell checked.
+Words inside literal Org blocks are code, logs, or transcripts rather than
+prose, so checking them produces only noise."
+  (not (ai-code--prompt-inside-literal-block-p)))
+
+;;;###autoload
+(defun ai-code-prompt-wrap-region-in-block (type)
+  "Wrap the active region in an Org block of TYPE.
+TYPE is the text following `#+begin_', so \"example\" or \"src java\" are
+both valid.  Only the first word is repeated in the closing delimiter."
+  (interactive
+   (list (completing-read "Block type: "
+                          '("example" "quote" "src" "src java" "src python"
+                            "src emacs-lisp" "src sh")
+                          nil nil nil nil "example")))
+  (unless (use-region-p)
+    (user-error "No active region to wrap"))
+  (let* ((start (region-beginning))
+         (end (region-end))
+         ;; The closing delimiter names the block, never its arguments.
+         (keyword (car (split-string type " " t))))
+    (save-excursion
+      (goto-char end)
+      (unless (bolp) (insert "\n"))
+      (insert (format "#+end_%s\n" keyword))
+      (goto-char start)
+      (forward-line 0)
+      (insert (format "#+begin_%s\n" type)))))
+
+;;;###autoload
+(define-minor-mode ai-code-prompt-writing-mode
+  "Minor mode for comfortable long-form prompt writing.
+Wraps long lines visually and, when `visual-fill-column-mode' is
+available, centres the text at `ai-code-prompt-writing-fill-column'.  Only
+the display changes; buffer text is never modified."
+  :init-value nil
+  :lighter " AIWrite"
+  :group 'ai-code-prompt-writing
+  (if ai-code-prompt-writing-mode
+      (progn
+        (visual-line-mode 1)
+        (when (fboundp 'visual-fill-column-mode)
+          (setq-local visual-fill-column-width ai-code-prompt-writing-fill-column)
+          (visual-fill-column-mode 1)))
+    (visual-line-mode -1)
+    (when (fboundp 'visual-fill-column-mode)
+      (visual-fill-column-mode -1))))
+
+
+;;;; Reuse
+
+(defgroup ai-code-prompt-reuse nil
+  "Reuse of existing prompts and snippets."
+  :group 'ai-code
+  :prefix "ai-code-prompt-")
+
+(defcustom ai-code-prompt-corpus-additional-roots nil
+  "Extra task directories to search with a prefix argument.
+Each entry is a directory holding task Org files, typically the
+`.ai.code.files' directory of another repository."
+  :type '(repeat directory)
+  :group 'ai-code-prompt-reuse)
+
+(defcustom ai-code-prompt-corpus-min-length 25
+  "Minimum length of a corpus line offered for reuse.
+Short lines are usually fragments rather than reusable prompts."
+  :type 'integer
+  :group 'ai-code-prompt-reuse)
+
+(defun ai-code--prompt-corpus-roots (&optional all)
+  "Return the task directories to search, most relevant first.
+Search only the current repository unless ALL is non-nil, in which case
+`ai-code-prompt-corpus-additional-roots' is included as well."
+  (let ((roots (list (ai-code--get-files-directory))))
+    (when all
+      (setq roots (append roots ai-code-prompt-corpus-additional-roots)))
+    (delete-dups (delq nil roots))))
+
+(defun ai-code--prompt-corpus-files (roots)
+  "Return every task Org file under ROOTS."
+  (cl-loop for root in roots
+           when (and root (file-directory-p root))
+           append (directory-files-recursively root "\\.org\\'")))
+
+(defun ai-code--prompt-corpus-candidate-p (line)
+  "Return non-nil when LINE is worth offering as a reusable prompt.
+Headings, comments, keywords, block delimiters, and drawers describe the
+document rather than the prompt, so they are filtered out."
+  (and (>= (length line) ai-code-prompt-corpus-min-length)
+       (not (string-match-p "\\`[ \t]*\\*+ " line))
+       (not (string-match-p "\\`[ \t]*#" line))
+       (not (string-match-p "\\`[ \t]*:" line))))
+
+(defun ai-code--prompt-corpus-lines (roots)
+  "Return deduplicated reusable prompt lines from the task files under ROOTS."
+  (let (lines)
+    (dolist (file (ai-code--prompt-corpus-files roots))
+      (when (file-readable-p file)
+        (with-temp-buffer
+          (insert-file-contents file)
+          (goto-char (point-min))
+          (while (not (eobp))
+            (let ((line (string-trim
+                         (buffer-substring-no-properties
+                          (line-beginning-position) (line-end-position)))))
+              (when (ai-code--prompt-corpus-candidate-p line)
+                (push line lines)))
+            (forward-line 1)))))
+    (delete-dups (nreverse lines))))
+
+;;;###autoload
+(defun ai-code-prompt-insert-from-history (arg)
+  "Insert a previously written prompt, chosen from past task files, at point.
+With a prefix argument ARG, widen the search to
+`ai-code-prompt-corpus-additional-roots' as well as the current repository."
+  (interactive "P")
+  (let* ((roots (ai-code--prompt-corpus-roots arg))
+         (lines (ai-code--prompt-corpus-lines roots)))
+    (unless lines
+      (user-error "No reusable prompts found in %s"
+                  (mapconcat #'identity roots ", ")))
+    (let ((choice (completing-read "Previous prompt: " lines nil t)))
+      (when (and choice (not (string-empty-p choice)))
+        (insert choice)))))
+
+(defun ai-code--prompt-snippet-directory ()
+  "Return the directory holding the prompt-mode snippets, or nil."
+  (when-let* ((library (locate-library "ai-code"))
+              (dir (expand-file-name
+                    "snippets/ai-code-prompt-mode"
+                    (file-name-directory (file-truename library)))))
+    (and (file-directory-p dir) dir)))
+
+(defun ai-code--prompt-parse-snippet-file (file)
+  "Return a (NAME . KEY) pair parsed from snippet FILE, or nil.
+Metadata comes from the yasnippet header comments, so no yasnippet
+internals are needed to list the library."
+  (when (file-readable-p file)
+    (with-temp-buffer
+      ;; The header is short; reading the whole file would be wasteful.
+      (insert-file-contents file nil 0 2048)
+      (let ((name nil) (key nil))
+        (goto-char (point-min))
+        (when (re-search-forward "^# *name: *\\(.*\\)$" nil t)
+          (setq name (string-trim (match-string 1))))
+        (goto-char (point-min))
+        (when (re-search-forward "^# *key: *\\(.*\\)$" nil t)
+          (setq key (string-trim (match-string 1))))
+        ;; Fall back to the file name, which is the key by convention.
+        (unless key (setq key (file-name-nondirectory file)))
+        (when (and name (not (string-empty-p name)))
+          (cons name key))))))
+
+(defun ai-code--prompt-snippet-candidates ()
+  "Return an alist of (NAME . KEY) for every prompt-mode snippet."
+  (when-let* ((dir (ai-code--prompt-snippet-directory)))
+    (let (candidates)
+      (dolist (file (directory-files dir t "\\`[^.]"))
+        (when (file-regular-p file)
+          (when-let* ((parsed (ai-code--prompt-parse-snippet-file file)))
+            (push (cons (format "%s (%s)" (car parsed) (cdr parsed))
+                        (cdr parsed))
+                  candidates))))
+      (sort candidates (lambda (a b) (string< (car a) (car b)))))))
+
+;;;###autoload
+(defun ai-code-prompt-insert-snippet ()
+  "Insert a prompt snippet chosen by its descriptive name.
+Snippet keys are terse, so browsing by name is the discoverable path into
+the snippet library."
+  (interactive)
+  (let ((candidates (ai-code--prompt-snippet-candidates)))
+    (unless candidates
+      (user-error "No prompt snippets found"))
+    (let* ((label (completing-read "Snippet: " candidates nil t))
+           (key (cdr (assoc label candidates))))
+      (unless key
+        (user-error "No snippet matches %s" label))
+      (insert key)
+      ;; Expand through yasnippet when available, else leave the key so the
+      ;; user can expand it manually.
+      (when (fboundp 'yas-expand)
+        (ignore-errors (funcall (intern "yas-expand")))))))
+
+(defun ai-code--prompt-ctx-file ()
+  "Return the current buffer's repository-relative file name, or nil."
+  (when-let* ((file buffer-file-name))
+    (let ((root (ignore-errors (ai-code--git-root))))
+      (if root
+          (file-relative-name file root)
+        (file-name-nondirectory file)))))
+
+(defun ai-code--prompt-ctx-branch ()
+  "Return the current Git branch name, or nil when unavailable."
+  (ignore-errors (magit-get-current-branch)))
+
+(defun ai-code--prompt-ctx-defun ()
+  "Return the name of the function surrounding point, or nil."
+  (and (require 'which-func nil t)
+       (ignore-errors (which-function))))
+
+(defun ai-code--prompt-ctx-diff ()
+  "Return the staged diff of the current repository, or nil when empty."
+  (when-let* ((root (ignore-errors (ai-code--git-root))))
+    (let ((default-directory root))
+      (let ((diff (ignore-errors
+                    (with-output-to-string
+                      (with-current-buffer standard-output
+                        (call-process "git" nil t nil "diff" "--staged"))))))
+        (and diff (not (string-empty-p (string-trim diff))) diff)))))
+
+(provide 'ai-code-prompt-editing)
+
+;;; ai-code-prompt-editing.el ends here

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -683,12 +683,7 @@ GIT-ROOT-TRUENAME is the normalized Git root."
   (when (not (minibufferp))
     (pcase (char-before)
       ((and ?@ (guard (ai-code--prompt-reference-position-p)))
-       (let ((candidates (ai-code--prompt-filepath-candidates)))
-         (when candidates
-           (let ((choice (completing-read "File: " candidates nil nil)))
-             (when (and choice (not (string-empty-p choice)))
-               (delete-char -1)  ; Remove the '@' we just typed
-               (insert choice))))))
+       (ai-code--prompt-start-inline-reference-completion))
       (?#
        (require 'ai-code-input nil t)
        (when (and (fboundp 'ai-code--hash-completion-target-file)
@@ -747,7 +742,10 @@ Special commands:
 ;; Bound at load time rather than inside the mode body, so the bindings are
 ;; discoverable through `describe-mode' before the mode is ever activated.
 (define-key ai-code-prompt-mode-map (kbd "C-c C-c") #'ai-code-prompt-send-block)
-(define-key ai-code-prompt-mode-map (kbd "C-c @") #'ai-code-prompt-complete-reference)
+;; This map defines its own C-c prefix, so preserve Org's subtree command
+;; explicitly instead of relying on keymap inheritance for this sequence.
+(define-key ai-code-prompt-mode-map (kbd "C-c @") #'org-mark-subtree)
+(define-key ai-code-prompt-mode-map (kbd "C-c r") #'ai-code-prompt-complete-reference)
 (define-key ai-code-prompt-mode-map (kbd "C-c j") #'ai-code-prompt-goto-heading)
 (define-key ai-code-prompt-mode-map (kbd "C-c f") #'ai-code-prompt-focus-subtree)
 (define-key ai-code-prompt-mode-map (kbd "C-c m") #'ai-code--mark-prompt-block)

--- a/ai-code-prompt-mode.el
+++ b/ai-code-prompt-mode.el
@@ -14,8 +14,10 @@
 (require 'org)
 (require 'magit)
 (require 'ai-code-utils)
+(require 'ai-code-prompt-editing)
 
 (defvar yas-snippet-dirs)
+(defvar flyspell-generic-check-word-predicate)
 
 (defvar ai-code-use-gptel-headline nil)
 (defvar ai-code-prompt-suffix)
@@ -671,7 +673,7 @@ GIT-ROOT-TRUENAME is the normalized Git root."
                    (skip-chars-backward "A-Za-z0-9_./-")
                    (when (eq (char-before) ?@)
                      (1- (point))))))
-      (when start
+      (when (and start (ai-code--prompt-reference-position-p start))
         (let ((candidates (ai-code--prompt-filepath-candidates)))
           (when candidates
             (list start end candidates :exclusive 'no)))))))
@@ -680,7 +682,7 @@ GIT-ROOT-TRUENAME is the normalized Git root."
   "Auto trigger file path/symbol completion when '@' or '#' is inserted."
   (when (not (minibufferp))
     (pcase (char-before)
-      (?@
+      ((and ?@ (guard (ai-code--prompt-reference-position-p)))
        (let ((candidates (ai-code--prompt-filepath-candidates)))
          (when candidates
            (let ((choice (completing-read "File: " candidates nil nil)))
@@ -730,13 +732,29 @@ Special commands:
   (setq-local comment-start "# ")
   (setq-local comment-end "")
   (setq-local truncate-lines nil)  ; Disable line truncation, allowing lines to wrap
-  (define-key ai-code-prompt-mode-map (kbd "C-c C-c") #'ai-code-prompt-send-block)
   (add-hook 'completion-at-point-functions #'ai-code--prompt-filepath-capf nil t)
   (add-hook 'post-self-insert-hook #'ai-code--prompt-auto-trigger-filepath-completion nil t)
+  ;; Keep the spell checker away from pasted code and logs.
+  (setq-local flyspell-generic-check-word-predicate
+              #'ai-code--prompt-flyspell-verify)
+  (ai-code--prompt-setup-inline-completion)
+  (ai-code--prompt-apply-startup-folding)
   ;; YASnippet support
   (when (require 'yasnippet nil t)
     (yas-minor-mode 1)
     (ai-code--setup-snippets)))
+
+;; Bound at load time rather than inside the mode body, so the bindings are
+;; discoverable through `describe-mode' before the mode is ever activated.
+(define-key ai-code-prompt-mode-map (kbd "C-c C-c") #'ai-code-prompt-send-block)
+(define-key ai-code-prompt-mode-map (kbd "C-c @") #'ai-code-prompt-complete-reference)
+(define-key ai-code-prompt-mode-map (kbd "C-c j") #'ai-code-prompt-goto-heading)
+(define-key ai-code-prompt-mode-map (kbd "C-c f") #'ai-code-prompt-focus-subtree)
+(define-key ai-code-prompt-mode-map (kbd "C-c m") #'ai-code--mark-prompt-block)
+(define-key ai-code-prompt-mode-map (kbd "C-c b") #'ai-code-prompt-wrap-region-in-block)
+(define-key ai-code-prompt-mode-map (kbd "C-c w") #'ai-code-prompt-writing-mode)
+(define-key ai-code-prompt-mode-map (kbd "C-c h") #'ai-code-prompt-insert-from-history)
+(define-key ai-code-prompt-mode-map (kbd "C-c s") #'ai-code-prompt-insert-snippet)
 
 ;;;###autoload
 (defun ai-code-prompt-send-block ()

--- a/ai-code-task.el
+++ b/ai-code-task.el
@@ -90,6 +90,8 @@ Returns a filename with .org suffix."
     (insert (format "#+AGENT: %s\n" label))
     (insert
      "#+SESSION_ID: <Usually you can get the session id with /status or /stat in AI coding window>\n"))
+  ;; Task files grow long, so open them showing headings only.
+  (insert "#+STARTUP: content\n")
   (insert "\n* Task Description\n\n")
   (insert task-name)
   (insert "\n\n* Investigation\n\n")

--- a/test/run_ai_code_prompt_editing_gauntlet.sh
+++ b/test/run_ai_code_prompt_editing_gauntlet.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# Gauntlet for the prompt editing enhancements.
+#
+# Runs every applicable constraint layer as an executable gate. Any layer that
+# does not run, crashes, or cannot enforce its constraint is a failure, never a
+# pass.
+#
+# Usage: test/run_ai_code_prompt_editing_gauntlet.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Files under test.
+NEW_FILES=(ai-code-prompt-editing.el)
+CHANGED_FILES=(ai-code-prompt-mode.el ai-code-task.el)
+ALL_FILES=("${NEW_FILES[@]}" "${CHANGED_FILES[@]}")
+
+FOCUSED_TESTS=(test/test_ai-code-prompt-editing.el)
+
+# Number of pre-existing failures in the suite, recorded verbatim at spec time.
+# Any deviation fails the run.
+BASELINE_UNEXPECTED=13
+
+# An isolated package directory works around a pre-existing bug in
+# test/test_00-bootstrap.el, which passes full paths to `version<' and so
+# crashes when two versions of a dependency are installed locally.
+PKG_DIR="${AI_CODE_GAUNTLET_PKG_DIR:-}"
+
+FAILURES=()
+LAYERS_RUN=()
+
+fail_layer() {
+  echo "FAIL: $1"
+  FAILURES+=("$1")
+}
+
+record_layer() {
+  LAYERS_RUN+=("$1")
+}
+
+# ---------------------------------------------------------------------------
+# Emacs invocation
+# ---------------------------------------------------------------------------
+
+emacs_batch() {
+  if [[ -n "$PKG_DIR" ]]; then
+    emacs -Q -batch -L . \
+      --eval "(progn (setq package-user-dir \"$PKG_DIR\") (require 'package) (package-initialize))" \
+      "$@"
+  else
+    emacs -Q -batch -L . \
+      --eval "(progn (require 'package) (package-initialize))" \
+      "$@"
+  fi
+}
+
+# Run ERT over the given test files and echo the summary line.
+run_ert() {
+  emacs_batch -l test/test_00-bootstrap.el -l ert "$@" \
+    -f ert-run-tests-batch-and-exit 2>&1 || true
+}
+
+unexpected_count() {
+  # Extract the "N unexpected" figure from an ERT summary. Prints "MISSING"
+  # when no summary line exists, so a crashed run can never look like a pass.
+  local output="$1"
+  local line
+  line="$(printf '%s\n' "$output" | grep -E "^Ran [0-9]+ tests" | tail -1)"
+  if [[ -z "$line" ]]; then
+    echo "MISSING"
+    return
+  fi
+  if [[ "$line" =~ ([0-9]+)\ unexpected ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo 0
+  fi
+}
+
+ran_count() {
+  local output="$1"
+  local line
+  line="$(printf '%s\n' "$output" | grep -E "^Ran [0-9]+ tests" | tail -1)"
+  if [[ "$line" =~ ^Ran\ ([0-9]+)\ tests ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo MISSING
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: focused tests
+# ---------------------------------------------------------------------------
+
+echo "== Layer: focused tests =="
+FOCUSED_ARGS=()
+for f in "${FOCUSED_TESTS[@]}"; do
+  [[ -f "$f" ]] || { fail_layer "focused tests: missing input $f"; }
+  FOCUSED_ARGS+=(-l "$f")
+done
+FOCUSED_OUT="$(run_ert "${FOCUSED_ARGS[@]}")"
+FOCUSED_RAN="$(ran_count "$FOCUSED_OUT")"
+FOCUSED_BAD="$(unexpected_count "$FOCUSED_OUT")"
+echo "focused: ran=$FOCUSED_RAN unexpected=$FOCUSED_BAD"
+if [[ "$FOCUSED_BAD" != "0" ]]; then
+  fail_layer "focused tests: expected 0 unexpected, got $FOCUSED_BAD"
+fi
+if [[ "$FOCUSED_RAN" == "MISSING" || "$FOCUSED_RAN" -lt 50 ]]; then
+  fail_layer "focused tests: implausibly few tests ran ($FOCUSED_RAN)"
+fi
+record_layer "focused tests"
+
+# ---------------------------------------------------------------------------
+# Layer 2: full suite, compared against the recorded baseline
+# ---------------------------------------------------------------------------
+
+echo "== Layer: full suite =="
+FULL_OUT="$(run_ert --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))")"
+FULL_RAN="$(ran_count "$FULL_OUT")"
+FULL_BAD="$(unexpected_count "$FULL_OUT")"
+echo "full suite: ran=$FULL_RAN unexpected=$FULL_BAD (baseline $BASELINE_UNEXPECTED)"
+if [[ "$FULL_BAD" == "MISSING" ]]; then
+  fail_layer "full suite: no ERT summary, the run crashed"
+elif [[ "$FULL_BAD" -gt "$BASELINE_UNEXPECTED" ]]; then
+  fail_layer "full suite: $FULL_BAD unexpected exceeds baseline $BASELINE_UNEXPECTED"
+fi
+if [[ "$FULL_RAN" == "MISSING" || "$FULL_RAN" -lt 1400 ]]; then
+  fail_layer "full suite: implausibly few tests ran ($FULL_RAN)"
+fi
+record_layer "full suite"
+
+# ---------------------------------------------------------------------------
+# Layer 3: byte compilation, no new warnings
+# ---------------------------------------------------------------------------
+
+echo "== Layer: byte compilation =="
+rm -f ./*.elc
+# The bootstrap adds installed dependencies to `load-path'; without it magit is
+# unresolvable and the compile errors out instead of merely warning.
+BYTE_OUT="$(emacs_batch -l test/test_00-bootstrap.el -f batch-byte-compile "${ALL_FILES[@]}" 2>&1 || true)"
+BYTE_ERRORS="$(printf '%s\n' "$BYTE_OUT" | grep -cE "^[^ ]+\.el:[0-9]+:[0-9]+: Error:" || true)"
+if [[ "$BYTE_ERRORS" != "0" ]]; then
+  printf '%s\n' "$BYTE_OUT" | grep -E "Error:" | head -10
+  fail_layer "byte compilation: $BYTE_ERRORS errors"
+fi
+# Obsolete-macro warnings for when-let/if-let are pre-existing across the
+# repository and are not introduced by this work.
+BYTE_WARNINGS="$(printf '%s\n' "$BYTE_OUT" \
+  | grep -E "Warning:" \
+  | grep -vE "(when-let|if-let). is an obsolete macro" \
+  | grep -cE "Warning:" || true)"
+echo "byte compilation warnings (excluding pre-existing obsolete-macro): $BYTE_WARNINGS"
+if [[ "$BYTE_WARNINGS" != "0" ]]; then
+  printf '%s\n' "$BYTE_OUT" | grep -E "Warning:" \
+    | grep -vE "(when-let|if-let). is an obsolete macro" | head -20
+  fail_layer "byte compilation: $BYTE_WARNINGS new warnings"
+fi
+for f in "${ALL_FILES[@]}"; do
+  if [[ ! -f "${f}c" ]]; then
+    fail_layer "byte compilation: ${f}c was not produced"
+  fi
+done
+rm -f ./*.elc
+record_layer "byte compilation"
+
+# ---------------------------------------------------------------------------
+# Layer 4: checkdoc
+# ---------------------------------------------------------------------------
+
+echo "== Layer: checkdoc =="
+CHECKDOC_TOTAL=0
+for f in "${ALL_FILES[@]}"; do
+  n="$(emacs -Q -batch \
+        ${PKG_DIR:+--eval "(progn (setq package-user-dir \"$PKG_DIR\") (require 'package) (package-initialize))"} \
+        --eval "(progn (require 'checkdoc) (setq checkdoc-diagnostic-buffer \"*w*\") (checkdoc-file \"$f\"))" 2>&1 \
+        | grep -c "^$f:" || true)"
+  echo "checkdoc $f: $n"
+  CHECKDOC_TOTAL=$((CHECKDOC_TOTAL + n))
+done
+if [[ "$CHECKDOC_TOTAL" != "0" ]]; then
+  fail_layer "checkdoc: $CHECKDOC_TOTAL issues"
+fi
+record_layer "checkdoc"
+
+# ---------------------------------------------------------------------------
+# Layer 5: whitespace
+# ---------------------------------------------------------------------------
+
+echo "== Layer: whitespace =="
+if ! git diff --check; then
+  fail_layer "whitespace: git diff --check reported problems"
+fi
+record_layer "whitespace"
+
+# ---------------------------------------------------------------------------
+# Layer 6: mutation testing
+# ---------------------------------------------------------------------------
+#
+# Each mutant introduces one plausible bug. A mutant that cannot be applied is
+# an error, not a kill, so every application is verified with cmp before the
+# tests run.
+
+echo "== Layer: mutation =="
+
+MUTANTS_TOTAL=0
+MUTANTS_KILLED=0
+
+run_mutant() {
+  local name="$1" file="$2" perl_expr="$3"
+  local backup
+  backup="$(mktemp)"
+  cp "$file" "$backup"
+
+  MUTANTS_TOTAL=$((MUTANTS_TOTAL + 1))
+
+  perl -0pi -e "$perl_expr" "$file"
+
+  # Prove the mutation actually changed the source.
+  if cmp -s "$file" "$backup"; then
+    cp "$backup" "$file"
+    rm -f "$backup"
+    fail_layer "mutation '$name': mutation did not apply, cannot count as a kill"
+    return
+  fi
+
+  local out bad
+  out="$(run_ert "${FOCUSED_ARGS[@]}")"
+  bad="$(unexpected_count "$out")"
+
+  cp "$backup" "$file"
+  rm -f "$backup"
+
+  # Confirm restoration really happened.
+  if ! git diff --quiet "$file" && ! git diff "$file" | grep -q .; then
+    fail_layer "mutation '$name': source not restored"
+    return
+  fi
+
+  if [[ "$bad" == "MISSING" ]]; then
+    # The suite never completed, so this proves nothing about detection: a
+    # mutant that breaks loading would look identical to a real behavioral
+    # kill. Treat it as a broken mutant, never as a pass.
+    fail_layer "mutation '$name': suite did not complete, mutant is unloadable rather than detected"
+  elif [[ "$bad" -gt 0 ]]; then
+    echo "mutant '$name': KILLED ($bad failing tests)"
+    MUTANTS_KILLED=$((MUTANTS_KILLED + 1))
+  else
+    fail_layer "mutation '$name': SURVIVED, the tests do not detect this bug"
+  fi
+}
+
+# M1: remove the literal-block check, so annotations in src blocks trigger again.
+run_mutant "guard ignores literal blocks" ai-code-prompt-editing.el \
+  's/\(not \(ai-code--prompt-inside-literal-block-p sigil-pos\)\)/t/'
+
+# M2: neutralise the word-boundary check, so "user@" triggers again. Written to
+# keep the file loadable, so the kill has to come from a failing assertion
+# rather than from the suite refusing to start.
+run_mutant "guard ignores word boundary" ai-code-prompt-editing.el \
+  's/\(or \(= sigil-pos \(point-min\)\)/(or t (= sigil-pos (point-min))/'
+
+# M3: invert the block-delimiter decision, so begin and end are swapped.
+run_mutant "block detection inverted" ai-code-prompt-editing.el \
+  's/\(looking-at-p ai-code--prompt-block-begin-regexp\)/(not (looking-at-p ai-code--prompt-block-begin-regexp))/'
+
+# M4: make every file look like a task file, so plain org files get folded.
+run_mutant "task file predicate always true" ai-code-prompt-editing.el \
+  's/\(let \(\(file \(or file buffer-file-name\)\)\)/(let ((file (or file buffer-file-name "\/x\/.ai.code.files\/y.org")))/'
+
+# M5: drop the corpus deduplication, so repeated prompts appear many times.
+run_mutant "corpus dedup removed" ai-code-prompt-editing.el \
+  's/\(delete-dups \(nreverse lines\)\)/(nreverse lines)/'
+
+# M6: accept structural lines as reusable prompts, by removing the minimum
+# length guard.
+run_mutant "corpus accepts short lines" ai-code-prompt-editing.el \
+  's/>= \(length line\) ai-code-prompt-corpus-min-length/>= (length line) 0/'
+
+echo "manual mutation: $MUTANTS_KILLED/$MUTANTS_TOTAL killed"
+if [[ "$MUTANTS_KILLED" != "$MUTANTS_TOTAL" ]]; then
+  fail_layer "mutation: only $MUTANTS_KILLED of $MUTANTS_TOTAL mutants killed"
+fi
+record_layer "mutation"
+
+# ---------------------------------------------------------------------------
+# Layer 7: negative control
+# ---------------------------------------------------------------------------
+#
+# Proves the guard tests can fail: stub the guard to always return t and
+# confirm the suite goes red. A green result here means the gate is blind.
+
+echo "== Layer: negative control =="
+NC_BACKUP="$(mktemp)"
+cp ai-code-prompt-editing.el "$NC_BACKUP"
+# Force the guard to accept every position. Appending a second definition after
+# the real one is paren-safe and unambiguously overrides it at load time.
+cat >> ai-code-prompt-editing.el <<'STUB'
+;; NEGATIVE CONTROL STUB
+(defun ai-code--prompt-reference-position-p (&optional _sigil-pos)
+  "Always claim a reference position." t)
+STUB
+if cmp -s ai-code-prompt-editing.el "$NC_BACKUP"; then
+  cp "$NC_BACKUP" ai-code-prompt-editing.el
+  rm -f "$NC_BACKUP"
+  fail_layer "negative control: stub did not apply"
+else
+  # Verify the stub really makes the guard permissive before trusting the run.
+  NC_PROOF="$(emacs_batch -l test/test_00-bootstrap.el --eval "
+(progn (require 'ai-code-prompt-editing)
+       (with-temp-buffer
+         (insert \"#+begin_src java\n@Override\")
+         (princ (format \"nc:guard=%s\" (ai-code--prompt-reference-position-p)))))" 2>&1 || true)"
+  if ! printf '%s\n' "$NC_PROOF" | grep -qF "nc:guard=t"; then
+    cp "$NC_BACKUP" ai-code-prompt-editing.el
+    rm -f "$NC_BACKUP"
+    fail_layer "negative control: stub applied but guard still rejects, control is invalid"
+  else
+    NC_OUT="$(run_ert "${FOCUSED_ARGS[@]}")"
+    NC_BAD="$(unexpected_count "$NC_OUT")"
+    cp "$NC_BACKUP" ai-code-prompt-editing.el
+    rm -f "$NC_BACKUP"
+    echo "negative control: unexpected=$NC_BAD (must be > 0)"
+    if [[ "$NC_BAD" == "MISSING" ]]; then
+      # The stub was already proven loadable and permissive above, so a suite
+      # that cannot complete is an unexplained failure, not evidence.
+      fail_layer "negative control: suite did not complete, result is uninterpretable"
+    elif [[ "$NC_BAD" -lt 1 ]]; then
+      fail_layer "negative control: suite stayed green with a stubbed guard, the gate is blind"
+    fi
+  fi
+fi
+record_layer "negative control"
+
+# ---------------------------------------------------------------------------
+# Layer 8: real execution against a real task file
+# ---------------------------------------------------------------------------
+
+echo "== Layer: real execution =="
+REAL_DIR="$(mktemp -d)"
+trap 'rm -rf "$REAL_DIR"' EXIT
+mkdir -p "$REAL_DIR/.ai.code.files"
+REAL_FILE="$REAL_DIR/.ai.code.files/task.org"
+{
+  echo "#+TITLE: Real task"
+  echo "#+STARTUP: content"
+  echo ""
+  echo "* Investigation"
+  echo "Prose line that should be spell checked."
+  echo "#+begin_src java"
+  echo "@Override"
+  echo "public void run() {}"
+  echo "#+end_src"
+  echo "* Code Change"
+} > "$REAL_FILE"
+
+REAL_OUT="$(emacs_batch -l test/test_00-bootstrap.el --eval "
+(progn
+  (require 'ai-code-prompt-mode)
+  (find-file \"$REAL_FILE\")
+  (ai-code-prompt-mode)
+  (princ (format \"real:mode=%s\n\" major-mode))
+  (princ (format \"real:taskfile=%s\n\" (if (ai-code--prompt-task-file-p) \"yes\" \"no\")))
+  ;; The annotation inside the src block must not be a reference position.
+  (goto-char (point-min))
+  (search-forward \"@Override\")
+  (goto-char (match-beginning 0))
+  (princ (format \"real:annotation-guarded=%s\n\"
+                 (if (ai-code--prompt-reference-position-p (point)) \"no\" \"yes\")))
+  ;; Spell checking must be suppressed there too.
+  (princ (format \"real:flyspell-skips-code=%s\n\"
+                 (if (ai-code--prompt-flyspell-verify) \"no\" \"yes\")))
+  ;; A real reference at word start must still be accepted.
+  (goto-char (point-max))
+  (insert \"\nPlease read @\")
+  (princ (format \"real:reference-accepted=%s\n\"
+                 (if (ai-code--prompt-reference-position-p) \"yes\" \"no\")))
+  ;; Body text must be folded, headings visible.
+  (goto-char (point-min))
+  (search-forward \"Prose line\")
+  (goto-char (match-beginning 0))
+  (princ (format \"real:body-folded=%s\n\" (if (org-invisible-p) \"yes\" \"no\")))
+  (goto-char (point-min))
+  (search-forward \"* Code Change\")
+  (goto-char (match-beginning 0))
+  (princ (format \"real:heading-visible=%s\n\" (if (org-invisible-p) \"no\" \"yes\")))
+  (set-buffer-modified-p nil))" 2>&1 || true)"
+
+printf '%s\n' "$REAL_OUT" | grep -E "^real:" || true
+
+for expect in \
+  "real:mode=ai-code-prompt-mode" \
+  "real:taskfile=yes" \
+  "real:annotation-guarded=yes" \
+  "real:flyspell-skips-code=yes" \
+  "real:reference-accepted=yes" \
+  "real:body-folded=yes" \
+  "real:heading-visible=yes"
+do
+  if ! printf '%s\n' "$REAL_OUT" | grep -qF "$expect"; then
+    fail_layer "real execution: expected '$expect'"
+  fi
+done
+record_layer "real execution"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "== Layers run: ${#LAYERS_RUN[@]} =="
+for l in "${LAYERS_RUN[@]}"; do echo "  - $l"; done
+
+REQUIRED_LAYERS=8
+if [[ "${#LAYERS_RUN[@]}" -ne "$REQUIRED_LAYERS" ]]; then
+  echo "FAIL: expected $REQUIRED_LAYERS layers, only ${#LAYERS_RUN[@]} ran"
+  exit 1
+fi
+
+if [[ "${#FAILURES[@]}" -gt 0 ]]; then
+  echo
+  echo "== FAILURES: ${#FAILURES[@]} =="
+  for f in "${FAILURES[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+
+echo
+echo "GAUNTLET PASSED"
+echo "  full suite:  ran=$FULL_RAN unexpected=$FULL_BAD (baseline $BASELINE_UNEXPECTED)"
+echo "  focused:     ran=$FOCUSED_RAN unexpected=$FOCUSED_BAD"
+echo "  mutation:    $MUTANTS_KILLED/$MUTANTS_TOTAL killed"
+echo "  checkdoc:    $CHECKDOC_TOTAL issues"
+exit 0

--- a/test/test_ai-code-prompt-editing.el
+++ b/test/test_ai-code-prompt-editing.el
@@ -1,0 +1,654 @@
+;;; test_ai-code-prompt-editing.el --- Tests for ai-code-prompt-editing -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for editing support in AI prompt task files: @ reference gating,
+;; navigation, long-form writing, and reuse of the existing prompt corpus.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'org)
+(require 'ai-code-prompt-editing)
+(require 'ai-code-prompt-mode)
+
+(defmacro ai-code-test-with-prompt-text (text &rest body)
+  "Insert TEXT into a temp buffer, leave point at end, then run BODY.
+Point is left after the final character of TEXT, which is how the
+auto-trigger hook sees the buffer right after a sigil is typed."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (insert ,text)
+     (goto-char (point-max))
+     ,@body))
+
+(defmacro ai-code-test-with-task-org (&rest body)
+  "Run BODY in an `org-mode' buffer holding a deep task outline."
+  (declare (indent 0))
+  `(with-temp-buffer
+     (let ((org-mode-hook nil))
+       (org-mode))
+     (insert "* Task Description\n"
+             "Top level prose.\n"
+             "* Investigation\n"
+             "** Root cause\n"
+             "*** Candidate A\n"
+             "**** Deep detail\n"
+             "Deep prose here.\n"
+             "* Code Change\n")
+     (goto-char (point-min))
+     ,@body))
+
+(defmacro ai-code-test-with-corpus (&rest body)
+  "Create a throwaway repository with a task-file corpus, then run BODY.
+Binds `corpus-root' to the repository root and `corpus-dir' to its task
+directory."
+  (declare (indent 0))
+  `(let* ((corpus-root (make-temp-file "ai-code-corpus" t))
+          (corpus-dir (expand-file-name ".ai.code.files" corpus-root)))
+     (unwind-protect
+         (progn
+           (make-directory corpus-dir t)
+           (with-temp-file (expand-file-name "one.org" corpus-dir)
+             (insert "* Investigation\n"
+                     "Refactor the payment retry logic.\n"
+                     "* Code Change\n"
+                     "Add a regression test for retries.\n"))
+           (with-temp-file (expand-file-name "two.org" corpus-dir)
+             (insert "* Investigation\n"
+                     "Investigate the flaky upload test.\n"))
+           ,@body)
+       (delete-directory corpus-root t))))
+
+
+;;;; Reference gating
+
+;;; Scenario: Java annotation inside a src block does not trigger
+
+(ert-deftest ai-code-test-prompt-reference-rejects-annotation-in-src-block ()
+  "A Java annotation typed inside a src block is not a file reference."
+  (ai-code-test-with-prompt-text
+      "Look at this:\n#+begin_src java\n@Override\n"
+    ;; Point sits on the empty line after "@Override"; place it just after
+    ;; the "@" the user would have typed.
+    (goto-char (point-min))
+    (should (search-forward "@" nil t))
+    (should-not (ai-code--prompt-reference-position-p))))
+
+;;; Scenario: Annotation in an example block does not trigger
+
+(ert-deftest ai-code-test-prompt-reference-rejects-annotation-in-example-block ()
+  "An annotation typed inside an example block is not a file reference."
+  (ai-code-test-with-prompt-text
+      "#+begin_example\n@Deprecated"
+    (should-not (ai-code--prompt-reference-position-p))))
+
+(ert-deftest ai-code-test-prompt-reference-accepts-after-closed-block ()
+  "A reference typed after a block has been closed still triggers."
+  (ai-code-test-with-prompt-text
+      "#+begin_src java\ncode();\n#+end_src\nNow check @"
+    (should (ai-code--prompt-reference-position-p))))
+
+;;; Scenario: Email-like text does not trigger
+
+(ert-deftest ai-code-test-prompt-reference-rejects-email-like-at ()
+  "An \"@\" following a word character is part of a word, not a reference."
+  (ai-code-test-with-prompt-text "mail tninja@"
+    (should-not (ai-code--prompt-reference-position-p))))
+
+;;; Scenario: Real reference at word start triggers
+
+(ert-deftest ai-code-test-prompt-reference-accepts-after-whitespace ()
+  "An \"@\" following whitespace starts a file reference."
+  (ai-code-test-with-prompt-text "Please read @"
+    (should (ai-code--prompt-reference-position-p))))
+
+(ert-deftest ai-code-test-prompt-reference-accepts-at-beginning-of-line ()
+  "An \"@\" at the beginning of a line starts a file reference."
+  (ai-code-test-with-prompt-text "Please read:\n@"
+    (should (ai-code--prompt-reference-position-p))))
+
+(ert-deftest ai-code-test-prompt-reference-accepts-after-open-paren ()
+  "An \"@\" after a punctuation delimiter starts a file reference."
+  (ai-code-test-with-prompt-text "see (@"
+    (should (ai-code--prompt-reference-position-p))))
+
+(ert-deftest ai-code-test-prompt-reference-accepts-at-buffer-start ()
+  "An \"@\" as the very first character starts a file reference."
+  (ai-code-test-with-prompt-text "@"
+    (should (ai-code--prompt-reference-position-p))))
+
+;;; Scenario: the auto-trigger path honours the guard
+
+(ert-deftest ai-code-test-prompt-auto-trigger-skips-annotation-in-src-block ()
+  "The blocking auto-trigger must not fire for an annotation in a src block."
+  (let ((prompted nil))
+    (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
+              ((symbol-function 'ai-code--prompt-filepath-candidates)
+               (lambda () '("@src/main.el")))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _) (setq prompted t) "@src/main.el")))
+      (ai-code-test-with-prompt-text "#+begin_src java\n@"
+        (let ((before (buffer-string)))
+          (ai-code--prompt-auto-trigger-filepath-completion)
+          (should-not prompted)
+          (should (string= before (buffer-string))))))))
+
+(ert-deftest ai-code-test-prompt-capf-skips-annotation-in-src-block ()
+  "The capf path must not offer candidates for an annotation in a src block."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
+            ((symbol-function 'ai-code--prompt-filepath-candidates)
+             (lambda () '("@src/main.el"))))
+    (ai-code-test-with-prompt-text "#+begin_src java\n@Over"
+      (should-not (ai-code--prompt-filepath-capf)))))
+
+;;; Scenario: Explicit blocking selector remains available
+
+(ert-deftest ai-code-test-prompt-complete-reference-ignores-guard ()
+  "The explicit command completes even where auto-triggering is suppressed."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
+            ((symbol-function 'ai-code--prompt-filepath-candidates)
+             (lambda () '("@src/main.el")))
+            ((symbol-function 'completing-read)
+             (lambda (&rest _) "@src/main.el")))
+    (ai-code-test-with-prompt-text "#+begin_src java\n"
+      (ai-code-prompt-complete-reference)
+      (should (string-match-p (regexp-quote "@src/main.el") (buffer-string))))))
+
+(ert-deftest ai-code-test-prompt-complete-reference-replaces-partial-reference ()
+  "The explicit command replaces an already-typed partial reference."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
+            ((symbol-function 'ai-code--prompt-filepath-candidates)
+             (lambda () '("@src/main.el")))
+            ((symbol-function 'completing-read)
+             (lambda (&rest _) "@src/main.el")))
+    (ai-code-test-with-prompt-text "read @src/ma"
+      (ai-code-prompt-complete-reference)
+      (should (string= "read @src/main.el" (buffer-string))))))
+
+(ert-deftest ai-code-test-prompt-complete-reference-errors-without-repo ()
+  "The explicit command reports a user error outside a repository."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) nil)))
+    (ai-code-test-with-prompt-text "read "
+      (should-error (ai-code-prompt-complete-reference) :type 'user-error))))
+
+;;; Scenario: Inline, non-blocking completion inside prompt mode
+
+;; Declared special so `let' binds it dynamically even when company is absent,
+;; which is the case in continuous integration.  The helm option is deliberately
+;; NOT declared here: the implementation must cope with it being void.
+(defvar company-backends nil)
+
+(ert-deftest ai-code-test-prompt-inline-completion-opts-out-of-helm ()
+  "Setup registers the mode in helm's supported opt-out list."
+  (let ((helm-mode-no-completion-in-region-in-modes nil))
+    (with-temp-buffer
+      (ai-code--prompt-setup-inline-completion)
+      (should (memq 'ai-code-prompt-mode
+                    helm-mode-no-completion-in-region-in-modes)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-opt-out-is-idempotent ()
+  "Repeated setup does not add duplicate entries to helm's opt-out list."
+  (let ((helm-mode-no-completion-in-region-in-modes nil))
+    (with-temp-buffer
+      (ai-code--prompt-setup-inline-completion)
+      (ai-code--prompt-setup-inline-completion)
+      (should (= 1 (cl-count 'ai-code-prompt-mode
+                             helm-mode-no-completion-in-region-in-modes))))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-adds-flex-locally ()
+  "Setup appends the flex style buffer-locally without touching the default."
+  (let ((global-styles (default-value 'completion-styles)))
+    (with-temp-buffer
+      (ai-code--prompt-setup-inline-completion)
+      (should (memq 'flex completion-styles))
+      (should (local-variable-p 'completion-styles))
+      (should (equal global-styles (default-value 'completion-styles))))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-preserves-existing-styles ()
+  "Setup keeps the styles that were already configured."
+  (with-temp-buffer
+    (let ((completion-styles '(basic partial-completion)))
+      (ai-code--prompt-setup-inline-completion)
+      (should (memq 'basic completion-styles))
+      (should (memq 'partial-completion completion-styles)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-survives-missing-company ()
+  "Setup degrades silently when company is not installed."
+  (cl-letf (((symbol-function 'fboundp)
+             (lambda (sym) (not (memq sym '(company-mode))))))
+    (with-temp-buffer
+      ;; Must not signal even though company appears unavailable.
+      (ai-code--prompt-setup-inline-completion)
+      ;; The helm opt-out and flex style still apply.
+      (should (memq 'flex completion-styles)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-survives-void-helm-option ()
+  "Setup must not signal when helm has never been loaded.
+Regression test: the option is void until helm-mode loads, and signalling
+here aborts activation of the whole major mode."
+  (let ((had-value (boundp 'helm-mode-no-completion-in-region-in-modes))
+        (saved (and (boundp 'helm-mode-no-completion-in-region-in-modes)
+                    helm-mode-no-completion-in-region-in-modes)))
+    (unwind-protect
+        (progn
+          (makunbound 'helm-mode-no-completion-in-region-in-modes)
+          (with-temp-buffer
+            (ai-code--prompt-setup-inline-completion)
+            ;; The opt-out still records the mode so it applies once helm loads.
+            (should (memq 'ai-code-prompt-mode
+                          helm-mode-no-completion-in-region-in-modes))))
+      (if had-value
+          (setq helm-mode-no-completion-in-region-in-modes saved)
+        (makunbound 'helm-mode-no-completion-in-region-in-modes)))))
+
+
+;;;; Navigation
+
+;;; Scenario: Jump to a heading by outline path
+
+(ert-deftest ai-code-test-prompt-nav-heading-candidates-use-outline-path ()
+  "Candidates identify a deep heading by its full outline path."
+  (ai-code-test-with-task-org
+    (let* ((candidates (ai-code--prompt-heading-candidates))
+           (labels (mapcar #'car candidates)))
+      (should (cl-find-if (lambda (label)
+                            (and (string-match-p "Investigation" label)
+                                 (string-match-p "Root cause" label)
+                                 (string-match-p "Deep detail" label)))
+                          labels)))))
+
+(ert-deftest ai-code-test-prompt-nav-heading-candidates-are-positions ()
+  "Each candidate carries a buffer position for its heading."
+  (ai-code-test-with-task-org
+    (dolist (candidate (ai-code--prompt-heading-candidates))
+      (should (integer-or-marker-p (cdr candidate))))))
+
+(ert-deftest ai-code-test-prompt-nav-goto-heading-moves-point ()
+  "Selecting a heading moves point to that heading."
+  (ai-code-test-with-task-org
+    (cl-letf (((symbol-function 'completing-read)
+               (lambda (_prompt collection &rest _)
+                 (cl-find-if (lambda (label) (string-match-p "Deep detail" label))
+                             (mapcar #'car collection)))))
+      (ai-code-prompt-goto-heading)
+      (should (string-match-p "Deep detail"
+                              (buffer-substring-no-properties
+                               (line-beginning-position) (line-end-position)))))))
+
+(ert-deftest ai-code-test-prompt-nav-goto-heading-errors-without-headings ()
+  "Jumping reports a user error when the buffer has no headings."
+  (with-temp-buffer
+    (let ((org-mode-hook nil)) (org-mode))
+    (insert "just prose, no headings\n")
+    (should-error (ai-code-prompt-goto-heading) :type 'user-error)))
+
+;;; Scenario: Focus and restore a subtree
+
+(ert-deftest ai-code-test-prompt-nav-focus-subtree-narrows ()
+  "Focusing narrows the buffer to the enclosing subtree."
+  (ai-code-test-with-task-org
+    (goto-char (point-min))
+    (should (search-forward "Deep prose here." nil t))
+    (ai-code-prompt-focus-subtree)
+    (should (buffer-narrowed-p))
+    (let ((visible (buffer-string)))
+      (should (string-match-p "Deep detail" visible))
+      (should-not (string-match-p "Code Change" visible)))))
+
+(ert-deftest ai-code-test-prompt-nav-focus-subtree-toggles-back ()
+  "Focusing a second time restores the whole buffer."
+  (ai-code-test-with-task-org
+    (goto-char (point-min))
+    (should (search-forward "Deep prose here." nil t))
+    (ai-code-prompt-focus-subtree)
+    (should (buffer-narrowed-p))
+    (ai-code-prompt-focus-subtree)
+    (should-not (buffer-narrowed-p))
+    (should (string-match-p "Code Change" (buffer-string)))))
+
+;;; Scenario: Task files fold by default, other org files do not
+
+(ert-deftest ai-code-test-prompt-nav-task-file-is-recognised ()
+  "A file under the task directory is recognised as a task file."
+  (should (ai-code--prompt-task-file-p "/repo/.ai.code.files/issue-1.org")))
+
+(ert-deftest ai-code-test-prompt-nav-plain-org-file-is-not-task-file ()
+  "An Org file outside the task directory is not a task file."
+  (should-not (ai-code--prompt-task-file-p "/repo/docs/notes.org")))
+
+(ert-deftest ai-code-test-prompt-nav-nil-file-is-not-task-file ()
+  "A buffer without a file is not treated as a task file."
+  (should-not (ai-code--prompt-task-file-p nil)))
+
+(ert-deftest ai-code-test-prompt-nav-folds-task-file-only ()
+  "Startup folding runs for task files and is skipped elsewhere."
+  (let ((folded nil))
+    (cl-letf (((symbol-function 'org-content) (lambda (&rest _) (setq folded t))))
+      (with-temp-buffer
+        (setq buffer-file-name "/repo/.ai.code.files/issue-1.org")
+        (ai-code--prompt-apply-startup-folding)
+        (should folded)
+        (setq buffer-file-name nil))
+      (setq folded nil)
+      (with-temp-buffer
+        (setq buffer-file-name "/repo/docs/notes.org")
+        (ai-code--prompt-apply-startup-folding)
+        (should-not folded)
+        (setq buffer-file-name nil)))))
+
+(ert-deftest ai-code-test-prompt-nav-folding-can-be-disabled ()
+  "Setting the folding option to nil disables startup folding."
+  (let ((folded nil))
+    (cl-letf (((symbol-function 'org-content) (lambda (&rest _) (setq folded t)))
+              ((symbol-function 'org-overview) (lambda (&rest _) (setq folded t))))
+      (with-temp-buffer
+        (setq buffer-file-name "/repo/.ai.code.files/issue-1.org")
+        (let ((ai-code-prompt-startup-folded nil))
+          (ai-code--prompt-apply-startup-folding))
+        (should-not folded)
+        (setq buffer-file-name nil)))))
+
+
+;;;; Writing
+
+;;; Scenario: flyspell ignores code inside blocks
+
+(ert-deftest ai-code-test-prompt-flyspell-skips-src-block ()
+  "Spell checking is suppressed inside a source block."
+  (with-temp-buffer
+    (insert "#+begin_src java\nreturn foobarbaz;\n")
+    (goto-char (point-min))
+    (should (search-forward "foobarbaz" nil t))
+    (should-not (ai-code--prompt-flyspell-verify))))
+
+(ert-deftest ai-code-test-prompt-flyspell-skips-example-block ()
+  "Spell checking is suppressed inside an example block."
+  (with-temp-buffer
+    (insert "#+begin_example\nENOSPC qqzz\n")
+    (goto-char (point-min))
+    (should (search-forward "qqzz" nil t))
+    (should-not (ai-code--prompt-flyspell-verify))))
+
+(ert-deftest ai-code-test-prompt-flyspell-checks-prose ()
+  "Spell checking still applies to ordinary prose."
+  (with-temp-buffer
+    (insert "This is ordinary prose.\n")
+    (goto-char (point-min))
+    (should (search-forward "ordinary" nil t))
+    (should (ai-code--prompt-flyspell-verify))))
+
+(ert-deftest ai-code-test-prompt-flyspell-checks-prose-after-block ()
+  "Spell checking resumes after a block has been closed."
+  (with-temp-buffer
+    (insert "#+begin_src java\ncode();\n#+end_src\nordinary prose\n")
+    (goto-char (point-min))
+    (should (search-forward "ordinary" nil t))
+    (should (ai-code--prompt-flyspell-verify))))
+
+;;; Scenario: Wrap pasted logs in an example block
+
+(ert-deftest ai-code-test-prompt-wrap-region-in-block-wraps-example ()
+  "Wrapping encloses the active region in an example block."
+  (with-temp-buffer
+    (insert "line one\nline two\n")
+    (let ((transient-mark-mode t))
+      (goto-char (point-min))
+      (set-mark (point))
+      (goto-char (point-max))
+      (ai-code-prompt-wrap-region-in-block "example"))
+    (let ((content (buffer-string)))
+      (should (string-match-p "^#\\+begin_example$" content))
+      (should (string-match-p "^#\\+end_example$" content))
+      (should (string-match-p "line one" content))
+      (should (string-match-p "line two" content)))))
+
+(ert-deftest ai-code-test-prompt-wrap-region-keeps-content-order ()
+  "Wrapping places the region text between the delimiters, in order."
+  (with-temp-buffer
+    (insert "payload\n")
+    (let ((transient-mark-mode t))
+      (goto-char (point-min))
+      (set-mark (point))
+      (goto-char (point-max))
+      (ai-code-prompt-wrap-region-in-block "example"))
+    (should (string= "#+begin_example\npayload\n#+end_example\n"
+                     (buffer-string)))))
+
+(ert-deftest ai-code-test-prompt-wrap-region-supports-src-block ()
+  "Wrapping accepts a source block type with a language."
+  (with-temp-buffer
+    (insert "int x = 1;\n")
+    (let ((transient-mark-mode t))
+      (goto-char (point-min))
+      (set-mark (point))
+      (goto-char (point-max))
+      (ai-code-prompt-wrap-region-in-block "src java"))
+    (let ((content (buffer-string)))
+      (should (string-match-p "^#\\+begin_src java$" content))
+      (should (string-match-p "^#\\+end_src$" content)))))
+
+(ert-deftest ai-code-test-prompt-wrap-region-errors-without-region ()
+  "Wrapping reports a user error when no region is active."
+  (with-temp-buffer
+    (insert "text\n")
+    (deactivate-mark)
+    (should-error (ai-code-prompt-wrap-region-in-block "example")
+                  :type 'user-error)))
+
+;;; Scenario: Block marking is reachable
+
+(ert-deftest ai-code-test-prompt-mark-block-has-binding ()
+  "The block-marking command is reachable from the prompt mode map."
+  (should (eq 'ai-code--mark-prompt-block
+              (lookup-key ai-code-prompt-mode-map (kbd "C-c m")))))
+
+(ert-deftest ai-code-test-prompt-bindings-do-not-shadow-org-ctrl-c-ctrl-c ()
+  "The send binding on C-c C-c is preserved."
+  (should (eq 'ai-code-prompt-send-block
+              (lookup-key ai-code-prompt-mode-map (kbd "C-c C-c")))))
+
+;;; Scenario: writing mode is opt-in and degrades without its dependency
+
+(ert-deftest ai-code-test-prompt-writing-mode-enables-visual-line ()
+  "Enabling writing mode turns on visual line wrapping."
+  (with-temp-buffer
+    (ai-code-prompt-writing-mode 1)
+    (should visual-line-mode)))
+
+(ert-deftest ai-code-test-prompt-writing-mode-disables-cleanly ()
+  "Disabling writing mode turns visual line wrapping back off."
+  (with-temp-buffer
+    (ai-code-prompt-writing-mode 1)
+    (ai-code-prompt-writing-mode -1)
+    (should-not visual-line-mode)))
+
+(ert-deftest ai-code-test-prompt-writing-mode-survives-missing-fill-column ()
+  "Writing mode does not signal when visual-fill-column is absent."
+  (cl-letf (((symbol-function 'fboundp)
+             (lambda (sym) (not (memq sym '(visual-fill-column-mode))))))
+    (with-temp-buffer
+      (ai-code-prompt-writing-mode 1)
+      (should visual-line-mode))))
+
+
+;;;; Reuse
+
+;;; Scenario: Search current repo corpus by default
+
+(ert-deftest ai-code-test-prompt-reuse-default-root-is-current-repo ()
+  "Without a prefix argument the search covers the current repository only."
+  (ai-code-test-with-corpus
+    (cl-letf (((symbol-function 'ai-code--get-files-directory)
+               (lambda () corpus-dir)))
+      (should (equal (list corpus-dir) (ai-code--prompt-corpus-roots nil))))))
+
+(ert-deftest ai-code-test-prompt-reuse-finds-lines-in-corpus ()
+  "Corpus search returns prose lines from the task files."
+  (ai-code-test-with-corpus
+    (let ((lines (ai-code--prompt-corpus-lines (list corpus-dir))))
+      (should (cl-find-if (lambda (line) (string-match-p "payment retry" line))
+                          lines))
+      (should (cl-find-if (lambda (line) (string-match-p "flaky upload" line))
+                          lines)))))
+
+(ert-deftest ai-code-test-prompt-reuse-excludes-short-fragments ()
+  "Corpus search omits lines too short to be reusable prompts."
+  (ai-code-test-with-corpus
+    (with-temp-file (expand-file-name "short.org" corpus-dir)
+      (insert "ok\n" "yes\n" "TODO\n"))
+    (let ((lines (ai-code--prompt-corpus-lines (list corpus-dir))))
+      (should-not (member "ok" lines))
+      (should-not (member "yes" lines))
+      (should-not (member "TODO" lines))
+      ;; Every surviving candidate meets the configured minimum length.
+      (dolist (line lines)
+        (should (>= (length line) ai-code-prompt-corpus-min-length))))))
+
+(ert-deftest ai-code-test-prompt-reuse-excludes-org-headings ()
+  "Corpus search omits Org headings, which are structure rather than prompts."
+  (ai-code-test-with-corpus
+    (let ((lines (ai-code--prompt-corpus-lines (list corpus-dir))))
+      (should-not (cl-find-if (lambda (line)
+                                (string-match-p "^\\*+ " line))
+                              lines)))))
+
+(ert-deftest ai-code-test-prompt-reuse-deduplicates-lines ()
+  "Identical prompt lines across files collapse to a single candidate."
+  (ai-code-test-with-corpus
+    (with-temp-file (expand-file-name "three.org" corpus-dir)
+      (insert "Refactor the payment retry logic.\n"))
+    (let* ((lines (ai-code--prompt-corpus-lines (list corpus-dir)))
+           (matches (cl-count-if
+                     (lambda (line) (string-match-p "payment retry" line))
+                     lines)))
+      (should (= 1 matches)))))
+
+(ert-deftest ai-code-test-prompt-reuse-handles-missing-directory ()
+  "A nonexistent corpus directory yields no candidates instead of an error."
+  (should-not (ai-code--prompt-corpus-lines
+               (list "/nonexistent/ai-code-corpus-dir"))))
+
+;;; Scenario: Prefix argument widens to all known corpora
+
+(ert-deftest ai-code-test-prompt-reuse-prefix-widens-to-all-roots ()
+  "With a prefix argument every configured corpus root is searched."
+  (ai-code-test-with-corpus
+    (cl-letf (((symbol-function 'ai-code--get-files-directory)
+               (lambda () corpus-dir)))
+      (let ((ai-code-prompt-corpus-additional-roots '("/extra/corpus")))
+        (let ((roots (ai-code--prompt-corpus-roots t)))
+          (should (member corpus-dir roots))
+          (should (member "/extra/corpus" roots)))))))
+
+(ert-deftest ai-code-test-prompt-reuse-prefix-deduplicates-roots ()
+  "A root listed twice is searched once."
+  (ai-code-test-with-corpus
+    (cl-letf (((symbol-function 'ai-code--get-files-directory)
+               (lambda () corpus-dir)))
+      (let ((ai-code-prompt-corpus-additional-roots (list corpus-dir)))
+        (should (= 1 (length (ai-code--prompt-corpus-roots t))))))))
+
+;;; Scenario: Selected historical prompt is inserted at point
+
+(ert-deftest ai-code-test-prompt-reuse-inserts-selection-at-point ()
+  "The chosen historical prompt is inserted at point."
+  (ai-code-test-with-corpus
+    (cl-letf (((symbol-function 'ai-code--get-files-directory)
+               (lambda () corpus-dir))
+              ((symbol-function 'completing-read)
+               (lambda (_prompt collection &rest _)
+                 (cl-find-if (lambda (line) (string-match-p "payment retry" line))
+                             collection))))
+      (with-temp-buffer
+        (insert "prefix ")
+        (ai-code-prompt-insert-from-history nil)
+        (should (string-match-p "^prefix .*payment retry" (buffer-string)))))))
+
+(ert-deftest ai-code-test-prompt-reuse-insert-errors-on-empty-corpus ()
+  "An empty corpus reports a user error rather than inserting nothing."
+  (let ((empty (make-temp-file "ai-code-empty-corpus" t)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code--get-files-directory)
+                   (lambda () empty)))
+          (with-temp-buffer
+            (should-error (ai-code-prompt-insert-from-history nil)
+                          :type 'user-error)))
+      (delete-directory empty t))))
+
+;;; Scenario: Snippets are discoverable by description
+
+(ert-deftest ai-code-test-prompt-reuse-snippet-candidates-use-names ()
+  "Snippet candidates are labelled by name, not by key abbreviation."
+  (let ((candidates (ai-code--prompt-snippet-candidates)))
+    (should candidates)
+    ;; "Commit Message" is the name of the snippet whose key is "commit".
+    (should (cl-find-if (lambda (candidate)
+                          (string-match-p "Commit Message" (car candidate)))
+                        candidates))))
+
+(ert-deftest ai-code-test-prompt-reuse-snippet-candidates-carry-keys ()
+  "Each snippet candidate carries the key needed to expand it."
+  (dolist (candidate (ai-code--prompt-snippet-candidates))
+    (should (stringp (cdr candidate)))
+    (should-not (string-empty-p (cdr candidate)))))
+
+(ert-deftest ai-code-test-prompt-reuse-snippet-parses-name-and-key ()
+  "Snippet metadata is parsed from the yasnippet header comments."
+  (let ((file (make-temp-file "ai-code-snippet")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "# -*- mode: snippet -*-\n"
+                    "# name: Explain Code\n"
+                    "# key: explain\n"
+                    "# --\n"
+                    "Explain the following code.\n"))
+          (let ((parsed (ai-code--prompt-parse-snippet-file file)))
+            (should (equal "Explain Code" (car parsed)))
+            (should (equal "explain" (cdr parsed)))))
+      (delete-file file))))
+
+;;; Scenario: Context helpers return live values
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-file-returns-relative-path ()
+  "The file helper returns a repository-relative path."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/repo/")))
+    (with-temp-buffer
+      (setq buffer-file-name "/repo/src/main.el")
+      (should (equal "src/main.el" (ai-code--prompt-ctx-file)))
+      (setq buffer-file-name nil))))
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-file-nil-without-file ()
+  "The file helper returns nil in a buffer with no file."
+  (with-temp-buffer
+    (should-not (ai-code--prompt-ctx-file))))
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-branch-returns-branch ()
+  "The branch helper returns the current branch name."
+  (cl-letf (((symbol-function 'magit-get-current-branch) (lambda () "kang_feat_11")))
+    (should (equal "kang_feat_11" (ai-code--prompt-ctx-branch)))))
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-branch-nil-outside-repo ()
+  "The branch helper returns nil when there is no branch."
+  (cl-letf (((symbol-function 'magit-get-current-branch) (lambda () nil)))
+    (should-not (ai-code--prompt-ctx-branch))))
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-defun-nil-without-function ()
+  "The defun helper returns nil when point is not inside a function."
+  (cl-letf (((symbol-function 'which-function) (lambda () nil)))
+    (with-temp-buffer
+      (should-not (ai-code--prompt-ctx-defun)))))
+
+(ert-deftest ai-code-test-prompt-reuse-ctx-defun-returns-name ()
+  "The defun helper returns the enclosing function name."
+  (cl-letf (((symbol-function 'which-function) (lambda () "my-function")))
+    (with-temp-buffer
+      (should (equal "my-function" (ai-code--prompt-ctx-defun))))))
+
+(provide 'test_ai-code-prompt-editing)
+
+;;; test_ai-code-prompt-editing.el ends here

--- a/test/test_ai-code-prompt-editing.el
+++ b/test/test_ai-code-prompt-editing.el
@@ -124,17 +124,28 @@ directory."
 ;;; Scenario: the auto-trigger path honours the guard
 
 (ert-deftest ai-code-test-prompt-auto-trigger-skips-annotation-in-src-block ()
-  "The blocking auto-trigger must not fire for an annotation in a src block."
-  (let ((prompted nil))
-    (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
-              ((symbol-function 'ai-code--prompt-filepath-candidates)
-               (lambda () '("@src/main.el")))
-              ((symbol-function 'completing-read)
-               (lambda (&rest _) (setq prompted t) "@src/main.el")))
+  "The inline auto-trigger must not fire for an annotation in a src block."
+  (let ((started nil))
+    (cl-letf (((symbol-function 'ai-code--prompt-start-inline-reference-completion)
+               (lambda () (setq started t))))
       (ai-code-test-with-prompt-text "#+begin_src java\n@"
         (let ((before (buffer-string)))
           (ai-code--prompt-auto-trigger-filepath-completion)
-          (should-not prompted)
+          (should-not started)
+          (should (string= before (buffer-string))))))))
+
+(ert-deftest ai-code-test-prompt-auto-trigger-starts-inline-completion ()
+  "A valid sigil starts inline completion without opening a minibuffer."
+  (let ((started nil))
+    (cl-letf (((symbol-function 'ai-code--prompt-start-inline-reference-completion)
+               (lambda () (setq started t)))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _)
+                 (ert-fail "Auto-trigger called completing-read"))))
+      (ai-code-test-with-prompt-text "read @"
+        (let ((before (buffer-string)))
+          (ai-code--prompt-auto-trigger-filepath-completion)
+          (should started)
           (should (string= before (buffer-string))))))))
 
 (ert-deftest ai-code-test-prompt-capf-skips-annotation-in-src-block ()
@@ -169,6 +180,17 @@ directory."
       (ai-code-prompt-complete-reference)
       (should (string= "read @src/main.el" (buffer-string))))))
 
+(ert-deftest ai-code-test-prompt-complete-reference-preserves-ordinary-text ()
+  "The explicit command does not delete text that lacks an @ sigil."
+  (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) "/tmp/repo/"))
+            ((symbol-function 'ai-code--prompt-filepath-candidates)
+             (lambda () '("@src/main.el")))
+            ((symbol-function 'completing-read)
+             (lambda (&rest _) "@src/main.el")))
+    (ai-code-test-with-prompt-text "keep"
+      (ai-code-prompt-complete-reference)
+      (should (string= "keep@src/main.el" (buffer-string))))))
+
 (ert-deftest ai-code-test-prompt-complete-reference-errors-without-repo ()
   "The explicit command reports a user error outside a repository."
   (cl-letf (((symbol-function 'ai-code--git-root) (lambda (&rest _) nil)))
@@ -181,6 +203,7 @@ directory."
 ;; which is the case in continuous integration.  The helm option is deliberately
 ;; NOT declared here: the implementation must cope with it being void.
 (defvar company-backends nil)
+(defvar company-mode nil)
 
 (ert-deftest ai-code-test-prompt-inline-completion-opts-out-of-helm ()
   "Setup registers the mode in helm's supported opt-out list."
@@ -244,6 +267,33 @@ here aborts activation of the whole major mode."
       (if had-value
           (setq helm-mode-no-completion-in-region-in-modes saved)
         (makunbound 'helm-mode-no-completion-in-region-in-modes)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-starts-company-capf ()
+  "Inline completion uses Company's CAPF backend when Company is active."
+  (let ((company-mode t)
+        backend)
+    (cl-letf (((symbol-function 'company-begin-backend)
+               (lambda (value) (setq backend value)))
+              ((symbol-function 'completion-at-point)
+               (lambda () (ert-fail "CAPF fallback was called"))))
+      (ai-code--prompt-start-inline-reference-completion)
+      (should (eq backend 'company-capf)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-tolerates-no-company-candidates ()
+  "Inline completion does not signal when Company finds no candidates."
+  (let ((company-mode t))
+    (cl-letf (((symbol-function 'company-begin-backend)
+               (lambda (&rest _) (user-error "Cannot complete at point"))))
+      (should-not (ai-code--prompt-start-inline-reference-completion)))))
+
+(ert-deftest ai-code-test-prompt-inline-completion-falls-back-to-capf ()
+  "Inline completion uses the standard CAPF UI when Company is inactive."
+  (let ((company-mode nil)
+        (called nil))
+    (cl-letf (((symbol-function 'completion-at-point)
+               (lambda () (setq called t))))
+      (ai-code--prompt-start-inline-reference-completion)
+      (should called))))
 
 
 ;;;; Navigation
@@ -450,6 +500,16 @@ here aborts activation of the whole major mode."
   "The send binding on C-c C-c is preserved."
   (should (eq 'ai-code-prompt-send-block
               (lookup-key ai-code-prompt-mode-map (kbd "C-c C-c")))))
+
+(ert-deftest ai-code-test-prompt-bindings-preserve-org-mark-subtree ()
+  "Prompt mode preserves Org's subtree marking binding on C-c @."
+  (should (eq 'org-mark-subtree
+              (lookup-key ai-code-prompt-mode-map (kbd "C-c @")))))
+
+(ert-deftest ai-code-test-prompt-complete-reference-has-nonconflicting-binding ()
+  "Explicit reference completion remains available on C-c r."
+  (should (eq 'ai-code-prompt-complete-reference
+              (lookup-key ai-code-prompt-mode-map (kbd "C-c r")))))
 
 ;;; Scenario: writing mode is opt-in and degrades without its dependency
 

--- a/test/test_ai-code-prompt-mode.el
+++ b/test/test_ai-code-prompt-mode.el
@@ -1082,24 +1082,19 @@ evaluates BODY, and ensures everything is cleaned up afterward."
            (should (equal candidates '("@src/main.el" "@src/main.js")))))))))
 
 (ert-deftest ai-code-test-prompt-auto-trigger-filepath-completion ()
-  "Test that ai-code--prompt-auto-trigger-filepath-completion triggers completion after '@'."
+  "Test that @ starts inline completion without changing prompt text."
   (ai-code-with-test-repo
    (with-temp-buffer
-     ;; Insert @ symbol
      (insert "@")
-     
-     ;; Mock filepath candidates and selection
-     (cl-letf (((symbol-function 'ai-code--prompt-filepath-candidates)
-                (lambda () '("@src/main.el")))
-               ((symbol-function 'completing-read)
-                (lambda (_prompt candidates &rest _args)
-                  (car candidates))))
-       
-       ;; Call auto-trigger function
-       (ai-code--prompt-auto-trigger-filepath-completion)
-       
-       ;; Should replace @ with chosen candidate
-       (should (string= (buffer-string) "@src/main.el"))))))
+     (let ((completion-started nil))
+       (cl-letf (((symbol-function 'ai-code--prompt-start-inline-reference-completion)
+                  (lambda () (setq completion-started t)))
+                 ((symbol-function 'completing-read)
+                  (lambda (&rest _)
+                    (ert-fail "Auto-trigger called completing-read"))))
+         (ai-code--prompt-auto-trigger-filepath-completion)
+         (should completion-started)
+         (should (string= (buffer-string) "@")))))))
 
 (ert-deftest ai-code-test-prompt-auto-trigger-no-trigger-without-at ()
   "Test that ai-code--prompt-auto-trigger-filepath-completion doesn't trigger without '@'."
@@ -1107,17 +1102,13 @@ evaluates BODY, and ensures everything is cleaned up afterward."
    (with-temp-buffer
      ;; Insert text without @
      (insert "text")
-     
-     ;; Mock completion-at-point
-     (let ((completion-called nil))
-       (cl-letf (((symbol-function 'completion-at-point)
-                  (lambda () (setq completion-called t))))
-         
+     (let ((completion-started nil))
+       (cl-letf (((symbol-function 'ai-code--prompt-start-inline-reference-completion)
+                  (lambda () (setq completion-started t))))
          ;; Call auto-trigger function
          (ai-code--prompt-auto-trigger-filepath-completion)
-         
-         ;; Should NOT have called completion-at-point
-         (should-not completion-called))))))
+         ;; Should NOT have started inline completion.
+         (should-not completion-started))))))
 
 ;;; Tests for # symbol completion in prompt mode
 

--- a/test/test_ai-code-task.el
+++ b/test/test_ai-code-task.el
@@ -454,6 +454,18 @@
       (let ((content (buffer-string)))
         (should-not (string-match-p "#+BRANCH:" content))))))
 
+(ert-deftest ai-code-test-initialize-task-file-content-sets-startup-folding ()
+  "Task file initialization requests content-level folding on open."
+  (cl-letf (((symbol-function 'magit-get-current-branch)
+             (lambda () nil))
+            ((symbol-function 'ai-code-current-backend-label)
+             (lambda () "codex")))
+    (with-temp-buffer
+      (ai-code--initialize-task-file-content "Test Task" "")
+      (let ((content (buffer-string)))
+        (should
+         (string-match-p (regexp-quote "#+STARTUP: content") content))))))
+
 (ert-deftest ai-code-test-create-or-open-task-file-adds-org-extension ()
   "Create/open task file adds .org when the user omits it."
   (ai-code-with-test-repo


### PR DESCRIPTION
## Summary

Task files are becoming the main place I write prompts, so this adds editing support aimed at that workflow: `@` reference gating, outline navigation, long-form writing helpers, and reuse of prompts already written.

The immediate motivation was that `@` completion fired on every `@` character. Prompt files routinely contain pasted Java or Python, where `@` is an annotation, not a file reference, so pasting code triggered a blocking completion prompt repeatedly. A single guard, `ai-code--prompt-reference-position-p`, now decides: `@` must be outside any literal Org block and must begin a word. Both the capf path and the `post-self-insert-hook` path call that one guard, so they cannot drift apart. The explicit `C-c @` command deliberately bypasses it, so completion is still reachable inside a src block when you actually want it.

### Changes

- **Reference gating** — mode-agnostic literal-block detection (textual, not `org-in-src-block-p`, so it also holds in non-org buffers); rejects `@Override` and `user@`, accepts `@` at word start. Opts the mode out of helm's `completion-in-region` via helm's own supported option rather than advising helm internals, and enables `company-capf` buffer-locally so `global-company-mode` stays off.
- **Navigation** — jump to a heading by full outline path, focus/restore a subtree, and per-file startup folding. New task files get `#+STARTUP: content`; folding applies only to files under the task directory, so the global `org-startup-folded` setting is untouched.
- **Writing** — flyspell skips literal blocks (pasted code and logs are not prose), `C-c b` wraps a region in a block, and an opt-in `ai-code-prompt-writing-mode` for visual wrapping. Display only; buffer text is never rewritten, so what gets sent to the agent is unchanged.
- **Reuse** — search past task files as a prompt corpus, browse the existing snippets by descriptive name instead of terse key, plus small context helpers for file/branch/defun.

All new keybindings are bound at load time rather than inside the mode body, so `describe-mode` lists them before the mode has been activated. Every soft dependency (helm, company, visual-fill-column, yasnippet) degrades silently when absent, with tests on the missing-dependency path.

## Verification

A gauntlet script (`test/run_ai_code_prompt_editing_gauntlet.sh`) runs eight layers as fail-closed gates: 62 focused tests green, full suite at 1482 tests with the 13 pre-existing failures unchanged (names verified identical to baseline), byte compilation clean, checkdoc clean, 6/6 mutants killed by failing assertions, a negative control proving the guard tests actually bite, and real execution against a live task file in a real Emacs.

Two findings worth flagging, both fixed: a `void-variable` on helm's option aborted mode activation entirely and was caught only by the real-execution layer — the unit tests had been masking it — and one mutant initially "killed" the suite by making the file unloadable rather than by being detected, so the gauntlet now treats an incomplete run as a failure instead of evidence.

## Scope

Additive. No change to the backend send path, no new hard dependencies, and the existing snippets are untouched. The pre-existing `version<` bug in `test/test_00-bootstrap.el` is out of scope; the gauntlet works around it with an isolated `package-user-dir`.