### PR TITLE
feat: Add MCP support for Antigravity CLI

### DIFF
--- a/README.org
+++ b/README.org
@@ -305,22 +305,25 @@ screenshot inside Codex cli:
 
 ***** Use It with an AI CLI
 
-Set the backend to =claude-code=, =codex=, or =github-copilot-cli= and start a session with =C-c a a=. AI Code will:
+Set the backend to =claude-code=, =codex=, =github-copilot-cli=, or =antigravity= and start a session with =C-c a a=. AI Code will:
 - start a local Emacs MCP HTTP server
 - register the current project/buffer as the MCP session context
 - inject a session-scoped MCP config into that agent session automatically
 
-Auto-wiring is currently enabled for =claude-code=, =codex=, and =github-copilot-cli=.
+Auto-wiring is currently enabled for =claude-code=, =codex=, =github-copilot-cli=, =open-interpreter=, and =antigravity=.
+
+Antigravity does not expand environment variables in MCP headers, so AI Code temporarily writes the session token to =.agents/mcp_config.json= with private permissions. Existing JSON configuration is merged and restored byte for byte when the last Antigravity session exits. If the file changes outside AI Code while a session is active, cleanup leaves the edited file untouched rather than overwriting it.
 
 If you disabled it before, enable it again with:
 
 #+begin_src emacs-lisp
-(setq ai-code-mcp-agent-enabled-backends '(claude-code codex github-copilot-cli))
+(setq ai-code-mcp-agent-enabled-backends
+      '(claude-code codex github-copilot-cli open-interpreter antigravity))
 #+end_src
 
 ***** Make Sure It Works
 
-1. Start =claude-code=, =codex=, or =github-copilot-cli= with =C-c a a= from the file or project you want to work on.
+1. Start =claude-code=, =codex=, =github-copilot-cli=, =open-interpreter=, or =antigravity= with =C-c a a= from the file or project you want to work on.
 2. Switch to the agent buffer and run =M-x ai-code-mcp-agent-show-buffer-status=.
 
 If it shows =:backend=, =:session-id=, and a local =:server-url=, then Emacs has attached MCP to this session.
@@ -555,6 +558,9 @@ To transfer development work between different AI coding backends (e.g., from Co
      point at a different binary or pass additional flags. After that, select the backend through
      `ai-code-select-backend` or bind a helper in your config.
      The resume command adds =--continue= automatically.
+     Emacs MCP tools are wired automatically through a temporary workspace
+     =.agents/mcp_config.json= entry when this backend is enabled in
+     =ai-code-mcp-agent-enabled-backends=.
 
 **** Muse Code setup
      Install Muse Code on macOS or Linux with:

--- a/ai-code-antigravity-cli.el
+++ b/ai-code-antigravity-cli.el
@@ -12,6 +12,7 @@
 
 (require 'ai-code-backends)
 (require 'ai-code-backends-infra)
+(require 'ai-code-mcp-agent)
 
 (defgroup ai-code-antigravity-cli nil
   "Antigravity CLI integration via `ai-code-backends-infra'."
@@ -46,7 +47,11 @@ With prefix ARG, prompt for CLI args using
          :label "Antigravity"
          :process-table ai-code-antigravity-cli--processes
          :session-prefix ai-code-antigravity-cli--session-prefix
-         :escape-function #'ai-code-antigravity-cli-send-escape)
+         :escape-function #'ai-code-antigravity-cli-send-escape
+         :prepare-launch
+         (lambda (working-dir argv)
+           (ai-code-mcp-agent-prepare-launch
+            'antigravity working-dir argv)))
    arg))
 
 ;;;###autoload

--- a/ai-code-backends-infra.el
+++ b/ai-code-backends-infra.el
@@ -1339,6 +1339,17 @@ behavior."
         (message "CLI failed to start - see buffer for error details"))
     (message "CLI failed to start - process exited immediately")))
 
+(defun ai-code-backends-infra--cleanup-failed-launch (cleanup-fn)
+  "Call CLEANUP-FN after a failed launch without masking the startup error."
+  (when cleanup-fn
+    (condition-case err
+        (funcall cleanup-fn)
+      (error
+       (display-warning
+        'ai-code-backends-infra
+        (format "Failed to clean up CLI launch resources: %s"
+                (error-message-string err)))))))
+
 (defun ai-code-backends-infra--start-cli-session (options arg)
   "Start a generic CLI session described by OPTIONS and prefix ARG.
 When ARG is non-nil, prompt for CLI args, working directory, and
@@ -1507,8 +1518,12 @@ TASK-FILE and SOURCE-BUFFER preserve file-to-session binding."
               env-vars
             (ai-code-editor-viewport-environment env-vars)))
          (buffer-and-process
-          (ai-code-backends-infra--create-terminal-session
-           resolved-buffer-name working-dir command editor-environment))
+          (condition-case err
+              (ai-code-backends-infra--create-terminal-session
+               resolved-buffer-name working-dir command editor-environment)
+            (error
+             (ai-code-backends-infra--cleanup-failed-launch cleanup-fn)
+             (signal (car err) (cdr err)))))
          (new-buffer (car buffer-and-process))
          (process (cdr buffer-and-process)))
     (puthash session-key process process-table)
@@ -1532,10 +1547,12 @@ TASK-FILE and SOURCE-BUFFER preserve file-to-session binding."
            task-file)
           (ai-code-backends-infra--remember-file-session-buffer
            prefix source-buffer new-buffer))
-      (ai-code-backends-infra--handle-session-start-failure
-       new-buffer
-       session-key
-       process-table))))
+      (unwind-protect
+          (ai-code-backends-infra--handle-session-start-failure
+           new-buffer
+           session-key
+           process-table)
+        (ai-code-backends-infra--cleanup-failed-launch cleanup-fn)))))
 
 (defun ai-code-backends-infra--toggle-or-create-session (working-dir buffer-name process-table command
                                                                      &optional escape-fn cleanup-fn

--- a/ai-code-mcp-agent.el
+++ b/ai-code-mcp-agent.el
@@ -18,7 +18,8 @@
   :group 'tools
   :prefix "ai-code-mcp-agent-")
 
-(defcustom ai-code-mcp-agent-enabled-backends '(codex open-interpreter github-copilot-cli claude-code)
+(defcustom ai-code-mcp-agent-enabled-backends
+  '(codex open-interpreter github-copilot-cli claude-code antigravity)
   "Backends that should receive automatic Emacs MCP integration."
   :type '(repeat symbol)
   :group 'ai-code-mcp-agent)
@@ -37,6 +38,14 @@
 
 (defconst ai-code-mcp-agent--status-buffer-name "*AI Code MCP Status*"
   "Buffer name used to display MCP status to users.")
+
+(defconst ai-code-mcp-agent--antigravity-config-relative-path
+  ".agents/mcp_config.json"
+  "Workspace-relative path used by Antigravity for MCP configuration.")
+
+(defvar ai-code-mcp-agent--antigravity-config-states
+  (make-hash-table :test 'equal)
+  "Active Antigravity MCP config leases keyed by absolute config path.")
 
 (defvar-local ai-code-mcp-agent--backend nil
   "Backend symbol attached to the current agent buffer.")
@@ -77,46 +86,65 @@
 (defun ai-code-mcp-agent-prepare-launch (backend working-dir argv)
   "Return MCP launch metadata for BACKEND, WORKING-DIR, and ARGV."
   (when (memq backend ai-code-mcp-agent-enabled-backends)
-    (ai-code-mcp-builtins-setup)
-    (let* ((port (ai-code-mcp-http-server-ensure))
+    (let* ((backend-state
+            (ai-code-mcp-agent--prepare-backend-state backend working-dir))
+           (server-was-live (ai-code-mcp-http-server-live-p))
            (session-id (ai-code-mcp-agent--make-session-id backend))
            (token (ai-code-mcp--random-secret))
-           (url (ai-code-mcp-agent--make-server-url port))
-           (launch-metadata
-            (ai-code-mcp-agent--inject-argv backend argv url
-                                            ai-code-mcp-agent--token-environment-variable))
-           (runtime-files (plist-get launch-metadata :runtime-files)))
-      (ai-code-mcp-register-session
-       session-id working-dir (current-buffer)
-       (list :backend backend
-             :state 'pending
-             :tool-profile ai-code-mcp-default-tool-profile
-             :token token
-             :expires-at
-             (time-add (current-time)
-                       (seconds-to-time
-                        ai-code-mcp-agent-token-lifetime-seconds))))
-      (list :argv (plist-get launch-metadata :argv)
-            :env-vars
-            (list (format "%s=%s"
-                          ai-code-mcp-agent--token-environment-variable
-                          token))
-            :mcp-session-id session-id
-            :mcp-server-url url
-            :cleanup-fn
-            (ai-code-mcp-agent--make-cleanup-function
-             session-id runtime-files)
-            :post-start-fn (lambda (buffer _process _instance-name)
-                             (ai-code-mcp-agent--record-buffer-session
-                              buffer backend session-id url))))))
+           launch-metadata)
+      (condition-case err
+          (progn
+            (ai-code-mcp-builtins-setup)
+            (let* ((port (ai-code-mcp-http-server-ensure))
+                   (url (ai-code-mcp-agent--make-server-url port)))
+              (setq launch-metadata
+                    (ai-code-mcp-agent--inject-argv
+                     backend argv url
+                     ai-code-mcp-agent--token-environment-variable
+                     token backend-state session-id))
+              (ai-code-mcp-register-session
+               session-id working-dir (current-buffer)
+               (list :backend backend
+                     :state 'pending
+                     :tool-profile ai-code-mcp-default-tool-profile
+                     :token token
+                     :modern-protocol-enabled
+                     (not (eq backend 'antigravity))
+                     :expires-at
+                     (time-add (current-time)
+                               (seconds-to-time
+                                ai-code-mcp-agent-token-lifetime-seconds))))
+              (list :argv (plist-get launch-metadata :argv)
+                    :env-vars
+                    (list (format "%s=%s"
+                                  ai-code-mcp-agent--token-environment-variable
+                                  token))
+                    :mcp-session-id session-id
+                    :mcp-server-url url
+                    :cleanup-fn
+                    (ai-code-mcp-agent--make-cleanup-function
+                     session-id
+                     (plist-get launch-metadata :runtime-files)
+                     (plist-get launch-metadata :runtime-cleanup-functions))
+                    :post-start-fn
+                    (lambda (buffer _process _instance-name)
+                      (ai-code-mcp-agent--record-buffer-session
+                       buffer backend session-id url)))))
+        (error
+         (ai-code-mcp-agent--discard-failed-launch
+          session-id launch-metadata server-was-live)
+         (signal (car err) (cdr err)))))))
 
-(defun ai-code-mcp-agent--make-cleanup-function (session-id runtime-files)
-  "Return a repeat-safe cleanup function for SESSION-ID and RUNTIME-FILES.
-Failed file removals are retried; session unregistration occurs at most once."
+(defun ai-code-mcp-agent--make-cleanup-function
+    (session-id runtime-files &optional runtime-cleanup-functions)
+  "Return a repeat-safe cleanup function for SESSION-ID and runtime resources.
+RUNTIME-FILES are removed and RUNTIME-CLEANUP-FUNCTIONS are called.  Failed
+resource cleanup is retried; session unregistration occurs at most once."
   (let ((remaining-files (copy-sequence runtime-files))
+        (remaining-cleanups (copy-sequence runtime-cleanup-functions))
         (unregistered nil))
     (lambda ()
-      (let (failed-files)
+      (let (failed-files failed-cleanups)
         (dolist (path remaining-files)
           (when (stringp path)
             (condition-case err
@@ -128,7 +156,17 @@ Failed file removals are retried; session unregistration occurs at most once."
                 'ai-code-mcp-agent
                 (format "Failed to delete runtime file %s: %s"
                         path (error-message-string err)))))))
-        (setq remaining-files (nreverse failed-files)))
+        (dolist (cleanup remaining-cleanups)
+          (condition-case err
+              (funcall cleanup)
+            (error
+             (push cleanup failed-cleanups)
+             (display-warning
+              'ai-code-mcp-agent
+              (format "Failed to clean up an MCP runtime resource: %s"
+                      (error-message-string err))))))
+        (setq remaining-files (nreverse failed-files)
+              remaining-cleanups (nreverse failed-cleanups)))
       (unless unregistered
         (ai-code-mcp-unregister-session session-id)
         (setq unregistered t)
@@ -164,8 +202,12 @@ The bearer token selects the registered agent session."
       (when session-id
         (ai-code-mcp-update-source-context session-id source-buffer)))))
 
-(defun ai-code-mcp-agent--inject-argv (backend argv url token-env-var)
-  "Return launch metadata after injecting URL and TOKEN-ENV-VAR into ARGV for BACKEND."
+(defun ai-code-mcp-agent--inject-argv
+    (backend argv url token-env-var &optional token backend-state session-id)
+  "Return MCP launch metadata for BACKEND and ARGV.
+URL identifies the server and TOKEN-ENV-VAR names its secret environment
+variable.  TOKEN, BACKEND-STATE, and SESSION-ID support backends that require a
+workspace config file instead of environment substitution."
   (pcase backend
     ((or 'codex 'open-interpreter)
      (let ((config-override
@@ -182,7 +224,229 @@ The bearer token selects the registered agent session."
      (let ((config-file (ai-code-mcp-agent--claude-code-config-file url token-env-var)))
        (list :argv (append argv (list "--mcp-config" config-file))
              :runtime-files (list config-file))))
+    ('antigravity
+     (list
+      :argv argv
+      :runtime-cleanup-functions
+      (list (ai-code-mcp-agent--install-antigravity-config
+             backend-state session-id url token))))
     (_ (list :argv argv))))
+
+(defun ai-code-mcp-agent--prepare-backend-state (backend working-dir)
+  "Validate and return pre-launch state for BACKEND in WORKING-DIR."
+  (when (eq backend 'antigravity)
+    (ai-code-mcp-agent--prepare-antigravity-config working-dir)))
+
+(defun ai-code-mcp-agent--prepare-antigravity-config (working-dir)
+  "Return validated Antigravity config state for WORKING-DIR."
+  (unless (and (stringp working-dir) (file-directory-p working-dir))
+    (error "Antigravity MCP working directory does not exist: %s" working-dir))
+  (let* ((project-directory (file-name-as-directory
+                             (file-truename working-dir)))
+         (path (expand-file-name
+                ai-code-mcp-agent--antigravity-config-relative-path
+                project-directory))
+         (directory (file-name-directory path))
+         (active-state
+          (gethash path ai-code-mcp-agent--antigravity-config-states)))
+    (when (file-symlink-p directory)
+      (error "Refusing to write Antigravity MCP config through symlink: %s"
+             directory))
+    (when (and (file-exists-p directory)
+               (not (file-directory-p directory)))
+      (error "Antigravity MCP config parent is not a directory: %s" directory))
+    (when (file-symlink-p path)
+      (error "Refusing to replace symlinked Antigravity MCP config: %s" path))
+    (if active-state
+        (progn
+          (unless (and (file-regular-p path)
+                       (equal (ai-code-mcp-agent--file-contents path)
+                              (plist-get active-state :written-content)))
+            (error "Antigravity MCP config changed during an active session: %s"
+                   path))
+          active-state)
+      (let* ((original-exists-p (file-exists-p path))
+             (original-content
+              (when original-exists-p
+                (unless (file-regular-p path)
+                  (error "Antigravity MCP config is not a regular file: %s" path))
+                (ai-code-mcp-agent--file-contents path))))
+        (when original-exists-p
+          (ai-code-mcp-agent--parse-antigravity-config original-content path))
+        (list :path path
+              :directory directory
+              :directory-created-p nil
+              :original-exists-p original-exists-p
+              :original-content original-content
+              :original-mode (and original-exists-p (file-modes path))
+              :leases nil
+              :written-content nil)))))
+
+(defun ai-code-mcp-agent--file-contents (path)
+  "Return the literal contents of PATH."
+  (with-temp-buffer
+    (insert-file-contents-literally path)
+    (buffer-string)))
+
+(defun ai-code-mcp-agent--parse-antigravity-config (content path)
+  "Parse Antigravity config CONTENT from PATH as a JSON object."
+  (let* ((config
+          (json-parse-string content
+                             :object-type 'hash-table
+                             :array-type 'array
+                             :null-object :null
+                             :false-object :json-false))
+         (missing (make-symbol "missing"))
+         (servers (and (hash-table-p config)
+                       (gethash "mcpServers" config missing))))
+    (unless (hash-table-p config)
+      (error "Antigravity MCP config must contain a JSON object: %s" path))
+    (unless (or (eq servers missing) (hash-table-p servers))
+      (error "Antigravity mcpServers must contain a JSON object: %s" path))
+    config))
+
+(defun ai-code-mcp-agent--antigravity-config-content (state url token)
+  "Return merged Antigravity config for STATE using URL and TOKEN."
+  (let* ((path (plist-get state :path))
+         (config
+          (if (plist-get state :original-exists-p)
+              (ai-code-mcp-agent--parse-antigravity-config
+               (plist-get state :original-content) path)
+            (make-hash-table :test 'equal)))
+         (servers (gethash "mcpServers" config)))
+    (setq servers (if (hash-table-p servers)
+                      (copy-hash-table servers)
+                    (make-hash-table :test 'equal)))
+    (let ((server (make-hash-table :test 'equal))
+          (headers (make-hash-table :test 'equal)))
+      (puthash "Authorization" (concat "Bearer " token) headers)
+      (puthash "serverUrl" url server)
+      (puthash "headers" headers server)
+      (puthash ai-code-mcp-agent--server-name server servers))
+    (puthash "mcpServers" servers config)
+    (concat (json-serialize config
+                            :null-object :null
+                            :false-object :json-false)
+            "\n")))
+
+(defun ai-code-mcp-agent--write-private-file (path content &optional mode)
+  "Atomically write CONTENT to PATH with private permissions or MODE."
+  (let ((temp-file
+         (make-temp-file
+          (expand-file-name ".ai-code-mcp-" (file-name-directory path)))))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert content))
+          (set-file-modes temp-file (or mode #o600))
+          (rename-file temp-file path t)
+          (setq temp-file nil))
+      (when (and temp-file (file-exists-p temp-file))
+        (delete-file temp-file)))))
+
+(defun ai-code-mcp-agent--install-antigravity-config
+    (state session-id url token)
+  "Install an Antigravity config lease in STATE for SESSION-ID, URL, and TOKEN."
+  (let* ((path (plist-get state :path))
+         (directory (plist-get state :directory))
+         (created-directory (not (file-directory-p directory)))
+         (content (ai-code-mcp-agent--antigravity-config-content state url token)))
+    (condition-case err
+        (progn
+          (when created-directory
+            (make-directory directory t))
+          (ai-code-mcp-agent--write-private-file path content)
+          (setq state
+                (plist-put state :directory-created-p
+                           (or created-directory
+                               (plist-get state :directory-created-p))))
+          (setq state
+                (plist-put state :leases
+                           (cons (cons session-id content)
+                                 (plist-get state :leases))))
+          (setq state (plist-put state :written-content content))
+          (puthash path state ai-code-mcp-agent--antigravity-config-states)
+          (lambda ()
+            (ai-code-mcp-agent--release-antigravity-config path session-id)))
+      (error
+       (when (and created-directory
+                  (file-directory-p directory)
+                  (null (directory-files
+                         directory nil directory-files-no-dot-files-regexp)))
+         (delete-directory directory))
+       (signal (car err) (cdr err))))))
+
+(defun ai-code-mcp-agent--release-antigravity-config (path session-id)
+  "Release SESSION-ID's Antigravity config lease at PATH."
+  (when-let* ((state
+               (gethash path ai-code-mcp-agent--antigravity-config-states))
+              (lease (assoc session-id (plist-get state :leases))))
+    (let* ((remaining (delq lease (copy-sequence (plist-get state :leases))))
+           (owned-p
+            (and (not (file-symlink-p path))
+                 (file-regular-p path)
+                 (equal (ai-code-mcp-agent--file-contents path)
+                        (plist-get state :written-content)))))
+      (if (not owned-p)
+          (display-warning
+           'ai-code-mcp-agent
+           (format
+            "Antigravity MCP config changed externally; leaving it untouched: %s"
+            path))
+        (if remaining
+            (let ((content (cdar remaining)))
+              (unless (equal content (plist-get state :written-content))
+                (ai-code-mcp-agent--write-private-file path content))
+              (setq state (plist-put state :written-content content)))
+          (if (plist-get state :original-exists-p)
+              (ai-code-mcp-agent--write-private-file
+               path
+               (plist-get state :original-content)
+               (plist-get state :original-mode))
+            (delete-file path))))
+      (if remaining
+          (progn
+            (setq state (plist-put state :leases remaining))
+            (puthash path state ai-code-mcp-agent--antigravity-config-states))
+        (remhash path ai-code-mcp-agent--antigravity-config-states)
+        (ai-code-mcp-agent--remove-created-config-directory state)))))
+
+(defun ai-code-mcp-agent--remove-created-config-directory (state)
+  "Remove STATE's package-created config directory when it is still empty."
+  (let ((directory (plist-get state :directory)))
+    (when (and (plist-get state :directory-created-p)
+               (file-directory-p directory)
+               (not (file-symlink-p directory))
+               (null (directory-files
+                      directory nil directory-files-no-dot-files-regexp)))
+      (delete-directory directory))))
+
+(defun ai-code-mcp-agent--discard-failed-launch
+    (session-id launch-metadata server-was-live)
+  "Discard failed SESSION-ID resources described by LAUNCH-METADATA.
+SERVER-WAS-LIVE records whether this launch started the shared HTTP server."
+  (dolist (path (plist-get launch-metadata :runtime-files))
+    (when (and (stringp path) (file-exists-p path))
+      (condition-case err
+          (delete-file path)
+        (error
+         (display-warning
+          'ai-code-mcp-agent
+          (format "Failed to discard MCP runtime file %s: %s"
+                  path (error-message-string err)))))))
+  (dolist (cleanup (plist-get launch-metadata :runtime-cleanup-functions))
+    (condition-case err
+        (funcall cleanup)
+      (error
+       (display-warning
+        'ai-code-mcp-agent
+        (format "Failed to discard an MCP runtime resource: %s"
+                (error-message-string err))))))
+  (when (ai-code-mcp-get-session-context session-id)
+    (ai-code-mcp-unregister-session session-id))
+  (when (and (not server-was-live)
+             (zerop (ai-code-mcp-session-count)))
+    (ai-code-mcp-http-server-stop)))
 
 (defun ai-code-mcp-agent--authorization-template (token-env-var)
   "Return an Authorization header template for TOKEN-ENV-VAR."

--- a/ai-code-mcp-http-server.el
+++ b/ai-code-mcp-http-server.el
@@ -323,7 +323,7 @@ When nil, an available port is selected automatically."
           (unless envelope-error
             (if modern
                 (ai-code-mcp-http-server--modern-transport-error
-                 method params request)
+                 method params request context)
               (ai-code-mcp-http-server--legacy-transport-error
                method request context)))))
     (cond
@@ -380,8 +380,8 @@ When nil, an available port is selected automatically."
         (equal body-version ai-code-mcp--modern-protocol-version))))
 
 (defun ai-code-mcp-http-server--modern-transport-error
-    (method params request)
-  "Return a modern transport error for METHOD, PARAMS, and REQUEST."
+    (method params request context)
+  "Return a modern transport error for METHOD, PARAMS, REQUEST, and CONTEXT."
   (let* ((headers (plist-get request :headers))
          (header-version (cdr (assoc "mcp-protocol-version" headers)))
          (header-method (cdr (assoc "mcp-method" headers)))
@@ -400,6 +400,11 @@ When nil, an available port is selected automatically."
          (requires-name
           (member method '("tools/call" "resources/read" "prompts/get"))))
     (cond
+     ((not (ai-code-mcp-http-server--modern-protocol-enabled-p context))
+      (list :code -32022
+            :message "Unsupported protocol version"
+            :data `((supported . [])
+                    (requested . ,(or body-version header-version)))))
      ((or (null version-entry) (not (stringp body-version))
           (null capabilities-entry))
       (list :code -32602
@@ -421,6 +426,11 @@ When nil, an available port is selected automatically."
                        body-name)))
       (list :code -32020
             :message "Header mismatch: Mcp-Name")))))
+
+(defun ai-code-mcp-http-server--modern-protocol-enabled-p (context)
+  "Return whether CONTEXT permits the stateless modern MCP protocol."
+  (or (not (plist-member context :modern-protocol-enabled))
+      (plist-get context :modern-protocol-enabled)))
 
 (defun ai-code-mcp-http-server--decode-header-value (value)
   "Decode modern MCP header VALUE, including its Base64 sentinel form."

--- a/test/run_ai_code_antigravity_mcp_gauntlet.sh
+++ b/test/run_ai_code_antigravity_mcp_gauntlet.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+task_tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/ai-code-antigravity-mcp-gauntlet.XXXXXX")
+
+cleanup() {
+  case "$task_tmp_dir" in
+    "${TMPDIR:-/tmp}"/ai-code-antigravity-mcp-gauntlet.*)
+      rm -rf -- "$task_tmp_dir"
+      ;;
+  esac
+}
+
+trap cleanup EXIT
+
+cd "$repo_root"
+
+emacs --version | sed -n '1p'
+git --version
+perl -e 'printf "perl %vd\n", $^V'
+agy --version
+
+copy_task_files() {
+  local destination=$1
+
+  cp ai-code-antigravity-cli.el "$destination/ai-code-antigravity-cli.el"
+  cp ai-code-backends-infra.el "$destination/ai-code-backends-infra.el"
+  cp ai-code-mcp-agent.el "$destination/ai-code-mcp-agent.el"
+  cp ai-code-mcp-http-server.el "$destination/ai-code-mcp-http-server.el"
+  cp test/test_ai-code-antigravity-cli.el \
+    "$destination/test_ai-code-antigravity-cli.el"
+  cp test/test_ai-code-backends-infra.el \
+    "$destination/test_ai-code-backends-infra.el"
+  cp test/test_ai-code-mcp-agent.el "$destination/test_ai-code-mcp-agent.el"
+  cp test/test_ai-code-mcp-http-server.el \
+    "$destination/test_ai-code-mcp-http-server.el"
+}
+
+run_focused_tests() {
+  local source_dir=$1
+  local emacs_home="$task_tmp_dir/emacs.d/"
+
+  emacs -Q --batch \
+    --eval "(setq user-emacs-directory \"$emacs_home\" load-prefer-newer t)" \
+    -L test/stubs -L "$source_dir" -L "$repo_root" \
+    -l ert \
+    -l "$source_dir/ai-code-backends-infra.el" \
+    -l "$source_dir/ai-code-mcp-http-server.el" \
+    -l "$source_dir/ai-code-mcp-agent.el" \
+    -l "$source_dir/ai-code-antigravity-cli.el" \
+    -l "$source_dir/test_ai-code-antigravity-cli.el" \
+    -l "$source_dir/test_ai-code-backends-infra.el" \
+    -l "$source_dir/test_ai-code-mcp-agent.el" \
+    -l "$source_dir/test_ai-code-mcp-http-server.el" \
+    --eval '(ert-run-tests-batch-and-exit
+             "\\`\\(ai-code-test-antigravity-cli-start\\|ai-code-test-mcp-agent-\\(antigravity\\|enables-antigravity\\)\\|ai-code-test-mcp-http-server-scopes-modern-protocol-opt-out\\|test-ai-code-backends-infra-create-new-session-cleans-\\)")'
+}
+
+run_byte_compile_gate() {
+  local source_dir=$1
+  local compile_log="$task_tmp_dir/byte-compile.log"
+
+  if ! emacs -Q --batch \
+    --eval '(setq load-prefer-newer t)' \
+    -L test/stubs -L "$source_dir" -L "$repo_root" \
+    -f batch-byte-compile \
+    "$source_dir/ai-code-antigravity-cli.el" \
+    "$source_dir/ai-code-backends-infra.el" \
+    "$source_dir/ai-code-mcp-agent.el" \
+    "$source_dir/ai-code-mcp-http-server.el" \
+    >"$compile_log" 2>&1; then
+    cat "$compile_log" >&2
+    return 1
+  fi
+  if rg -n 'Warning:|Error:' "$compile_log"; then
+    echo "Byte compilation emitted diagnostics" >&2
+    return 1
+  fi
+}
+
+run_checkdoc_gate() {
+  local checkdoc_log="$task_tmp_dir/checkdoc.log"
+
+  if ! emacs -Q --batch -L test/stubs -L "$repo_root" -l checkdoc \
+    --eval "(let ((checkdoc-force-docstrings-flag nil))
+              (mapc #'checkdoc-file
+                    '(\"ai-code-antigravity-cli.el\"
+                      \"ai-code-backends-infra.el\"
+                      \"ai-code-mcp-agent.el\"
+                      \"ai-code-mcp-http-server.el\"
+                      \"test/test_ai-code-antigravity-cli.el\"
+                      \"test/test_ai-code-backends-infra.el\"
+                      \"test/test_ai-code-mcp-agent.el\"
+                      \"test/test_ai-code-mcp-http-server.el\")))" \
+    >"$checkdoc_log" 2>&1; then
+    cat "$checkdoc_log" >&2
+    return 1
+  fi
+  if [[ -s "$checkdoc_log" ]]; then
+    cat "$checkdoc_log" >&2
+    echo "Checkdoc emitted diagnostics" >&2
+    return 1
+  fi
+}
+
+run_real_agy_probe() {
+  local agents_before
+  local agents_after
+  local probe_output
+
+  agents_before=$(git status --porcelain=v1 --untracked-files=all -- .agents)
+  probe_output=$(emacs -Q --batch -L . -l test/test_00-bootstrap.el \
+    -l ai-code-mcp-agent \
+    --eval "(let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+                    (ai-code-mcp-agent--antigravity-config-states
+                     (make-hash-table :test 'equal))
+                    (ai-code-mcp--sessions (make-hash-table :test 'equal))
+                    (ai-code-mcp-http-server-port nil)
+                    (ai-code-mcp-http-server--server nil)
+                    (ai-code-mcp-http-server--port nil)
+                    (output (generate-new-buffer
+                             \" *ai-code-agy-gauntlet-probe*\"))
+                    launch process session-id context sent)
+               (unwind-protect
+                   (progn
+                     (setq launch
+                           (ai-code-mcp-agent-prepare-launch
+                            'antigravity default-directory '(\"agy\")))
+                     (setq session-id (plist-get launch :mcp-session-id))
+                     (setq process
+                           (make-process
+                            :name \"ai-code-agy-gauntlet-probe\"
+                            :buffer output
+                            :command '(\"agy\")
+                            :connection-type 'pty
+                            :noquery t))
+                     (let ((started (float-time))
+                           (deadline (+ (float-time) 20.0)))
+                       (while (and
+                               (process-live-p process)
+                               (< (float-time) deadline)
+                               (eq 'pending
+                                   (plist-get
+                                    (ai-code-mcp-get-session-context session-id)
+                                    :state)))
+                         (accept-process-output nil 0.1)
+                         (when (and (not sent)
+                                    (> (- (float-time) started) 3.0))
+                           (process-send-string process \"/mcp\\r\")
+                           (setq sent t))))
+                     (setq context
+                           (ai-code-mcp-get-session-context session-id))
+                     (princ
+                      (format \"state=%s protocol=%s client=%s\\n\"
+                              (plist-get context :state)
+                              (or (plist-get context :protocol-version)
+                                  \"none\")
+                              (or (alist-get
+                                   'name (plist-get context :client-info))
+                                  \"none\"))))
+                 (when (process-live-p process)
+                   (delete-process process))
+                 (when-let ((release (plist-get launch :cleanup-fn)))
+                   (funcall release))
+                 (when (buffer-live-p output)
+                   (kill-buffer output))))")
+  printf '%s\n' "$probe_output"
+  if [[ "$probe_output" != *"state=ready protocol=2025-11-25 client=antigravity-client"* ]]; then
+    echo "Antigravity did not complete the legacy MCP handshake" >&2
+    return 1
+  fi
+  agents_after=$(git status --porcelain=v1 --untracked-files=all -- .agents)
+  if [[ "$agents_before" != "$agents_after" ]]; then
+    echo "Antigravity probe changed workspace .agents state" >&2
+    return 1
+  fi
+}
+
+run_mutant() {
+  local description=$1
+  local target_file=$2
+  local expression=$3
+  local mutant_dir="$task_tmp_dir/mutant"
+  local mutant_log="$task_tmp_dir/mutant.log"
+
+  rm -rf -- "$mutant_dir"
+  mkdir -p "$mutant_dir"
+  copy_task_files "$mutant_dir"
+  perl -0pi -e "$expression" "$mutant_dir/$target_file"
+
+  if cmp -s "$target_file" "$mutant_dir/$target_file"; then
+    echo "Mutation did not change source: $description" >&2
+    return 1
+  fi
+  if run_focused_tests "$mutant_dir" >"$mutant_log" 2>&1; then
+    echo "Mutation survived: $description" >&2
+    return 1
+  fi
+  if ! rg -q 'FAILED' "$mutant_log" || \
+     rg -q 'Cannot open load file|invalid-read-syntax|End of file during parsing' \
+       "$mutant_log"; then
+    cat "$mutant_log" >&2
+    echo "Mutation did not reach an assertion failure: $description" >&2
+    return 1
+  fi
+  echo "Mutation killed: $description"
+}
+
+copy_task_files "$task_tmp_dir"
+
+run_focused_tests "$task_tmp_dir"
+
+emacs -Q --batch -L . -l ert \
+  --eval "(mapc #'load-file (file-expand-wildcards \"test/test_*.el\"))" \
+  -f ert-run-tests-batch-and-exit
+
+run_byte_compile_gate "$task_tmp_dir"
+run_checkdoc_gate
+git diff --check
+run_real_agy_probe
+
+run_mutant "remove Antigravity from the default MCP backends" \
+  "ai-code-mcp-agent.el" \
+  's/\Qclaude-code antigravity)\E/claude-code)/'
+run_mutant "omit the Bearer authorization scheme" \
+  "ai-code-mcp-agent.el" \
+  's/\Q(concat "Bearer " token)\E/token/'
+run_mutant "discard the existing Antigravity JSON object" \
+  "ai-code-mcp-agent.el" \
+  's/\Q(if (plist-get state :original-exists-p)\E/(if nil/'
+run_mutant "ignore the session modern-protocol opt-out" \
+  "ai-code-mcp-http-server.el" \
+  's/\Q(not (ai-code-mcp-http-server--modern-protocol-enabled-p context))\E/nil/'
+run_mutant "skip cleanup on terminal startup failures" \
+  "ai-code-backends-infra.el" \
+  's/\Q(ai-code-backends-infra--cleanup-failed-launch cleanup-fn)\E/nil/g'
+
+echo "Antigravity MCP gauntlet passed"

--- a/test/test_ai-code-antigravity-cli.el
+++ b/test/test_ai-code-antigravity-cli.el
@@ -36,7 +36,29 @@
                 ai-code-antigravity-cli--processes))
     (should (equal (plist-get captured-options :session-prefix) "antigravity"))
     (should (eq (plist-get captured-options :escape-function)
-                #'ai-code-antigravity-cli-send-escape))))
+                #'ai-code-antigravity-cli-send-escape))
+    (should (functionp (plist-get captured-options :prepare-launch)))))
+
+(ert-deftest ai-code-test-antigravity-cli-start-prepares-mcp-launch ()
+  "Antigravity startup should prepare its MCP launch through the shared adapter."
+  (let (captured-options
+        captured-call)
+    (cl-letf (((symbol-function 'ai-code-backends-infra--start-cli-session)
+               (lambda (options _arg)
+                 (setq captured-options options)))
+              ((symbol-function 'ai-code-mcp-agent-prepare-launch)
+               (lambda (backend working-dir argv)
+                 (setq captured-call (list backend working-dir argv))
+                 '(:argv ("agy")))))
+      (ai-code-antigravity-cli)
+      (should
+       (equal '(:argv ("agy"))
+              (funcall (plist-get captured-options :prepare-launch)
+                       "/tmp/project/"
+                       '("agy" "--continue"))))
+      (should
+       (equal '(antigravity "/tmp/project/" ("agy" "--continue"))
+              captured-call)))))
 
 (provide 'test_ai-code-antigravity-cli)
 

--- a/test/test_ai-code-backends-infra.el
+++ b/test/test_ai-code-backends-infra.el
@@ -3999,6 +3999,46 @@ The prefix argument should also force instance-name prompting."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest test-ai-code-backends-infra-create-new-session-cleans-failed-launch ()
+  "An immediately failed CLI launch should release its prepared resources."
+  (let* ((working-dir "/tmp/ai-code-failed-launch-cleanup/")
+         (buffer-name "*ai-code-failed-launch-cleanup*")
+         (buffer (get-buffer-create buffer-name))
+         (process-table (make-hash-table :test 'equal))
+         (cleanup-count 0)
+         (failure-count 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-backends-infra--create-terminal-session)
+                   (lambda (&rest _args)
+                     (cons buffer 'failed-process)))
+                  ((symbol-function 'sleep-for) #'ignore)
+                  ((symbol-function 'process-live-p) (lambda (_process) nil))
+                  ((symbol-function 'ai-code-backends-infra--handle-session-start-failure)
+                   (lambda (&rest _args)
+                     (cl-incf failure-count))))
+          (ai-code-backends-infra--create-new-session
+           buffer-name working-dir '("agy") nil
+           'session-key process-table "default" "antigravity"
+           nil (lambda () (cl-incf cleanup-count)) nil nil nil buffer)
+          (should (= 1 failure-count))
+          (should (= 1 cleanup-count)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest test-ai-code-backends-infra-create-new-session-cleans-create-error ()
+  "A terminal creation error should release its prepared launch resources."
+  (let ((cleanup-count 0))
+    (cl-letf (((symbol-function 'ai-code-backends-infra--create-terminal-session)
+               (lambda (&rest _args)
+                 (error "Terminal creation failed"))))
+      (should-error
+       (ai-code-backends-infra--create-new-session
+        "*ai-code-create-error*" "/tmp/ai-code-create-error/" '("agy") nil
+        'session-key (make-hash-table :test 'equal) "default" "antigravity"
+        nil (lambda () (cl-incf cleanup-count)) nil nil nil (current-buffer))
+       :type 'error)
+      (should (= 1 cleanup-count)))))
+
 (ert-deftest test-ai-code-backends-infra-configure-session-buffer-does-not-bind-manual-navigation ()
   "Configuring a session buffer should not add a manual `C-c g' navigation feature."
   (let ((buffer (generate-new-buffer "*ai-code-session-config*")))

--- a/test/test_ai-code-mcp-agent.el
+++ b/test/test_ai-code-mcp-agent.el
@@ -17,6 +17,25 @@
   (provide 'magit))
 (require 'ai-code-mcp-agent)
 
+(defun ai-code-test-mcp-agent--file-contents (path)
+  "Return the literal contents of PATH."
+  (with-temp-buffer
+    (insert-file-contents-literally path)
+    (buffer-string)))
+
+(defun ai-code-test-mcp-agent--json-file (path)
+  "Parse the JSON object stored at PATH as an alist."
+  (json-parse-string
+   (ai-code-test-mcp-agent--file-contents path)
+   :object-type 'alist
+   :array-type 'list
+   :null-object :null
+   :false-object :json-false))
+
+(ert-deftest ai-code-test-mcp-agent-enables-antigravity-by-default ()
+  "Antigravity should receive automatic Emacs MCP integration by default."
+  (should (memq 'antigravity ai-code-mcp-agent-enabled-backends)))
+
 (ert-deftest ai-code-test-mcp-agent-launch-url-matches-http-endpoint ()
   "Launch metadata should use the exact path accepted by the HTTP server."
   (let ((ai-code-mcp-agent-enabled-backends '(codex))
@@ -186,6 +205,293 @@
                 (funcall (plist-get launch :cleanup-fn))))))
       (when (buffer-live-p source-buffer)
         (kill-buffer source-buffer)))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-writes-private-workspace-config ()
+  "Antigravity should receive a private workspace config with its bearer token."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-" t))
+         (config-file
+          (expand-file-name ".agents/mcp_config.json" working-dir))
+         (secret (make-string 64 ?b))
+         launch)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop) #'ignore)
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () secret))
+                  ((symbol-function 'ai-code-mcp-agent--make-session-id)
+                   (lambda (_backend) "antigravity-test-session")))
+          (setq launch
+                (ai-code-mcp-agent-prepare-launch
+                 'antigravity working-dir '("agy" "--continue")))
+          (should (equal '("agy" "--continue")
+                         (plist-get launch :argv)))
+          (should (file-exists-p config-file))
+          (should (zerop (logand (file-modes config-file) #o077)))
+          (let* ((config (ai-code-test-mcp-agent--json-file config-file))
+                 (server (alist-get
+                          'emacs_tools
+                          (alist-get 'mcpServers config))))
+            (should (equal "http://127.0.0.1:8765/mcp"
+                           (alist-get 'serverUrl server)))
+            (should (equal (concat "Bearer " secret)
+                           (alist-get 'Authorization
+                                      (alist-get 'headers server))))
+            (should-not
+             (string-match-p
+              (regexp-quote ai-code-mcp-agent--token-environment-variable)
+              (ai-code-test-mcp-agent--file-contents config-file))))
+          (let ((context
+                 (ai-code-mcp-get-session-context
+                  (plist-get launch :mcp-session-id))))
+            (should (plist-member context :modern-protocol-enabled))
+            (should-not (plist-get context :modern-protocol-enabled)))
+          (funcall (plist-get launch :cleanup-fn))
+          (setq launch nil)
+          (should-not (file-exists-p config-file)))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-restores-existing-config ()
+  "Antigravity cleanup should restore an existing MCP config byte for byte."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-existing-" t))
+         (config-dir (expand-file-name ".agents" working-dir))
+         (config-file (expand-file-name "mcp_config.json" config-dir))
+         (original
+          (concat
+           "{\n"
+           "  \"mcpServers\": {\n"
+           "    \"user_server\": {\"command\": \"keep-me\"},\n"
+           "    \"emacs_tools\": {\"serverUrl\": \"https://original.invalid\"}\n"
+           "  },\n"
+           "  \"keep\": true\n"
+           "}\n"))
+         launch)
+    (make-directory config-dir)
+    (with-temp-file config-file
+      (insert original))
+    (set-file-modes config-file #o640)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop) #'ignore)
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () (make-string 64 ?c)))
+                  ((symbol-function 'ai-code-mcp-agent--make-session-id)
+                   (lambda (_backend) "antigravity-existing-session")))
+          (setq launch
+                (ai-code-mcp-agent-prepare-launch
+                 'antigravity working-dir '("agy")))
+          (let* ((config (ai-code-test-mcp-agent--json-file config-file))
+                 (servers (alist-get 'mcpServers config)))
+            (should (equal "keep-me"
+                           (alist-get 'command
+                                      (alist-get 'user_server servers))))
+            (should (equal t (alist-get 'keep config)))
+            (should (equal
+                     (concat "Bearer " (make-string 64 ?c))
+                     (alist-get
+                      'Authorization
+                      (alist-get 'headers
+                                 (alist-get 'emacs_tools servers))))))
+          (funcall (plist-get launch :cleanup-fn))
+          (setq launch nil)
+          (should (equal original
+                         (ai-code-test-mcp-agent--file-contents config-file)))
+          (should (= #o640 (logand (file-modes config-file) #o777))))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-rejects-invalid-config ()
+  "Antigravity preparation should reject invalid JSON without side effects."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-invalid-" t))
+         (config-dir (expand-file-name ".agents" working-dir))
+         (config-file (expand-file-name "mcp_config.json" config-dir))
+         (server-start-count 0)
+         launch
+         outcome)
+    (make-directory config-dir)
+    (with-temp-file config-file
+      (insert "{not-json\n"))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda ()
+                     (cl-incf server-start-count)
+                     8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop) #'ignore))
+          (setq outcome
+                (condition-case err
+                    (progn
+                      (setq launch
+                            (ai-code-mcp-agent-prepare-launch
+                             'antigravity working-dir '("agy")))
+                      :unexpected-success)
+                  (error err)))
+          (should (eq 'json-parse-error (car outcome)))
+          (should (zerop server-start-count))
+          (should (zerop (hash-table-count ai-code-mcp--sessions)))
+          (should (equal "{not-json\n"
+                         (ai-code-test-mcp-agent--file-contents config-file))))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-coordinates-config-leases ()
+  "Concurrent Antigravity launches should restore config after the last lease."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-leases-" t))
+         (config-file
+          (expand-file-name ".agents/mcp_config.json" working-dir))
+         (session-ids '("antigravity-session-1" "antigravity-session-2"))
+         (secrets (list (make-string 64 ?d) (make-string 64 ?e)))
+         first-launch
+         second-launch)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop) #'ignore)
+                  ((symbol-function 'ai-code-mcp--random-secret)
+                   (lambda () (pop secrets)))
+                  ((symbol-function 'ai-code-mcp-agent--make-session-id)
+                   (lambda (_backend) (pop session-ids))))
+          (setq first-launch
+                (ai-code-mcp-agent-prepare-launch
+                 'antigravity working-dir '("agy")))
+          (setq second-launch
+                (ai-code-mcp-agent-prepare-launch
+                 'antigravity working-dir '("agy")))
+          (should (string-match-p
+                   (regexp-quote (concat "Bearer " (make-string 64 ?e)))
+                   (ai-code-test-mcp-agent--file-contents config-file)))
+          (funcall (plist-get first-launch :cleanup-fn))
+          (setq first-launch nil)
+          (should (file-exists-p config-file))
+          (should (string-match-p
+                   (regexp-quote (concat "Bearer " (make-string 64 ?e)))
+                   (ai-code-test-mcp-agent--file-contents config-file)))
+          (funcall (plist-get second-launch :cleanup-fn))
+          (setq second-launch nil)
+          (should-not (file-exists-p config-file)))
+      (when-let ((cleanup-fn (plist-get first-launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (when-let ((cleanup-fn (plist-get second-launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-rolls-back-failed-registration ()
+  "A failed Antigravity registration should remove config and stop its server."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (ai-code-mcp-http-server--server nil)
+         (ai-code-mcp-http-server--port nil)
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-rollback-" t))
+         (config-file
+          (expand-file-name ".agents/mcp_config.json" working-dir))
+         (stop-count 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop)
+                   (lambda () (cl-incf stop-count)))
+                  ((symbol-function 'ai-code-mcp-register-session)
+                   (lambda (&rest _args) (error "Registration failed"))))
+          (should-error
+           (ai-code-mcp-agent-prepare-launch
+            'antigravity working-dir '("agy"))
+           :type 'error)
+          (should-not (file-exists-p config-file))
+          (should (zerop
+                   (hash-table-count
+                    ai-code-mcp-agent--antigravity-config-states)))
+          (should (= 1 stop-count)))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-preserves-external-edit ()
+  "Cleanup should not overwrite an Antigravity config changed by the user."
+  (let* ((ai-code-mcp-agent-enabled-backends '(antigravity))
+         (ai-code-mcp-agent--antigravity-config-states
+          (make-hash-table :test 'equal))
+         (ai-code-mcp--sessions (make-hash-table :test 'equal))
+         (working-dir (make-temp-file "ai-code-mcp-antigravity-edit-" t))
+         (config-file
+          (expand-file-name ".agents/mcp_config.json" working-dir))
+         (user-content "{\"mcpServers\":{},\"userEdit\":true}\n")
+         launch)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ai-code-mcp-builtins-setup) #'ignore)
+                  ((symbol-function 'ai-code-mcp-http-server-ensure)
+                   (lambda () 8765))
+                  ((symbol-function 'ai-code-mcp-http-server-stop) #'ignore)
+                  ((symbol-function 'display-warning) #'ignore))
+          (setq launch
+                (ai-code-mcp-agent-prepare-launch
+                 'antigravity working-dir '("agy")))
+          (with-temp-file config-file
+            (insert user-content))
+          (funcall (plist-get launch :cleanup-fn))
+          (setq launch nil)
+          (should (equal user-content
+                         (ai-code-test-mcp-agent--file-contents config-file))))
+      (when-let ((cleanup-fn (plist-get launch :cleanup-fn)))
+        (funcall cleanup-fn))
+      (delete-directory working-dir t))))
+
+(ert-deftest ai-code-test-mcp-agent-antigravity-preserves-json-values ()
+  "Merging the Antigravity server should preserve unrelated JSON values."
+  (dolist (original
+           '("{\"mcpServers\":{},\"preserve\":[1,false,null,{\"nested\":\"x\"}]}"
+             "{\"empty\":{},\"text\":\"quoted \\\"// value\\\"\"}"))
+    (let* ((state (list :path "/tmp/mcp_config.json"
+                        :original-exists-p t
+                        :original-content original))
+           (before
+            (ai-code-mcp-agent--parse-antigravity-config
+             original (plist-get state :path)))
+           (after
+            (ai-code-mcp-agent--parse-antigravity-config
+             (ai-code-mcp-agent--antigravity-config-content
+              state "http://127.0.0.1:8765/mcp" "test-token")
+             (plist-get state :path)))
+           (missing (make-symbol "missing")))
+      (dolist (key '("preserve" "empty" "text"))
+        (let ((expected (gethash key before missing)))
+          (unless (eq expected missing)
+            (should
+             (equal
+              (json-serialize expected
+                              :null-object :null
+                              :false-object :json-false)
+              (json-serialize (gethash key after missing)
+                              :null-object :null
+                              :false-object :json-false))))))
+      (should
+       (hash-table-p
+        (gethash ai-code-mcp-agent--server-name
+                 (gethash "mcpServers" after)))))))
 
 (ert-deftest ai-code-test-mcp-agent-show-buffer-status-displays-help-buffer ()
   "The interactive MCP status command should display current buffer status."

--- a/test/test_ai-code-mcp-http-server.el
+++ b/test/test_ai-code-mcp-http-server.el
@@ -137,7 +137,7 @@
    (when name `(("Mcp-Name" . ,name)))))
 
 (defun ai-code-test-mcp-http--modern-meta ()
-  "Return required per-request metadata for modern MCP tests."
+  "Return required per-request metadata for a modern MCP test."
   `((_meta
      . ((io.modelcontextprotocol/protocolVersion . "2026-07-28")
         (io.modelcontextprotocol/clientInfo
@@ -218,6 +218,51 @@
       (should (alist-get 'tools (alist-get 'capabilities result)))
       (should-not (assoc "mcp-session-id"
                          (ai-code-test-mcp-http-response-headers response))))))
+
+(ert-deftest ai-code-test-mcp-http-server-scopes-modern-protocol-opt-out ()
+  "A session may reject modern discovery while retaining legacy MCP support."
+  (let ((ai-code-mcp--sessions (make-hash-table :test 'equal))
+        (ai-code-mcp-server-tools nil)
+        (ai-code-mcp-http-server-port nil)
+        (ai-code-mcp-http-server--server nil)
+        (ai-code-mcp-http-server--port nil)
+        (project-dir (make-temp-file "ai-code-mcp-http-legacy-only-" t))
+        (source-buffer (generate-new-buffer " *ai-code-mcp-http-legacy-only*")))
+    (unwind-protect
+        (progn
+          (ai-code-mcp-register-session
+           "legacy-only-session" project-dir source-buffer
+           '(:token "legacy-only-token"
+             :state pending
+             :modern-protocol-enabled nil))
+          (let* ((port (ai-code-mcp-http-server-ensure))
+                 (modern-response
+                  (ai-code-test-mcp-http--exchange
+                   port "POST" "/mcp"
+                   (ai-code-test-mcp-http--modern-headers
+                    "legacy-only-token" "server/discover")
+                   (json-encode
+                    `((jsonrpc . "2.0")
+                      (id . "discover-opt-out")
+                      (method . "server/discover")
+                      (params . ,(ai-code-test-mcp-http--modern-meta))))))
+                 (modern-payload
+                  (json-parse-string
+                   (ai-code-test-mcp-http-response-body modern-response)
+                   :object-type 'alist :array-type 'list))
+                 (legacy-response
+                  (ai-code-test-mcp-http--legacy-initialize
+                   port "legacy-only-token")))
+            (should (= 400
+                       (ai-code-test-mcp-http-response-status modern-response)))
+            (should (= -32022
+                       (alist-get 'code (alist-get 'error modern-payload))))
+            (should (= 200
+                       (ai-code-test-mcp-http-response-status legacy-response)))))
+      (ai-code-mcp-http-server-stop)
+      (when (buffer-live-p source-buffer)
+        (kill-buffer source-buffer))
+      (delete-directory project-dir t))))
 
 (ert-deftest ai-code-test-mcp-http-server-validates-modern-mirrored-headers ()
   "Modern mirrored headers must agree with the JSON-RPC body."
@@ -353,13 +398,13 @@
                       (params . ((protocolVersion . "2025-11-25")
                                  (capabilities . ())
                                  (clientInfo . ((name . "ert")
-                                                (version . "1")))))))))
+                                                (version . "1"))))))))))
             (should (= 401 (ai-code-test-mcp-http-response-status response)))
             (should (string-empty-p
                      (ai-code-test-mcp-http-response-body response)))))
       (ai-code-mcp-http-server-stop)
       (when (buffer-live-p source-buffer)
-        (kill-buffer source-buffer))))))
+        (kill-buffer source-buffer)))))
 
 (ert-deftest ai-code-test-mcp-http-server-rejects-expired-bearer ()
   "An expired per-launch bearer token should no longer authenticate."


### PR DESCRIPTION
## Summary

Add automatic Emacs MCP support for Antigravity CLI (`agy`).

- Create a private, session-scoped `.agents/mcp_config.json` entry with safe restoration of existing configuration, concurrent-session coordination, and cleanup on failed launches.
- Keep AGY on the compatible legacy MCP handshake without changing modern protocol support for other backends.
- Document the setup and add focused coverage for configuration safety, protocol behavior, and launch cleanup.

## Verification

Ran `test/run_ai_code_antigravity_mcp_gauntlet.sh`: 13 focused tests passed; the full ERT suite completed with 1,461 passes, 13 environment skips, and no unexpected results. The gauntlet also passed byte compilation, checkdoc, diff checks, a real AGY legacy-handshake probe, and five manual mutation checks.