### PR TITLE
Prevent MCP HTTP client buffer leaks

### DIFF
--- a/ai-code-mcp-http-server.el
+++ b/ai-code-mcp-http-server.el
@@ -81,6 +81,7 @@ When nil, an available port is selected automatically."
                  :host "127.0.0.1"
                  :service (or ai-code-mcp-http-server-port 0)
                  :noquery t
+                 :filter #'ai-code-mcp-http-server--filter
                  :log #'ai-code-mcp-http-server--accept)))
     (setq ai-code-mcp-http-server--server server
           ai-code-mcp-http-server--port (process-contact server :service))))

--- a/test/test_ai-code-mcp-http-server.el
+++ b/test/test_ai-code-mcp-http-server.el
@@ -168,6 +168,29 @@
          (kill-buffer source-buffer))
        (delete-directory project-dir t))))
 
+(ert-deftest ai-code-test-mcp-http-server-does-not-leave-visible-client-buffers ()
+  "Accepted connections should not leave visible client buffers behind."
+  (let ((ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (buffers-before (buffer-list))
+        leaked-buffers)
+    (unwind-protect
+        (let ((port (ai-code-mcp-http-server-ensure)))
+          (ai-code-test-mcp-http--exchange port "GET" "/mcp" nil "")
+          (setq leaked-buffers
+                (seq-filter
+                 (lambda (buffer)
+                   (and (not (memq buffer buffers-before))
+                        (string-prefix-p "ai-code-mcp-http-server <"
+                                         (buffer-name buffer))))
+                 (buffer-list)))
+          (should-not leaked-buffers))
+      (ai-code-mcp-http-server-stop)
+      (dolist (buffer leaked-buffers)
+        (when (buffer-live-p buffer)
+          (kill-buffer buffer))))))
+
 (ert-deftest ai-code-test-mcp-http-server-discovers-modern-protocol-over-socket ()
   "Modern clients should discover capabilities without a session handshake."
   (ai-code-test-mcp-http--with-server


### PR DESCRIPTION
## Summary

Prevent the local MCP HTTP server from leaving an empty visible buffer behind for every accepted connection.

The listener now installs the existing HTTP process filter up front, which stops Emacs from allocating a default client process buffer before the accept callback runs. This keeps MCP requests out of the buffer list without changing request handling.

A real socket regression test verifies that a completed request leaves no `ai-code-mcp-http-server <...>` buffers behind.

## Verification

- MCP HTTP test suite: 23/23 passed
- Full ERT suite: 1,434 passed, 13 skipped, 0 unexpected
- 100 consecutive connections: 0 visible client buffers

Fixes #499