### PR TITLE
Default PR target branch to the reflog-recorded parent branch

### DIFF
--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -10,6 +10,7 @@
 ;;; Code:
 
 (require 'magit)
+(require 'seq)
 
 (require 'ai-code-input)
 (require 'ai-code-task)
@@ -84,9 +85,45 @@ Candidate values:
    (ignore-errors
      (magit-git-string "symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD"))))
 
+(defun ai-code--branch-creation-source (branch)
+  "Return the raw ref BRANCH was created from, or nil when unknown.
+Read the oldest \"branch: Created from REF\" entry in the reflog of BRANCH.
+Git does not record a branch parent, so this is the only available record and
+it disappears once the reflog expires (see `gc.reflogExpire')."
+  (when (and branch (not (string-empty-p branch)))
+    (let* ((entries (ignore-errors
+                      (magit-git-lines "reflog" "show" "--format=%gs" branch)))
+           ;; The creation entry is the oldest one; later resets and rebases add
+           ;; newer entries that must not be mistaken for the creation record.
+           (creation-entry
+            (car (last (seq-filter
+                        (lambda (entry)
+                          (string-match-p "\\`branch: Created from " entry))
+                        entries)))))
+      (when creation-entry
+        (let ((source (string-trim
+                       (substring creation-entry
+                                  (length "branch: Created from ")))))
+          (unless (string-empty-p source) source))))))
+
+(defun ai-code--branch-parent-branch (branch)
+  "Return the branch BRANCH was created from, or nil when not determinable.
+Only return a source that still resolves to an existing branch, so raw commits,
+`HEAD', tags, and deleted branches are rejected as PR targets."
+  (let* ((source (ai-code--branch-creation-source branch))
+         (normalized (ai-code--normalize-branch-name source)))
+    (when (and normalized
+               (not (string-empty-p normalized))
+               (not (string= normalized branch))
+               (or (magit-branch-p normalized)
+                   (magit-branch-p (concat "origin/" normalized))))
+      normalized)))
+
 (defun ai-code--default-pr-target-branch (current-branch)
   "Return the default PR target branch for CURRENT-BRANCH."
-  (let* ((upstream-branch
+  (let* ((parent-branch
+          (ai-code--branch-parent-branch current-branch))
+         (upstream-branch
           (ignore-errors
             (magit-git-string "rev-parse"
                               "--abbrev-ref"
@@ -97,6 +134,8 @@ Candidate values:
          (normalized-upstream
           (ai-code--normalize-branch-name upstream-branch)))
     (cond
+     ;; The branch this one was forked from is the most likely PR target.
+     (parent-branch parent-branch)
      ((and normalized-upstream
            (not (string-empty-p normalized-upstream))
            (not (string= normalized-upstream current-branch)))

--- a/ai-code-git.el
+++ b/ai-code-git.el
@@ -85,6 +85,23 @@ Candidate values:
    (ignore-errors
      (magit-git-string "symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD"))))
 
+(defun ai-code--strip-remote-prefix (ref)
+  "Strip a configured remote prefix from remote-tracking REF.
+REF is a name below `refs/remotes/'.  Match against the configured remote
+names rather than splitting on the first path segment, because a remote name
+may itself contain a slash while a branch name may contain several."
+  (let ((remotes (ignore-errors (magit-git-lines "remote"))))
+    (or (seq-some (lambda (remote)
+                    (let ((prefix (concat remote "/")))
+                      (when (and (string-prefix-p prefix ref)
+                                 (> (length ref) (length prefix)))
+                        (substring ref (length prefix)))))
+                  ;; Longest remote name first, so that a remote named "grp/sub"
+                  ;; wins over a remote named "grp".
+                  (sort (copy-sequence remotes)
+                        (lambda (a b) (> (length a) (length b)))))
+        ref)))
+
 (defun ai-code--branch-creation-source (branch)
   "Return the raw ref BRANCH was created from, or nil when unknown.
 Read the oldest \"branch: Created from REF\" entry in the reflog of BRANCH.
@@ -106,18 +123,40 @@ it disappears once the reflog expires (see `gc.reflogExpire')."
                                   (length "branch: Created from ")))))
           (unless (string-empty-p source) source))))))
 
+(defun ai-code--creation-source-parent-branch (source)
+  "Return the bare branch name SOURCE refers to, or nil when it is not a branch.
+SOURCE is a raw creation ref recorded in a reflog.  Resolve it with
+`git rev-parse --symbolic-full-name', which dereferences a symbolic ref such as
+`origin/HEAD' to the branch it points at."
+  ;; A bare HEAD records "created from wherever HEAD was", which carries no
+  ;; parent information: it resolves to whatever branch happens to be checked
+  ;; out now rather than to the fork point being looked up.
+  (unless (string= source "HEAD")
+    (when-let* ((full-ref (ignore-errors
+                            (magit-git-string "rev-parse"
+                                              "--symbolic-full-name"
+                                              source))))
+      (cond
+       ((string-prefix-p "refs/heads/" full-ref)
+        (substring full-ref (length "refs/heads/")))
+       ((string-prefix-p "refs/remotes/" full-ref)
+        (ai-code--strip-remote-prefix
+         (substring full-ref (length "refs/remotes/"))))
+       ;; Tags and other namespaces are not usable PR targets.
+       (t nil)))))
+
 (defun ai-code--branch-parent-branch (branch)
   "Return the branch BRANCH was created from, or nil when not determinable.
-Only return a source that still resolves to an existing branch, so raw commits,
-`HEAD', tags, and deleted branches are rejected as PR targets."
-  (let* ((source (ai-code--branch-creation-source branch))
-         (normalized (ai-code--normalize-branch-name source)))
-    (when (and normalized
-               (not (string-empty-p normalized))
-               (not (string= normalized branch))
-               (or (magit-branch-p normalized)
-                   (magit-branch-p (concat "origin/" normalized))))
-      normalized)))
+Only refs that resolve inside a branch namespace qualify, so raw commits, tags,
+and deleted branches are rejected.  Return a bare branch name, because a PR base
+takes a branch name rather than a remote-qualified one."
+  (when-let* ((source (ai-code--branch-creation-source branch))
+              (parent (ai-code--creation-source-parent-branch source)))
+    ;; Checking out an existing remote branch records its own remote-tracking
+    ;; ref as the creation source, which would make BRANCH its own PR target.
+    (unless (or (string-empty-p parent)
+                (string= parent branch))
+      parent)))
 
 (defun ai-code--default-pr-target-branch (current-branch)
   "Return the default PR target branch for CURRENT-BRANCH."

--- a/test/test_ai-code-github.el
+++ b/test/test_ai-code-github.el
@@ -263,25 +263,31 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
     (should (equal (ai-code--default-pr-target-branch "feature/improve-pr-flow")
                    "develop"))))
 
-(defun ai-code-test--with-reflog-entries (entries existing-branches thunk)
-  "Call THUNK with reflog ENTRIES and EXISTING-BRANCHES stubbed.
-ENTRIES is the list of `git reflog show --format=%gs' output lines,
-newest first.  EXISTING-BRANCHES is the list of branch names that
-`magit-branch-p' should report as present."
+(defun ai-code-test--with-reflog-entries (entries resolved-refs thunk &optional remotes)
+  "Call THUNK with reflog ENTRIES and ref resolution stubbed.
+ENTRIES is the list of `git reflog show --format=%gs' output lines, newest
+first.  RESOLVED-REFS is an alist mapping a raw ref to the full ref name that
+`git rev-parse --symbolic-full-name' would return, or nil when the ref does not
+resolve.  REMOTES overrides the configured remote names, defaulting to origin."
   (cl-letf (((symbol-function 'magit-git-lines)
              (lambda (&rest args)
                (pcase args
                  (`("reflog" "show" "--format=%gs" ,_branch) entries)
+                 (`("remote") (or remotes '("origin")))
                  (_ nil))))
-            ((symbol-function 'magit-branch-p)
-             (lambda (branch) (member branch existing-branches))))
+            ((symbol-function 'magit-git-string)
+             (lambda (&rest args)
+               (pcase args
+                 (`("rev-parse" "--symbolic-full-name" ,ref)
+                  (alist-get ref resolved-refs nil nil #'string=))
+                 (_ nil)))))
     (funcall thunk)))
 
 (ert-deftest ai-code-test-branch-parent-branch-reads-reflog-creation-entry ()
   "Parent branch detection should read the reflog creation entry."
   (ai-code-test--with-reflog-entries
    '("commit: work in progress" "branch: Created from 1.88")
-   '("1.88")
+   '(("1.88" . "refs/heads/1.88"))
    (lambda ()
      (should (equal (ai-code--branch-parent-branch "rdar_183143740_1.88")
                     "1.88")))))
@@ -290,7 +296,53 @@ newest first.  EXISTING-BRANCHES is the list of branch names that
   "A remote-tracking creation ref should be normalized to a bare branch name."
   (ai-code-test--with-reflog-entries
    '("branch: Created from refs/remotes/origin/develop")
-   '("origin/develop")
+   '(("refs/remotes/origin/develop" . "refs/remotes/origin/develop"))
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "develop")))))
+
+(ert-deftest ai-code-test-branch-parent-branch-strips-non-origin-remote-prefix ()
+  "A non-origin remote parent should return the bare branch name.
+Regression test: `gh pr create --base' takes a branch name, so a
+remote-qualified name such as upstream/develop is not a usable target."
+  ;; Short form, as recorded by `git switch -c feature upstream/develop'.
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from upstream/develop")
+   '(("upstream/develop" . "refs/remotes/upstream/develop"))
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "develop")))
+   '("origin" "upstream"))
+  ;; Full ref form must resolve even when the branch exists only on a fork
+  ;; remote, which a local-or-origin-only probe would have rejected.
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from refs/remotes/upstream/develop")
+   '(("refs/remotes/upstream/develop" . "refs/remotes/upstream/develop"))
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "develop")))
+   '("origin" "upstream")))
+
+(ert-deftest ai-code-test-branch-parent-branch-handles-remote-name-with-slash ()
+  "A remote name containing a slash should be stripped as a whole.
+Git allows remote names such as grp/sub, so splitting on the first path
+segment would yield the wrong branch name."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from grp/sub/develop")
+   '(("grp/sub/develop" . "refs/remotes/grp/sub/develop"))
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "develop")))
+   '("origin" "grp/sub")))
+
+(ert-deftest ai-code-test-branch-parent-branch-dereferences-remote-head ()
+  "A remote symbolic HEAD parent should resolve to the branch it points at.
+Regression test: returning the literal name HEAD would name a nonexistent
+branch as the PR base."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from origin/HEAD")
+   ;; git rev-parse dereferences origin/HEAD to the branch it points at.
+   '(("origin/HEAD" . "refs/remotes/origin/develop"))
    (lambda ()
      (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
                     "develop")))))
@@ -299,29 +351,38 @@ newest first.  EXISTING-BRANCHES is the list of branch names that
   "When several creation entries exist, use the oldest (last) one."
   (ai-code-test--with-reflog-entries
    '("branch: Created from stale-topic" "commit: work" "branch: Created from main")
-   '("main" "stale-topic")
+   '(("main" . "refs/heads/main") ("stale-topic" . "refs/heads/stale-topic"))
    (lambda ()
      (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
                     "main")))))
 
 (ert-deftest ai-code-test-branch-parent-branch-rejects-head-and-unknown-refs ()
   "Non-branch creation sources should not be treated as a parent branch."
+  ;; A bare HEAD carries no parent information: it resolves to whatever branch
+  ;; is checked out at lookup time, which need not be the branch under query.
   (ai-code-test--with-reflog-entries
-   '("branch: Created from HEAD") '("main")
+   '("branch: Created from HEAD")
+   '(("HEAD" . "refs/heads/some-other-checked-out-branch"))
    (lambda ()
      (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
-  ;; A raw commit or a deleted parent branch is not a usable PR target.
+  ;; A raw commit does not resolve to a symbolic ref at all.
   (ai-code-test--with-reflog-entries
-   '("branch: Created from 11465c9") '("main")
+   '("branch: Created from 11465c9") nil
    (lambda ()
      (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
+  ;; A tag resolves, but refs/tags is not a branch namespace.
   (ai-code-test--with-reflog-entries
-   '("branch: Created from merged-and-deleted") '("main")
+   '("branch: Created from v1.0") '(("v1.0" . "refs/tags/v1.0"))
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
+  ;; A deleted parent branch no longer resolves.
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from merged-and-deleted") nil
    (lambda ()
      (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
   ;; An expired or missing reflog yields no creation entry at all.
   (ai-code-test--with-reflog-entries
-   '("commit: work in progress") '("main")
+   '("commit: work in progress") nil
    (lambda ()
      (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow")))))
 
@@ -329,43 +390,66 @@ newest first.  EXISTING-BRANCHES is the list of branch names that
   "A creation entry naming the branch itself should be ignored."
   (ai-code-test--with-reflog-entries
    '("branch: Created from refs/remotes/origin/feature/improve-pr-flow")
-   '("origin/feature/improve-pr-flow")
+   '(("refs/remotes/origin/feature/improve-pr-flow"
+      . "refs/remotes/origin/feature/improve-pr-flow"))
    (lambda ()
      (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow")))))
 
+(ert-deftest ai-code-test-branch-parent-branch-keeps-nested-branch-name ()
+  "Slashes inside the branch name itself must be preserved."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from origin/release/2.0")
+   '(("origin/release/2.0" . "refs/remotes/origin/release/2.0"))
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "release/2.0")))))
+
 (ert-deftest ai-code-test-default-pr-target-branch-prefers-reflog-parent-branch ()
   "The reflog parent branch should outrank same-name upstream and origin HEAD."
-  (cl-letf (((symbol-function 'magit-git-string)
+  (cl-letf (((symbol-function 'magit-git-lines)
              (lambda (&rest args)
                (pcase args
+                 (`("reflog" "show" "--format=%gs" ,_branch)
+                  '("commit: work in progress" "branch: Created from 1.88"))
+                 (`("remote") '("origin"))
+                 (_ nil))))
+            ((symbol-function 'magit-git-string)
+             (lambda (&rest args)
+               (pcase args
+                 (`("rev-parse" "--symbolic-full-name" "1.88") "refs/heads/1.88")
                  ;; Typical workflow: upstream is the same-name remote branch.
                  (`("rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
                   "origin/rdar_183143740_1.88")
                  (`("symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD")
                   "origin/main")
-                 (_ nil)))))
-    (ai-code-test--with-reflog-entries
-     '("commit: work in progress" "branch: Created from 1.88")
-     '("1.88" "main")
-     (lambda ()
-       (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
-                      "1.88"))))))
+                 (_ nil))))
+            ((symbol-function 'magit-branch-p)
+             (lambda (branch) (member branch '("1.88" "main" "origin/main")))))
+    (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
+                   "1.88"))))
 
 (ert-deftest ai-code-test-default-pr-target-branch-falls-back-without-reflog-parent ()
   "Without a usable reflog parent, existing upstream fallbacks still apply."
-  (cl-letf (((symbol-function 'magit-git-string)
+  (cl-letf (((symbol-function 'magit-git-lines)
              (lambda (&rest args)
                (pcase args
+                 (`("reflog" "show" "--format=%gs" ,_branch)
+                  '("branch: Created from HEAD"))
+                 (`("remote") '("origin"))
+                 (_ nil))))
+            ((symbol-function 'magit-git-string)
+             (lambda (&rest args)
+               (pcase args
+                 ;; A bare HEAD is rejected before any ref resolution.
                  (`("rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
                   "origin/rdar_183143740_1.88")
                  (`("symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD")
                   "origin/main")
-                 (_ nil)))))
-    (ai-code-test--with-reflog-entries
-     '("branch: Created from HEAD") '("main")
-     (lambda ()
-       (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
-                      "main"))))))
+                 (_ nil))))
+            ((symbol-function 'magit-branch-p)
+             (lambda (branch) (member branch '("main" "origin/main")))))
+    (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
+                   "main"))))
 
 (ert-deftest ai-code-test-pull-or-review-pr-with-source-send-current-branch-pr-uses-neutral-prompt ()
   "Current branch PR flow should validate repo and use a PR creation prompt label."

--- a/test/test_ai-code-github.el
+++ b/test/test_ai-code-github.el
@@ -263,6 +263,110 @@ Return (CAPTURED-PROMPT DIFF-CALLED)."
     (should (equal (ai-code--default-pr-target-branch "feature/improve-pr-flow")
                    "develop"))))
 
+(defun ai-code-test--with-reflog-entries (entries existing-branches thunk)
+  "Call THUNK with reflog ENTRIES and EXISTING-BRANCHES stubbed.
+ENTRIES is the list of `git reflog show --format=%gs' output lines,
+newest first.  EXISTING-BRANCHES is the list of branch names that
+`magit-branch-p' should report as present."
+  (cl-letf (((symbol-function 'magit-git-lines)
+             (lambda (&rest args)
+               (pcase args
+                 (`("reflog" "show" "--format=%gs" ,_branch) entries)
+                 (_ nil))))
+            ((symbol-function 'magit-branch-p)
+             (lambda (branch) (member branch existing-branches))))
+    (funcall thunk)))
+
+(ert-deftest ai-code-test-branch-parent-branch-reads-reflog-creation-entry ()
+  "Parent branch detection should read the reflog creation entry."
+  (ai-code-test--with-reflog-entries
+   '("commit: work in progress" "branch: Created from 1.88")
+   '("1.88")
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "rdar_183143740_1.88")
+                    "1.88")))))
+
+(ert-deftest ai-code-test-branch-parent-branch-normalizes-remote-tracking-ref ()
+  "A remote-tracking creation ref should be normalized to a bare branch name."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from refs/remotes/origin/develop")
+   '("origin/develop")
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "develop")))))
+
+(ert-deftest ai-code-test-branch-parent-branch-uses-oldest-creation-entry ()
+  "When several creation entries exist, use the oldest (last) one."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from stale-topic" "commit: work" "branch: Created from main")
+   '("main" "stale-topic")
+   (lambda ()
+     (should (equal (ai-code--branch-parent-branch "feature/improve-pr-flow")
+                    "main")))))
+
+(ert-deftest ai-code-test-branch-parent-branch-rejects-head-and-unknown-refs ()
+  "Non-branch creation sources should not be treated as a parent branch."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from HEAD") '("main")
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
+  ;; A raw commit or a deleted parent branch is not a usable PR target.
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from 11465c9") '("main")
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from merged-and-deleted") '("main")
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow"))))
+  ;; An expired or missing reflog yields no creation entry at all.
+  (ai-code-test--with-reflog-entries
+   '("commit: work in progress") '("main")
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow")))))
+
+(ert-deftest ai-code-test-branch-parent-branch-rejects-self-reference ()
+  "A creation entry naming the branch itself should be ignored."
+  (ai-code-test--with-reflog-entries
+   '("branch: Created from refs/remotes/origin/feature/improve-pr-flow")
+   '("origin/feature/improve-pr-flow")
+   (lambda ()
+     (should-not (ai-code--branch-parent-branch "feature/improve-pr-flow")))))
+
+(ert-deftest ai-code-test-default-pr-target-branch-prefers-reflog-parent-branch ()
+  "The reflog parent branch should outrank same-name upstream and origin HEAD."
+  (cl-letf (((symbol-function 'magit-git-string)
+             (lambda (&rest args)
+               (pcase args
+                 ;; Typical workflow: upstream is the same-name remote branch.
+                 (`("rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
+                  "origin/rdar_183143740_1.88")
+                 (`("symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD")
+                  "origin/main")
+                 (_ nil)))))
+    (ai-code-test--with-reflog-entries
+     '("commit: work in progress" "branch: Created from 1.88")
+     '("1.88" "main")
+     (lambda ()
+       (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
+                      "1.88"))))))
+
+(ert-deftest ai-code-test-default-pr-target-branch-falls-back-without-reflog-parent ()
+  "Without a usable reflog parent, existing upstream fallbacks still apply."
+  (cl-letf (((symbol-function 'magit-git-string)
+             (lambda (&rest args)
+               (pcase args
+                 (`("rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
+                  "origin/rdar_183143740_1.88")
+                 (`("symbolic-ref" "--quiet" "--short" "refs/remotes/origin/HEAD")
+                  "origin/main")
+                 (_ nil)))))
+    (ai-code-test--with-reflog-entries
+     '("branch: Created from HEAD") '("main")
+     (lambda ()
+       (should (equal (ai-code--default-pr-target-branch "rdar_183143740_1.88")
+                      "main"))))))
+
 (ert-deftest ai-code-test-pull-or-review-pr-with-source-send-current-branch-pr-uses-neutral-prompt ()
   "Current branch PR flow should validate repo and use a PR creation prompt label."
   (let (captured-read-prompts captured-read-string-prompts captured-inserted-prompt)


### PR DESCRIPTION
## Problem

When sending out a PR for the current branch, the default target branch was almost always the repository default branch (`main`), even when the branch was clearly forked from something else. The first candidate in `ai-code--default-pr-target-branch` was `@{upstream}`, but in a normal workflow `@{upstream}` points at the *same-name* remote-tracking branch (`origin/my-feature`), which gets rejected by the self-comparison check and falls through to `origin/HEAD`. So a branch cut from a release branch like `1.88` still defaulted to `main`, and the target had to be corrected by hand every time.

## Approach

Added reflog-based parent branch detection and put it first in the target-branch priority chain, keeping all four existing fallbacks intact:

- `ai-code--branch-creation-source` reads `git reflog show --format=%gs <branch>` and takes the **oldest** `branch: Created from REF` entry. Oldest matters: later `reset`/`rebase` operations prepend newer entries that must not be mistaken for the creation record.
- `ai-code--branch-parent-branch` normalizes the ref via the existing `ai-code--normalize-branch-name`, then requires it to still resolve to an existing branch. That check is what rejects `HEAD`, raw SHAs, tags, deleted branches, and the self-reference case (`git checkout <remote-branch>` records `Created from refs/remotes/origin/<same-name>`, which would otherwise make a branch its own PR target).

Note on what is deliberately *not* here: `git merge-base --fork-point` looked like a natural fallback, but measurement showed it returns a SHA for nearly every candidate base, since they all share the same fork commit. It cannot discriminate the parent, so adding it would only produce confidently wrong defaults. Reflog is the only real signal, and it degrades to the old behavior when the reflog has expired (`gc.reflogExpire`, 90 days by default).

## Verification

- 7 new ERT tests covering the reflog parse, remote-ref normalization, oldest-entry selection, rejection of `HEAD`/SHA/deleted-branch/self-reference, and both the new-priority and fallback paths in `ai-code--default-pr-target-branch`.
- Validated end to end against real throwaway git repositories (real `git` binary, not stubs) across 11 scenarios: explicit start point, nested feature branch, slash-containing names, no start point, detached HEAD, short and full SHAs, tags, removed reflog, plus clone-side `Created from refs/remotes/...` and post-rename cases. All matched expectations.
- Full suite: 1426 tests, the same 13 pre-existing failures as on `main` (harness / backends-infra / editor-viewport), confirmed by running the baseline with these changes stashed. No new warnings from byte-compiling `ai-code-git.el`.
