### PR TITLE
Add Evidence-First Coding Harness

### DIFF
--- a/ai-code-harness.el
+++ b/ai-code-harness.el
@@ -216,7 +216,8 @@ If the harness file cannot be prepared, fall back to the inline suffix."
   (pcase type
     ((or 'test-after-change 'tdd 'tdd-with-refactoring
          'uncle-bob-coding-agent-harness
-         'uncle-bob-coding-agent-harness-plus)
+         'uncle-bob-coding-agent-harness-plus
+         'evidence-first-coding-harness)
      (ai-code--auto-test-harness-reference-suffix type))
     ('no-test "Do not write or run any test.")
     (_ nil)))
@@ -340,6 +341,7 @@ See the later `defcustom' for user-facing documentation and default.")
     ("Do not write or run tests" . no-test)
     ("TDD Red + Green (write failing test, then make it pass)" . tdd)
     ("TDD Red + Green + Blue (refactor after Green)" . tdd-with-refactoring)
+    ("Evidence-First coding harness" . evidence-first-coding-harness)
     ("Uncle Bob's coding agent harness" . uncle-bob-coding-agent-harness)
     ("Uncle Bob's coding agent harness+"
      . uncle-bob-coding-agent-harness-plus))

--- a/prompt/evidence-first-coding-harness-diagnostics.v1.md
+++ b/prompt/evidence-first-coding-harness-diagnostics.v1.md
@@ -1,0 +1,111 @@
+# Evidence-First Coding Harness
+
+Optimize for trustworthy outcomes, not for performing a prescribed coding ritual. The implementation process may vary by task and model, but completion requires fresh, reproducible evidence that the requested behavior works and important constraints still hold.
+
+## Diagnostics sensor
+
+Before editing, record a diagnostics baseline by calling the `diagnostics_baseline` MCP tool. After each edit, call the `get_diagnostics` MCP tool with `since="baseline"` for the touched files. Do not finish until its final status is `clean`, with no new diagnostics versus the baseline. Treat a diagnostics tool failure, skipped file, or unavailable result as missing evidence rather than a clean pass.
+
+## Core loop
+
+CONTRACT → PLAN → IMPLEMENT → VERIFY → REVIEW → EVIDENCE
+
+The loop is outcome-driven. TDD is an available implementation strategy, not a mandatory ceremony. Do not force a RED → GREEN sequence for ordinary feature work when another approach gives better design coverage or feedback. For bug fixes, establish an executable reproduction before the fix when practical so the defect cannot silently return.
+
+## 1. CONTRACT
+
+Before editing, turn the request into a compact change contract:
+
+- State the observable behavior that must change.
+- Record important edge cases, error cases, compatibility requirements, invariants, and negative constraints.
+- Identify assumptions and uncertainties that could materially change the implementation.
+- Keep the contract proportional to the task. Use named scenarios or Gherkin when they clarify behavior, but do not create ceremony for trivial work.
+- For ambiguous or high-risk work, clarify the contract with the human before implementation. In autonomous work, proceed only within the authority already granted and record important assumptions.
+
+The implementation must not silently redefine the contract. If new evidence changes the understanding of the task, update the contract explicitly and explain why.
+
+## 2. PLAN
+
+Inspect enough surrounding code, tests, architecture guidance, and repository conventions to choose a coherent design before making local edits.
+
+For non-trivial work, think through the relevant data model, APIs, boundaries, cross-cutting edge cases, and likely test strategy before implementation. Prefer the smallest relevant context and avoid unrelated exploration that pollutes the working context.
+
+Choose an implementation strategy appropriate to the task. Valid strategies include:
+
+- test-first or TDD when it provides useful feedback;
+- characterization-first for unfamiliar or legacy behavior;
+- implementation followed immediately by focused tests when the design is clearer as a whole;
+- a small spike when uncertainty must be reduced first, provided exploratory code is not mistaken for the final verified change.
+
+Do not claim a process step that did not actually occur.
+
+## 3. IMPLEMENT
+
+Keep the change narrowly scoped to the contract and follow established repository patterns.
+
+For bug fixes, first reproduce the defect with a failing regression test or another executable reproduction when practical. Confirm that the reproduction fails for the expected reason before applying the fix. If a test-first reproduction is impractical, record why and use the strongest executable substitute available.
+
+For features, add or update a small set of high-value tests that cover distinct behavior, important boundaries, and regressions. Avoid duplicate, vacuous, or coverage-only tests. Make randomized tests reproducible with fixed seeds or deterministic fixtures unless randomness itself is under test.
+
+Do not weaken existing tests, constraints, or checkers merely to obtain a green result. Avoid unrelated cleanup while behavior is still changing.
+
+## 4. VERIFY
+
+Use project-native tooling and run every applicable verification layer. A check is evidence only if it really ran against the final relevant source state and enforced the claimed constraint.
+
+Consider these layers according to task risk and repository support:
+
+- focused tests for the changed behavior;
+- the full relevant test suite;
+- build, compiler, static type, lint, format, and diagnostics checks;
+- changed-behavior coverage when coverage tooling is meaningful;
+- mutation testing when test effectiveness is uncertain or the change is high risk;
+- property or invariant tests for parsing, math, serialization, ordering, state machines, or round trips;
+- existing dependency-boundary or architecture checks;
+- realistic execution of the application, CLI, endpoint, or workflow when feasible;
+- dependency, license, secret, and capability checks when the change expands the supply chain or runtime authority;
+- repeated or randomized-order tests when flakiness or nondeterminism is a material risk.
+
+Treat false greens as failures. A checker that crashes, silently skips required inputs, only prints a metric without enforcing its requirement, or reports success without exercising the intended path is not evidence. For home-grown gates, prefer a known-bad negative control when practical to prove the failure path is reachable.
+
+## 5. REVIEW
+
+After behavior is working, review the final diff plus enough neighboring code to judge maintainability in context.
+
+Check for:
+
+- semantic duplication;
+- misplaced responsibilities;
+- reimplementation of an existing pattern or abstraction;
+- dependency-direction or architecture-boundary violations;
+- excessive change radius for a small requirement;
+- unnecessary coupling, indirection, or complexity;
+- public API, configuration, logging, schema, or compatibility changes that were not part of the contract.
+
+Use metrics as sensors, not verdicts. Do not refactor mechanically to satisfy one metric if that increases coupling, indirection, or change radius elsewhere. Apply only high-value refactoring, then rerun the applicable final verification layers.
+
+## 6. EVIDENCE
+
+Finish with a concise, reproducible evidence report based on fresh checks after the last edit. Include:
+
+- the final change contract and any important assumptions;
+- a behavior/scenario-to-test or check mapping;
+- the exact commands or tools actually run and their real results;
+- final status of applicable diagnostics, tests, static checks, and other sensors;
+- a short maintainability review for non-trivial multi-file changes;
+- the source state, preferably a commit SHA or reproducible tree hash when available;
+- every applicable layer not run, classified as `N/A`, `UNAVAILABLE`, or `SUBSTITUTED`, with the reason and blind spots;
+- failures encountered and how they were resolved;
+- remaining risks and uncertainty without claiming absolute proof.
+
+Never report a check, test, mutation, sensor, or review as completed when it was not actually performed.
+
+## Calibration
+
+- **Tier 1 — trivial/local:** use focused verification plus the repository's cheap standard checks. Explain briefly when no new test is warranted.
+- **Tier 2 — normal feature or bug fix:** use the full CONTRACT → PLAN → IMPLEMENT → VERIFY → REVIEW → EVIDENCE loop. Bug fixes require an executable reproduction when practical. Include semantic maintainability review when the change crosses files or module boundaries.
+- **Tier 3 — high stakes:** first write a short failure model for risks such as authentication, money, data loss, concurrency, migrations, public API compatibility, unbounded growth, security, or silent production failure. Add targeted property, mutation, fuzz, stress, rollback, contract, compatibility, observability, benchmark, or adversarial checks as appropriate.
+
+## Setup and safety
+
+Prefer the repository's existing tools and dependencies. Do not install packages, initialize Git, create checkpoint commits, rewrite history, or mutate a different working tree without authorization. If verification tooling is missing or cannot run, use the strongest available substitute and state the resulting confidence limit in EVIDENCE.

--- a/prompt/evidence-first-coding-harness.v1.md
+++ b/prompt/evidence-first-coding-harness.v1.md
@@ -1,0 +1,107 @@
+# Evidence-First Coding Harness
+
+Optimize for trustworthy outcomes, not for performing a prescribed coding ritual. The implementation process may vary by task and model, but completion requires fresh, reproducible evidence that the requested behavior works and important constraints still hold.
+
+## Core loop
+
+CONTRACT → PLAN → IMPLEMENT → VERIFY → REVIEW → EVIDENCE
+
+The loop is outcome-driven. TDD is an available implementation strategy, not a mandatory ceremony. Do not force a RED → GREEN sequence for ordinary feature work when another approach gives better design coverage or feedback. For bug fixes, establish an executable reproduction before the fix when practical so the defect cannot silently return.
+
+## 1. CONTRACT
+
+Before editing, turn the request into a compact change contract:
+
+- State the observable behavior that must change.
+- Record important edge cases, error cases, compatibility requirements, invariants, and negative constraints.
+- Identify assumptions and uncertainties that could materially change the implementation.
+- Keep the contract proportional to the task. Use named scenarios or Gherkin when they clarify behavior, but do not create ceremony for trivial work.
+- For ambiguous or high-risk work, clarify the contract with the human before implementation. In autonomous work, proceed only within the authority already granted and record important assumptions.
+
+The implementation must not silently redefine the contract. If new evidence changes the understanding of the task, update the contract explicitly and explain why.
+
+## 2. PLAN
+
+Inspect enough surrounding code, tests, architecture guidance, and repository conventions to choose a coherent design before making local edits.
+
+For non-trivial work, think through the relevant data model, APIs, boundaries, cross-cutting edge cases, and likely test strategy before implementation. Prefer the smallest relevant context and avoid unrelated exploration that pollutes the working context.
+
+Choose an implementation strategy appropriate to the task. Valid strategies include:
+
+- test-first or TDD when it provides useful feedback;
+- characterization-first for unfamiliar or legacy behavior;
+- implementation followed immediately by focused tests when the design is clearer as a whole;
+- a small spike when uncertainty must be reduced first, provided exploratory code is not mistaken for the final verified change.
+
+Do not claim a process step that did not actually occur.
+
+## 3. IMPLEMENT
+
+Keep the change narrowly scoped to the contract and follow established repository patterns.
+
+For bug fixes, first reproduce the defect with a failing regression test or another executable reproduction when practical. Confirm that the reproduction fails for the expected reason before applying the fix. If a test-first reproduction is impractical, record why and use the strongest executable substitute available.
+
+For features, add or update a small set of high-value tests that cover distinct behavior, important boundaries, and regressions. Avoid duplicate, vacuous, or coverage-only tests. Make randomized tests reproducible with fixed seeds or deterministic fixtures unless randomness itself is under test.
+
+Do not weaken existing tests, constraints, or checkers merely to obtain a green result. Avoid unrelated cleanup while behavior is still changing.
+
+## 4. VERIFY
+
+Use project-native tooling and run every applicable verification layer. A check is evidence only if it really ran against the final relevant source state and enforced the claimed constraint.
+
+Consider these layers according to task risk and repository support:
+
+- focused tests for the changed behavior;
+- the full relevant test suite;
+- build, compiler, static type, lint, format, and diagnostics checks;
+- changed-behavior coverage when coverage tooling is meaningful;
+- mutation testing when test effectiveness is uncertain or the change is high risk;
+- property or invariant tests for parsing, math, serialization, ordering, state machines, or round trips;
+- existing dependency-boundary or architecture checks;
+- realistic execution of the application, CLI, endpoint, or workflow when feasible;
+- dependency, license, secret, and capability checks when the change expands the supply chain or runtime authority;
+- repeated or randomized-order tests when flakiness or nondeterminism is a material risk.
+
+Treat false greens as failures. A checker that crashes, silently skips required inputs, only prints a metric without enforcing its requirement, or reports success without exercising the intended path is not evidence. For home-grown gates, prefer a known-bad negative control when practical to prove the failure path is reachable.
+
+## 5. REVIEW
+
+After behavior is working, review the final diff plus enough neighboring code to judge maintainability in context.
+
+Check for:
+
+- semantic duplication;
+- misplaced responsibilities;
+- reimplementation of an existing pattern or abstraction;
+- dependency-direction or architecture-boundary violations;
+- excessive change radius for a small requirement;
+- unnecessary coupling, indirection, or complexity;
+- public API, configuration, logging, schema, or compatibility changes that were not part of the contract.
+
+Use metrics as sensors, not verdicts. Do not refactor mechanically to satisfy one metric if that increases coupling, indirection, or change radius elsewhere. Apply only high-value refactoring, then rerun the applicable final verification layers.
+
+## 6. EVIDENCE
+
+Finish with a concise, reproducible evidence report based on fresh checks after the last edit. Include:
+
+- the final change contract and any important assumptions;
+- a behavior/scenario-to-test or check mapping;
+- the exact commands or tools actually run and their real results;
+- final status of applicable diagnostics, tests, static checks, and other sensors;
+- a short maintainability review for non-trivial multi-file changes;
+- the source state, preferably a commit SHA or reproducible tree hash when available;
+- every applicable layer not run, classified as `N/A`, `UNAVAILABLE`, or `SUBSTITUTED`, with the reason and blind spots;
+- failures encountered and how they were resolved;
+- remaining risks and uncertainty without claiming absolute proof.
+
+Never report a check, test, mutation, sensor, or review as completed when it was not actually performed.
+
+## Calibration
+
+- **Tier 1 — trivial/local:** use focused verification plus the repository's cheap standard checks. Explain briefly when no new test is warranted.
+- **Tier 2 — normal feature or bug fix:** use the full CONTRACT → PLAN → IMPLEMENT → VERIFY → REVIEW → EVIDENCE loop. Bug fixes require an executable reproduction when practical. Include semantic maintainability review when the change crosses files or module boundaries.
+- **Tier 3 — high stakes:** first write a short failure model for risks such as authentication, money, data loss, concurrency, migrations, public API compatibility, unbounded growth, security, or silent production failure. Add targeted property, mutation, fuzz, stress, rollback, contract, compatibility, observability, benchmark, or adversarial checks as appropriate.
+
+## Setup and safety
+
+Prefer the repository's existing tools and dependencies. Do not install packages, initialize Git, create checkpoint commits, rewrite history, or mutate a different working tree without authorization. If verification tooling is missing or cannot run, use the strongest available substitute and state the resulting confidence limit in EVIDENCE.

--- a/test/test_ai-code-evidence-first-harness.el
+++ b/test/test_ai-code-evidence-first-harness.el
@@ -1,0 +1,67 @@
+;;; test_ai-code-evidence-first-harness.el --- Tests for Evidence-First harness -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; Tests for the Evidence-First Coding Harness routing and bundled prompts.
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'ai-code-harness)
+
+(defun ai-code-evidence-first-test--prompt-content (diagnostics-p)
+  "Return bundled Evidence-First harness text for DIAGNOSTICS-P."
+  (let* ((package-dir (file-name-directory (file-truename (locate-library "ai-code"))))
+         (file-name (if diagnostics-p
+                        "evidence-first-coding-harness-diagnostics.v1.md"
+                      "evidence-first-coding-harness.v1.md"))
+         (file-path (expand-file-name file-name
+                                     (expand-file-name "prompt/" package-dir))))
+    (with-temp-buffer
+      (insert-file-contents file-path)
+      (buffer-string))))
+
+(ert-deftest ai-code-test-evidence-first-harness-is-ask-me-choice ()
+  "Evidence-First harness should be available in per-send harness choices."
+  (should
+   (equal
+    (cdr (assoc "Evidence-First coding harness"
+                ai-code--auto-test-type-ask-choices))
+    'evidence-first-coding-harness)))
+
+(ert-deftest ai-code-test-evidence-first-harness-routes-through-local-prompt ()
+  "Evidence-First harness should use the existing local harness routing."
+  (cl-letf (((symbol-function 'ai-code--diagnostics-harness-enabled-p)
+             (lambda () nil)))
+    (let ((suffix
+           (ai-code--auto-test-suffix-for-type
+            'evidence-first-coding-harness)))
+      (should (string-match-p "Read the local harness file:" suffix))
+      (should (string-match-p
+               "evidence-first-coding-harness\\.v1\\.md"
+               suffix)))))
+
+(ert-deftest ai-code-test-evidence-first-harness-keeps-process-flexible ()
+  "Evidence-First harness should require evidence without mandatory TDD."
+  (let ((content (ai-code-evidence-first-test--prompt-content nil)))
+    (should (string-match-p "not a mandatory ceremony" content))
+    (should (string-match-p "Do not force a RED → GREEN sequence" content))
+    (should (string-match-p "For bug fixes, first reproduce the defect" content))
+    (should (string-match-p "Treat false greens as failures" content))
+    (should (string-match-p "semantic duplication" content))
+    (should (string-match-p "## 6\\. EVIDENCE" content))))
+
+(ert-deftest ai-code-test-evidence-first-diagnostics-variant-adds-sensor-loop ()
+  "Diagnostics variant should require baseline-relative final diagnostics."
+  (let ((content (ai-code-evidence-first-test--prompt-content t)))
+    (should (string-match-p "diagnostics_baseline" content))
+    (should (string-match-p "get_diagnostics" content))
+    (should (string-match-p "since=\\\"baseline\\\"" content))
+    (should (string-match-p "final status is `clean`" content))))
+
+(provide 'test-ai-code-evidence-first-harness)
+
+;;; test_ai-code-evidence-first-harness.el ends here


### PR DESCRIPTION
## Summary

Add a new **Evidence-First Coding Harness** as an opt-in `ai-code-auto-test-type` `ask-me` choice, alongside the existing TDD and Uncle Bob harnesses.

The new harness keeps the strong verification, false-green protection, maintainability review, and evidence discipline of the existing harness work, but deliberately does **not** require ordinary feature work to follow a strict RED → GREEN sequence.

Its core loop is:

`CONTRACT → PLAN → IMPLEMENT → VERIFY → REVIEW → EVIDENCE`

TDD remains an available implementation strategy. Bug fixes still require an executable reproduction/regression test before the fix when practical.

## Why a separate harness

This intentionally does **not** change Uncle Bob's Coding Agent Harness+.

Harness+ has a clear process-oriented identity around:

`SPEC → RED → GREEN → REFACTOR → GAUNTLET → EVIDENCE`

The Evidence-First harness tests a different hypothesis: for modern coding agents, it may be more effective to constrain the **outcome and evidence** strongly while allowing the agent more freedom in how it gets there. Keeping the two harnesses separate makes that distinction explicit and lets users compare them on real work instead of silently changing the semantics of Harness+.

## What the Evidence-First harness requires

- a compact change contract covering behavior, invariants, edge cases, compatibility, and assumptions
- an up-front design pass for non-trivial work so cross-cutting concerns are not locked in by the first local test
- flexible implementation strategy: TDD/test-first, characterization-first, implementation plus immediate focused tests, or a bounded spike
- regression reproduction first for bug fixes when practical
- project-native tests/build/types/lint/format/diagnostics and risk-calibrated coverage, mutation, property, architecture, real-execution, supply-chain, and suite-health checks
- explicit false-green handling: skipped/broken/non-enforcing checks are not evidence
- semantic maintainability review covering duplication, responsibility placement, consistency, dependency direction, and change radius
- a fresh final evidence report with commands/results, sensor status, source state, skipped-layer classification, and remaining risk

The diagnostics-aware variant also requires `diagnostics_baseline` plus baseline-relative `get_diagnostics` checks through the final source state.

## Implementation

- add `evidence-first-coding-harness` to the existing per-send harness choices
- route it through the same bundled local harness mechanism as the Uncle Bob harnesses
- add normal and diagnostics-aware prompt variants
- add focused ERT coverage for choice registration, routing, process flexibility, bug-fix regression discipline, false-green protection, maintainability review, evidence output, and diagnostics requirements

No existing harness behavior is changed.

## Design inspiration

This is inspired by recent software-delivery discussions published on martinfowler.com rather than being presented as a "Martin Fowler harness":

- Birgitta Böckeler, **TDD inside the agent loop - theater or actual value?** — exploratory evidence that strict TDD inside an agent loop did not clearly improve outcomes, while adding significant process/token cost; the article argues for monitoring outcomes and automated feedback rather than over-specifying model process.
  https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html
- Giles Edwards-Alexander, **The Economic Benefit of Refactoring** — reinforces change locality and maintainable structure as part of the effective coding-agent environment.
  https://martinfowler.com/articles/exploring-gen-ai/refactoring-economic-benefit.html
- Rahul Garg, **The Orchestrator's Tax** — reinforces protecting working context and avoiding unnecessary process/context pollution.
  https://martinfowler.com/articles/orchestrator-tax.html
- Unmesh Joshi, **DSLs Enable Reliable Use of LLMs** — reinforces constrained contracts/abstractions and deterministic feedback as reliability mechanisms.
  https://martinfowler.com/articles/llm-and-dsls.html

The harness also reuses ideas already developed in this project for Harness+, especially evidence-first verification, false-green hardening, maintainability sensors, semantic modularity review, and risk calibration.

## Verification

Added focused ERT tests in `test/test_ai-code-evidence-first-harness.el`. GitHub CI should run the repository's normal test/lint checks for this PR.