### PR TITLE
Copy all marked Dired items in the @ context copy actions

### DIFF
--- a/ai-code-file.el
+++ b/ai-code-file.el
@@ -79,11 +79,24 @@ active region line range, then the current function, then the file path."
               (format "%s#%s" file-reference function-name)
             file-reference)))))))
 
+(defun ai-code--dired-explicitly-marked-files ()
+  "Return the files explicitly marked in the current Dired buffer.
+Return nil when nothing is marked.  `dired-get-marked-files' falls back
+to the file at point when no mark exists, so a single entry equal to
+that file is not an explicit mark."
+  (let ((all-marked (ignore-errors (dired-get-marked-files)))
+        (file-at-point (ignore-errors (dired-get-filename nil t))))
+    (unless (and (= (length all-marked) 1)
+                 file-at-point
+                 (equal (car all-marked) file-at-point))
+      all-marked)))
+
 ;;;###autoload
 (defun ai-code-copy-buffer-file-name-to-clipboard (&optional arg)
   "Copy the current buffer's file path or selected text to clipboard.
 If in a magit status buffer, copy the current branch name.
-If in a Dired buffer, copy the file at point or directory path.
+If in a Dired buffer, copy the marked files and directories, one path
+per line, falling back to the file at point or the directory path.
 In a regular file buffer, append the selected region's line range or
 the current function name to the file path.  Preserve selected text
 before that context reference.
@@ -109,18 +122,18 @@ with @ prefix if within git repo."
                context-reference)))
           ;; If current buffer is a dired buffer
           ((derived-mode-p 'dired-mode)
-           (let* ((file-at-point (ignore-errors (dired-get-file-for-visit)))
-                  (git-root-truename (ai-code--git-root)))
-             (if file-at-point
-                 ;; If there's a file under cursor, copy its processed path
-                 (if (and git-root-truename (not arg))
-                     (ai-code--process-word-for-filepath file-at-point git-root-truename)
-                   file-at-point)
-               ;; If no file under cursor, copy the dired directory path
-               (let ((dir-path (dired-current-directory)))
-                 (if (and git-root-truename (not arg))
-                     (ai-code--process-word-for-filepath dir-path git-root-truename)
-                   dir-path)))))
+           (let* ((git-root-truename (ai-code--git-root))
+                  ;; Marked items win; otherwise keep the previous behavior of
+                  ;; copying the file under cursor, then the dired directory.
+                  (targets (or (ai-code--dired-explicitly-marked-files)
+                               (list (or (ignore-errors (dired-get-file-for-visit))
+                                         (dired-current-directory))))))
+             (mapconcat (lambda (path)
+                          (if (and git-root-truename (not arg))
+                              (ai-code--process-word-for-filepath path git-root-truename)
+                            path))
+                        targets
+                        "\n")))
           ;; For other buffer types, return nil
           (t nil))))
     (if path-to-copy
@@ -546,16 +559,9 @@ in the form filepath#Lstart-Lend."
                                        ordered-roots
                                        nil t nil nil (car ordered-roots))))))
     (if (derived-mode-p 'dired-mode)
-        (let* ((all-marked (dired-get-marked-files))
-               (file-at-point (dired-get-filename nil t))
-               (has-marks (and all-marked
-                               (not (and (= (length all-marked) 1)
-                                         file-at-point
-                                         (equal (car all-marked) file-at-point)))))
-               (targets (cond
-                         (has-marks all-marked)
-                         (file-at-point (list file-at-point))
-                         (t nil))))
+        (let* ((file-at-point (dired-get-filename nil t))
+               (targets (or (ai-code--dired-explicitly-marked-files)
+                            (when file-at-point (list file-at-point)))))
           (unless targets
             (user-error "No file or directory selected in Dired"))
           (dolist (path targets)

--- a/test/test_ai-code-file.el
+++ b/test/test_ai-code-file.el
@@ -819,6 +819,103 @@ everything is cleaned up afterward."
         (kill-buffer source-buffer))
       (delete-directory repo-root t))))
 
+(defmacro ai-code-file-test--with-dired-repo (root buffer &rest body)
+  "Run BODY inside a Dired buffer for a temporary repository.
+ROOT is bound to the repository root truename and BUFFER to its Dired
+buffer.  The repository contains a.el, b.el and sub/.  `magit-toplevel'
+reports ROOT and `kill-ring' starts empty inside BODY."
+  (declare (indent 2))
+  `(let* ((,root (file-name-as-directory
+                  (file-truename (make-temp-file "ai-code-dired-copy-" t))))
+          (,buffer nil))
+     (unwind-protect
+         (progn
+           (with-temp-file (expand-file-name "a.el" ,root) (insert ";; a\n"))
+           (with-temp-file (expand-file-name "b.el" ,root) (insert ";; b\n"))
+           (make-directory (expand-file-name "sub" ,root) t)
+           (setq ,buffer (dired-noselect ,root))
+           (with-current-buffer ,buffer
+             (cl-letf (((symbol-function 'magit-toplevel)
+                        (lambda (&optional _dir) ,root)))
+               (let ((kill-ring nil))
+                 ,@body))))
+       (when (buffer-live-p ,buffer)
+         (kill-buffer ,buffer))
+       (delete-directory ,root t))))
+
+(defun ai-code-file-test--select-context-action (action)
+  "Return a `completing-read' replacement that always answers ACTION."
+  (lambda (&rest _args) action))
+
+(ert-deftest ai-code-test-context-action-copies-dired-marked-files ()
+  "Copy context copies every marked Dired item, one path per line."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (dired-goto-file (expand-file-name "a.el" repo-root))
+    (dired-mark 1)
+    (dired-goto-file (expand-file-name "sub" repo-root))
+    (dired-mark 1)
+    (cl-letf (((symbol-function 'completing-read)
+               (ai-code-file-test--select-context-action "Copy context")))
+      (ai-code-context-action nil))
+    (should (equal (current-kill 0 t) "@a.el\n@sub"))))
+
+(ert-deftest ai-code-test-context-action-copies-dired-marked-files-full-path ()
+  "Copy context with full path copies marked Dired items as absolute paths."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (dired-goto-file (expand-file-name "a.el" repo-root))
+    (dired-mark 1)
+    (dired-goto-file (expand-file-name "sub" repo-root))
+    (dired-mark 1)
+    (cl-letf (((symbol-function 'completing-read)
+               (ai-code-file-test--select-context-action
+                "Copy context with full path")))
+      (ai-code-context-action nil))
+    (should (equal (current-kill 0 t)
+                   (concat (expand-file-name "a.el" repo-root)
+                           "\n"
+                           (expand-file-name "sub" repo-root))))))
+
+(ert-deftest ai-code-test-context-action-copies-single-dired-mark-without-newline ()
+  "A single marked item wins over the file at point and carries no newline."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (dired-goto-file (expand-file-name "a.el" repo-root))
+    (dired-mark 1)
+    (dired-goto-file (expand-file-name "b.el" repo-root))
+    (cl-letf (((symbol-function 'completing-read)
+               (ai-code-file-test--select-context-action "Copy context")))
+      (ai-code-context-action nil))
+    (should (equal (current-kill 0 t) "@a.el"))))
+
+(ert-deftest ai-code-test-context-action-copies-dired-file-at-point-without-marks ()
+  "Without marks the copy action keeps copying the Dired file at point."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (dired-goto-file (expand-file-name "b.el" repo-root))
+    (cl-letf (((symbol-function 'completing-read)
+               (ai-code-file-test--select-context-action "Copy context")))
+      (ai-code-context-action nil))
+    (should (equal (current-kill 0 t) "@b.el"))))
+
+(ert-deftest ai-code-test-context-action-copies-dired-directory-without-file-at-point ()
+  "Without marks or a file at point the copy action keeps copying the directory."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (goto-char (point-min))
+    (cl-letf (((symbol-function 'completing-read)
+               (ai-code-file-test--select-context-action
+                "Copy context with full path")))
+      (ai-code-context-action nil))
+    (should (equal (current-kill 0 t) (dired-current-directory)))))
+
+(ert-deftest ai-code-test-add-context-stores-dired-marked-files ()
+  "Adding context from Dired keeps storing the marked items only."
+  (ai-code-file-test--with-dired-repo repo-root dired-buffer
+    (let ((ai-code--repo-context-info (make-hash-table :test #'equal)))
+      (dired-goto-file (expand-file-name "a.el" repo-root))
+      (dired-mark 1)
+      (dired-goto-file (expand-file-name "b.el" repo-root))
+      (ai-code-add-context)
+      (should (equal (gethash repo-root ai-code--repo-context-info)
+                     (list (expand-file-name "a.el" repo-root)))))))
+
 (ert-deftest ai-code-test-context-action-add-calls-add-context ()
   "Test that selecting 'Add context' calls `ai-code-add-context' and lists."
   (let ((add-called nil)


### PR DESCRIPTION
## Problem

`C-c a @` -> "Copy context" / "Copy context with full path" only ever copied a single path when invoked from Dired: the file under the cursor, or the Dired directory when the cursor was not on a file. Marks were ignored, so marking several files and copying gave you just one of them.

## Approach

Marked items now win in both copy actions, and multiple paths are joined with a newline.

- Added `ai-code--dired-explicitly-marked-files`, which distinguishes a real mark from `dired-get-marked-files`' fallback to the file at point (a single result equal to the file at point is not a mark).
- The Dired branch of `ai-code-copy-buffer-file-name-to-clipboard` now maps the existing git-relative / `@`-prefix processing over every target and joins with `\n`. With no marks it falls back to the previous behavior (file at point, then Dired directory), and the full-path prefix argument keeps its meaning.
- `ai-code-add-context` already had the same "explicit mark vs. file at point" logic inline, so it now reuses the helper instead of duplicating the concept in two places.

## Verification

- Focused ERT (`context-action` / `copy-file-context` / `add-context`): 14/14 pass, including five new Dired cases (multi-mark relative, multi-mark full path, single mark, no marks, no file at point) and one regression test covering the `ai-code-add-context` refactor.
- Full suite: 1486 tests with 13 unexpected — the same 13 that already fail on `main` (1480 tests there), so no new failures.
- `batch-byte-compile` and `checkdoc` on `ai-code-file.el`: no new warnings; `git diff --check` clean.
- Manual mutation pass over the changed forms: 6/6 killed (space instead of newline, first item only, marks ignored when copying, dropped file-at-point fallback, prefix arg ignored, marks ignored in `ai-code-add-context`).
