### PR TITLE
Freeze scrolled-away vterm viewports during redraw

### DIFF
--- a/ai-code-backends-infra-vterm.el
+++ b/ai-code-backends-infra-vterm.el
@@ -52,6 +52,7 @@
 (declare-function vterm-send-return "vterm" ())
 (declare-function vterm--window-adjust-process-window-size "vterm" (&rest args))
 (declare-function vterm--filter "vterm" (&rest args))
+(declare-function vterm--delayed-redraw "vterm" (buffer))
 
 (defvar ai-code-backends-infra-strip-alternate-screen)
 (defvar ai-code-backends-infra--session-terminal-backend)
@@ -260,29 +261,73 @@ applications write to the normal screen buffer (preserving scrollback)."
          (process-buffer process)
          filtered-input)))))
 
+(defun ai-code-backends-infra--vterm-window-scrolled-away-p (window)
+  "Return non-nil when WINDOW no longer shows the end of the current buffer.
+Such a window was scrolled away by the user, so its viewport should stay
+put instead of following new terminal output.  The buffer end counts as
+shown even when its line is only partially visible, otherwise a fractional
+last screen line would freeze the viewport permanently.  Anything that is
+not a live window is never reported as scrolled away."
+  (and (windowp window)
+       (window-live-p window)
+       (not (pos-visible-in-window-p (point-max) window t))))
+
+(defun ai-code-backends-infra--vterm-frozen-windows ()
+  "Return windows of the current buffer whose viewport must stay stable.
+`vterm-copy-mode' freezes every window showing the buffer.  Otherwise only
+windows the user has scrolled away from the buffer end are frozen, so a
+window that still shows live output keeps following it."
+  (let ((windows (get-buffer-window-list (current-buffer) nil t)))
+    (if (bound-and-true-p vterm-copy-mode)
+        windows
+      (cl-remove-if-not
+       #'ai-code-backends-infra--vterm-window-scrolled-away-p windows))))
+
 (defun ai-code-backends-infra--vterm-render-preserving-copy-mode-view (render-fn)
-  "Call RENDER-FN while keeping the user's `vterm-copy-mode' viewport stable."
-  (if (not (bound-and-true-p vterm-copy-mode))
-      (funcall render-fn)
-    (let ((point-marker (copy-marker (point) t))
-          (window-states
-           (mapcar (lambda (window)
-                     (list window
-                           (copy-marker (window-start window) t)
-                           (copy-marker (window-point window) t)))
-                   (get-buffer-window-list (current-buffer) nil t))))
-      (unwind-protect
-          (let ((inhibit-redisplay t))
-            (funcall render-fn))
-        (dolist (state window-states)
-          (pcase-let ((`(,window ,start-marker ,window-point-marker) state))
-            (when (window-live-p window)
-              (set-window-start window start-marker t)
-              (set-window-point window window-point-marker))
-            (set-marker start-marker nil)
-            (set-marker window-point-marker nil)))
-        (goto-char point-marker)
-        (set-marker point-marker nil)))))
+  "Call RENDER-FN while keeping frozen vterm viewports stable.
+A viewport is frozen in `vterm-copy-mode' and in any window the user has
+scrolled away from the buffer end, so terminal output keeps rendering
+without yanking the view back to the terminal cursor.  Windows that still
+show live output are left untouched and keep following it.
+Frozen windows are detected before RENDER-FN runs, because rendering is
+what moves the viewport."
+  (let* ((frozen-windows (ai-code-backends-infra--vterm-frozen-windows))
+         (preserve-point (or (bound-and-true-p vterm-copy-mode)
+                             (and (memq (selected-window) frozen-windows) t))))
+    (if (and (null frozen-windows) (not preserve-point))
+        (funcall render-fn)
+      (let ((point-marker (and preserve-point (copy-marker (point) t)))
+            (window-states
+             (mapcar (lambda (window)
+                       (list window
+                             (copy-marker (window-start window) t)
+                             (copy-marker (window-point window) t)))
+                     frozen-windows)))
+        (unwind-protect
+            (let ((inhibit-redisplay t))
+              (funcall render-fn))
+          (dolist (state window-states)
+            (pcase-let ((`(,window ,start-marker ,window-point-marker) state))
+              (when (window-live-p window)
+                (set-window-start window start-marker t)
+                (set-window-point window window-point-marker))
+              (set-marker start-marker nil)
+              (set-marker window-point-marker nil)))
+          (when point-marker
+            (goto-char point-marker)
+            (set-marker point-marker nil)))))))
+
+(defun ai-code-backends-infra--vterm-preserve-viewport-on-redraw (orig-fun buffer)
+  "Keep frozen viewports stable while ORIG-FUN redraws BUFFER.
+`vterm--delayed-redraw' is where the vterm module recenters windows on the
+terminal cursor, so session buffers wrap it to hold scrolled-away windows
+in place.  Other buffers redraw untouched."
+  (if (not (and (buffer-live-p buffer)
+                (ai-code-backends-infra--session-buffer-p buffer)))
+      (funcall orig-fun buffer)
+    (with-current-buffer buffer
+      (ai-code-backends-infra--vterm-render-preserving-copy-mode-view
+       (lambda () (funcall orig-fun buffer))))))
 
 (defun ai-code-backends-infra--vterm-render-queued-output (orig-fun buffer)
   "Render queued vterm output for BUFFER using ORIG-FUN."
@@ -386,6 +431,8 @@ returns to normal terminal interaction."
     (advice-add 'vterm--filter :around #'ai-code-backends-infra--vterm-notification-tracker)
     (when ai-code-backends-infra-vterm-anti-flicker
       (advice-add 'vterm--filter :around #'ai-code-backends-infra--vterm-smart-renderer))
+    (advice-add 'vterm--delayed-redraw :around
+                #'ai-code-backends-infra--vterm-preserve-viewport-on-redraw)
     (setq ai-code-backends-infra--vterm-advices-installed t)))
 
 (defun ai-code-backends-infra-vterm-create-session (buffer-name working-dir command env-vars)

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -3527,6 +3527,185 @@ The prefix argument should also force instance-name prompting."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ai-code-backends-infra-vterm-window-scrolled-away-p-rejects-dead-window ()
+  "Anything that is not a live window is never treated as scrolled away."
+  (should-not (ai-code-backends-infra--vterm-window-scrolled-away-p nil))
+  (should-not (ai-code-backends-infra--vterm-window-scrolled-away-p 'fake-window)))
+
+(ert-deftest test-ai-code-backends-infra-vterm-frozen-windows-freezes-all-in-copy-mode ()
+  "`vterm-copy-mode' freezes every window, even one showing the buffer end."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-frozen-copy-mode*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode t)
+            (cl-letf (((symbol-function
+                        'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                       (lambda (_window) nil)))
+              (should (equal (ai-code-backends-infra--vterm-frozen-windows)
+                             (list (selected-window)))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-frozen-windows-skips-following-window ()
+  "A window still showing the buffer end keeps following new output."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-frozen-following*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode nil)
+            (cl-letf (((symbol-function
+                        'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                       (lambda (_window) nil)))
+              (should (null (ai-code-backends-infra--vterm-frozen-windows))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-frozen-windows-freezes-scrolled-away-window ()
+  "A window scrolled away from the buffer end is frozen without copy mode."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-frozen-scrolled*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode nil)
+            (cl-letf (((symbol-function
+                        'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                       (lambda (_window) t)))
+              (should (equal (ai-code-backends-infra--vterm-frozen-windows)
+                             (list (selected-window)))))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-render-preserving-view-freezes-scrolled-away-window ()
+  "Rendering keeps a scrolled-away viewport stable outside `vterm-copy-mode'."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-scrolled-away-render*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode nil)
+            (dotimes (line 80)
+              (insert (format "line %02d\n" line)))
+            (goto-char (point-min))
+            (forward-line 25)
+            (set-window-start (selected-window) (point))
+            (forward-line 4)
+            (set-window-point (selected-window) (point))
+            (let ((original-start (window-start))
+                  (original-window-point (window-point))
+                  (original-point (point)))
+              (cl-letf (((symbol-function
+                          'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                         (lambda (_window) t)))
+                (ai-code-backends-infra--vterm-render-preserving-copy-mode-view
+                 (lambda ()
+                   ;; Mimic vterm recentering the window on the terminal cursor.
+                   (goto-char (point-max))
+                   (insert "tail\n")
+                   (set-window-start (selected-window) (point-max))
+                   (set-window-point (selected-window) (point-max)))))
+              (should (= (window-start) original-start))
+              (should (= (window-point) original-window-point))
+              (should (= (point) original-point)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-render-preserving-view-follows-output-at-bottom ()
+  "Rendering leaves a window that still shows the buffer end alone."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-following-render*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode nil)
+            (dotimes (line 80)
+              (insert (format "line %02d\n" line)))
+            (goto-char (point-min))
+            (set-window-start (selected-window) (point-min))
+            (set-window-point (selected-window) (point-min))
+            (cl-letf (((symbol-function
+                        'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                       (lambda (_window) nil)))
+              (ai-code-backends-infra--vterm-render-preserving-copy-mode-view
+               (lambda ()
+                 (goto-char (point-max))
+                 (insert "tail\n")
+                 (set-window-start (selected-window) (point-max))
+                 (set-window-point (selected-window) (point-max)))))
+            ;; Nothing was frozen, so the viewport and point follow the output.
+            (should (= (window-start) (point-max)))
+            (should (= (window-point) (point-max)))
+            (should (= (point) (point-max)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-preserve-viewport-on-redraw-freezes-session-buffer ()
+  "The redraw advice keeps a scrolled-away session viewport stable."
+  (let ((buffer (generate-new-buffer "*testclaude[redraw-freeze]*")))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (with-current-buffer buffer
+            (setq-local vterm-copy-mode nil)
+            (dotimes (line 80)
+              (insert (format "line %02d\n" line)))
+            (goto-char (point-min))
+            (forward-line 25)
+            (set-window-start (selected-window) (point))
+            (set-window-point (selected-window) (point))
+            (let ((original-start (window-start))
+                  (redrawn nil))
+              (cl-letf (((symbol-function
+                          'ai-code-backends-infra--vterm-window-scrolled-away-p)
+                         (lambda (_window) t)))
+                (ai-code-backends-infra--vterm-preserve-viewport-on-redraw
+                 (lambda (redraw-buffer)
+                   (setq redrawn redraw-buffer)
+                   (goto-char (point-max))
+                   (set-window-start (selected-window) (point-max))
+                   (set-window-point (selected-window) (point-max)))
+                 buffer))
+              (should (eq redrawn buffer))
+              (should (= (window-start) original-start)))))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-vterm-preserve-viewport-on-redraw-passes-through-other-buffers ()
+  "Non-session buffers redraw without viewport preservation."
+  (let ((buffer (generate-new-buffer " *ai-code-vterm-plain-redraw*")))
+    (unwind-protect
+        (let ((redrawn nil)
+              (preserved nil))
+          (cl-letf (((symbol-function
+                      'ai-code-backends-infra--vterm-render-preserving-copy-mode-view)
+                     (lambda (render-fn)
+                       (setq preserved t)
+                       (funcall render-fn))))
+            (ai-code-backends-infra--vterm-preserve-viewport-on-redraw
+             (lambda (redraw-buffer) (setq redrawn redraw-buffer))
+             buffer))
+          (should (eq redrawn buffer))
+          (should-not preserved))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-configure-vterm-buffer-installs-redraw-viewport-advice ()
+  "Configuring a vterm buffer should wrap vterm's delayed redraw."
+  (with-temp-buffer
+    (setq-local ai-code-backends-infra--session-terminal-backend 'vterm)
+    (let ((ai-code-backends-infra--vterm-advices-installed nil)
+          (installed nil))
+      (cl-letf (((symbol-function 'advice-add)
+                 (lambda (symbol _how function &rest _args)
+                   (push (cons symbol function) installed))))
+        (ai-code-backends-infra--configure-vterm-buffer))
+      (should (member (cons 'vterm--delayed-redraw
+                            #'ai-code-backends-infra--vterm-preserve-viewport-on-redraw)
+                      installed)))))
+
 (ert-deftest test-ai-code-backends-infra-vterm-render-queued-output-skips-dead-process ()
   "Queued output should be dropped when the buffer has no live process."
   (with-temp-buffer


### PR DESCRIPTION
Scrolling up in a vterm session to re-read earlier output doesn't work while the agent is streaming: the next redraw yanks the viewport back to the bottom. This change makes any scrolled-away window hold its position until you scroll back down.

**Why no setting fixes it.** The jump comes from `adjust_topline()` in vterm's C module, which calls `recenter()` on the selected window on every redraw. The `(setq-local vterm-scroll-to-bottom-on-output nil)` line already in this file is dead code — that variable does not exist in current vterm.

**Approach.** `--vterm-render-preserving-copy-mode-view` already saved and restored `window-start` / `window-point` around a render (from #241 / #285 / #286), but it only fired in `vterm-copy-mode`. Copy mode can't be reused as the trigger — entering it sends `^S` to the pty and unbinds the local map, so you could neither type nor interrupt the agent while scrolled up. The freeze condition becomes "copy mode **or** this window is scrolled away", evaluated per window:

- `--vterm-window-scrolled-away-p`: `(not (pos-visible-in-window-p (point-max) window t))`. PARTIALLY is `t` deliberately — otherwise a half-visible last screen line would freeze the viewport permanently.
- `--vterm-frozen-windows`: copy mode freezes every window showing the buffer; otherwise only scrolled-away ones, so a window still at the bottom keeps following output and two windows on one session behave independently.
- `--vterm-preserve-viewport-on-redraw`: new `:around` advice on `vterm--delayed-redraw`, session buffers only. The site matters — with `vterm-timer-delay` at its default `0.1` the `recenter` happens on a timer, outside the existing `vterm--filter` advice. `vterm--invalidate` funnels both the timer path and the immediate keystroke-echo path through `vterm--delayed-redraw`, so one advice covers every redraw.

Behaviour is silent and automatic: no new mode, no defcustom, no mode-line indicator. Typing and `ESC` keep reaching the agent while frozen, and scrolling back to the bottom resumes following.

**Verification.** 9 new ERT tests: the scrolled-away predicate, frozen-window selection (copy mode vs. scrolled-away vs. at-bottom), viewport frozen in one case and following in the other, the redraw advice for session and non-session buffers, and advice installation. Full suite 1455 tests with no new failures against the pre-change baseline on the same machine; the remaining local failures are pre-existing environment artifacts (ghostel not installed, tests needing a real frame, magit). `ai-code-backends-infra-vterm.el` byte-compiles without warnings, and the existing copy-mode tests still pass — `--vterm-render-preserving-copy-mode-view` keeps its name and its copy-mode contract.

One caveat worth flagging: `pos-visible-in-window-p` has no redisplay data under `emacs -batch`, so the display probe is isolated in its own predicate and stubbed in the unit tests. The end-to-end "scroll up while the agent streams" behaviour needs a real Emacs frame to confirm.
